### PR TITLE
chore: Allow changelog to be automatically populated by semantic-release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,4 @@ repos:
     rev: 0.3.4  # Use the ref you want to point at
     hooks:
     - id: mdformat
+      exclude: "CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Compliance-trestle changelog
+
+
+<!--next-version-placeholder-->

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ dev =
     dictdiffer
     mdformat
     python-dateutil
+    mypy
     
 [semantic_release]
 version_variable=trestle/__init__.py:__version__


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[x\] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.

Allows semantic release to correctly publish a changelog for trestle.  Should complete #103 
