### PR TITLE
Ensuring DCO bot does not limit core team access.

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[ \] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[ \] All new and existing tests passed.

This change ensures that DCObot will not break our ability to commit as members of the organisation. DCOBot configuration is gated by the IBM github organisation. If we cannot use DCO bot we may need to resort to simpler methods (tickbox in PR template).
