### PR TITLE
chore: Separating pre-commit actions and creating an automatic update

### DIFF
--- a/.github/workflows/precommit-update.yml
+++ b/.github/workflows/precommit-update.yml
@@ -1,0 +1,35 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.ADMIN_PAT }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: "chore: Auto-update pre-commit hooks"
+          body: |
+            Update versions of tools in pre-commit 
+            configs to latest version
+          labels: dependencies

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install build tools
       run: |
         make develop
+    - name: Setup pre-commit
+      run: |
+        make pre-commit
     - name: Install dependencies
       run: |
         make install

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Install build tools
       run: |
         make develop
+    - name: Setup pre-commit
+      run: |
+        make pre-commit
     - name: Install dependencies
       run: |
         make install

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@
 
 develop:
 	python -m pip install -e .[dev] --upgrade --upgrade-strategy eager
+
+pre-commit: 
 	pre-commit install
 	pre-commit autoupdate
 


### PR DESCRIPTION


Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[ \] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.

This adds functionality to ensure that pre-commit does the following:
1. Does not cause issues on releases
1. When pre-commit is updated a PR will be automagically generated if this occurs - keeping us up to date.
