### PR TITLE
fix:add

### DIFF
--- a/tests/trestle/core/commands/add_test.py
+++ b/tests/trestle/core/commands/add_test.py
@@ -28,21 +28,22 @@ from trestle.core.commands.add import AddCmd
 from trestle.core.models.elements import Element, ElementPath
 from trestle.core.models.file_content_type import FileContentType
 from trestle.oscal.catalog import Catalog
+from trestle.core.models.actions import UpdateAction
 
 
 def test_add(tmp_dir, sample_catalog_minimal):
     """Test AddCmd.add() method for trestle add."""
     # expected catalog after first add of Role
     file_path = pathlib.Path.joinpath(test_utils.JSON_TEST_DATA_PATH, 'minimal_catalog_roles.json')
-    expected_catalog_roles1 = Catalog.oscal_read(file_path)
+    expected_catalog_roles1 = Element(Catalog.oscal_read(file_path))
 
     # expected catalog after second add of Role
     file_path = pathlib.Path.joinpath(test_utils.JSON_TEST_DATA_PATH, 'minimal_catalog_roles_double.json')
-    expected_catalog_roles2 = Catalog.oscal_read(file_path)
+    expected_catalog_roles2 = Element(Catalog.oscal_read(file_path))
 
     # expected catalog after add of Responsible-Party
     file_path = pathlib.Path.joinpath(test_utils.JSON_TEST_DATA_PATH, 'minimal_catalog_roles_double_rp.json')
-    expected_catalog_roles2_rp = Catalog.oscal_read(file_path)
+    expected_catalog_roles2_rp = Element(Catalog.oscal_read(file_path))
 
     content_type = FileContentType.JSON
 
@@ -56,23 +57,27 @@ def test_add(tmp_dir, sample_catalog_minimal):
     # Execute first _add
     element_path = ElementPath('catalog.metadata.roles')
     catalog_element = Element(sample_catalog_minimal)
-    AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
+    expected_update_action_1 = UpdateAction(expected_catalog_roles1.get_at(element_path), catalog_element, element_path)
+    actual_update_action, actual_catalog_roles = AddCmd.add(element_path, Catalog, catalog_element)
 
-    actual_catalog_roles = Catalog.oscal_read(catalog_def_dir / catalog_def_file)
     assert actual_catalog_roles == expected_catalog_roles1
+    assert actual_update_action == expected_update_action_1
 
     # Execute second _add - this time roles already exists, so this adds a roles object to roles array
-    catalog_element = Element(actual_catalog_roles)
-    AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
-    actual_catalog_roles2 = Catalog.oscal_read(catalog_def_dir / catalog_def_file)
+    catalog_element = actual_catalog_roles
+    expected_update_action_2 = UpdateAction(expected_catalog_roles2.get_at(element_path), catalog_element, element_path)
+    actual_update_action2, actual_catalog_roles2 = AddCmd.add(element_path, Catalog, catalog_element)
     assert actual_catalog_roles2 == expected_catalog_roles2
+    assert actual_update_action2 == expected_update_action_2
+
 
     # Execute _add for responsible-parties to the same catalog
     element_path = ElementPath('catalog.metadata.responsible-parties')
-    catalog_element = Element(actual_catalog_roles2)
-    AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
-    actual_catalog_roles2_rp = Catalog.oscal_read(catalog_def_dir / catalog_def_file)
+    catalog_element = actual_catalog_roles2
+    expected_update_action_3 = UpdateAction(expected_catalog_roles2_rp.get_at(element_path), catalog_element, element_path)
+    actual_update_action3, actual_catalog_roles2_rp = AddCmd.add(element_path, Catalog, catalog_element)
     assert actual_catalog_roles2_rp == expected_catalog_roles2_rp
+    assert actual_update_action3 == expected_update_action_3
 
 
 def test_add_failure(tmp_dir, sample_catalog_minimal):
@@ -90,27 +95,27 @@ def test_add_failure(tmp_dir, sample_catalog_minimal):
     catalog_element = Element(sample_catalog_minimal)
 
     with pytest.raises(err.TrestleError):
-        AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
+        AddCmd.add(element_path, Catalog, catalog_element)
 
     element_path = ElementPath('catalog.metadata.title')
     with pytest.raises(err.TrestleError):
-        AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
+        AddCmd.add(element_path, Catalog, catalog_element)
 
     element_path = ElementPath('catalog.metadata.bad_path')
     with pytest.raises(err.TrestleError):
-        AddCmd.add(catalog_def_dir / catalog_def_file, element_path, Catalog, catalog_element)
+        AddCmd.add(element_path, Catalog, catalog_element)
 
 
 def test_run_failure():
     """Test failure of _run for AddCmd."""
     testargs = ['trestle', 'add', '-e', 'catalog.metadata.roles']
     with patch.object(sys, 'argv', testargs):
-        with pytest.raises(err.TrestleError):
+        with pytest.raises(SystemExit):
             Trestle().run()
 
     testargs = ['trestle', 'add', '-f', './catalog.json']
     with patch.object(sys, 'argv', testargs):
-        with pytest.raises(err.TrestleError):
+        with pytest.raises(SystemExit):
             Trestle().run()
 
 

--- a/tests/trestle/core/commands/add_test.py
+++ b/tests/trestle/core/commands/add_test.py
@@ -25,10 +25,10 @@ from tests import test_utils
 import trestle.core.err as err
 from trestle.cli import Trestle
 from trestle.core.commands.add import AddCmd
+from trestle.core.models.actions import UpdateAction
 from trestle.core.models.elements import Element, ElementPath
 from trestle.core.models.file_content_type import FileContentType
 from trestle.oscal.catalog import Catalog
-from trestle.core.models.actions import UpdateAction
 
 
 def test_add(tmp_dir, sample_catalog_minimal):
@@ -70,11 +70,12 @@ def test_add(tmp_dir, sample_catalog_minimal):
     assert actual_catalog_roles2 == expected_catalog_roles2
     assert actual_update_action2 == expected_update_action_2
 
-
     # Execute _add for responsible-parties to the same catalog
     element_path = ElementPath('catalog.metadata.responsible-parties')
     catalog_element = actual_catalog_roles2
-    expected_update_action_3 = UpdateAction(expected_catalog_roles2_rp.get_at(element_path), catalog_element, element_path)
+    expected_update_action_3 = UpdateAction(
+        expected_catalog_roles2_rp.get_at(element_path), catalog_element, element_path
+    )
     actual_update_action3, actual_catalog_roles2_rp = AddCmd.add(element_path, Catalog, catalog_element)
     assert actual_catalog_roles2_rp == expected_catalog_roles2_rp
     assert actual_update_action3 == expected_update_action_3

--- a/trestle/core/commands/add.py
+++ b/trestle/core/commands/add.py
@@ -39,11 +39,13 @@ class AddCmd(Command):
             f'-{const.ARG_FILE_SHORT}',
             f'--{const.ARG_FILE}',
             help=const.ARG_DESC_FILE + ' to add component/subcomponent to.',
+            required=True
         )
         self.add_argument(
             f'-{const.ARG_ELEMENT_SHORT}',
             f'--{const.ARG_ELEMENT}',
             help=const.ARG_DESC_ELEMENT + ' to add.',
+            required=True
         )
 
     def _run(self, args):
@@ -54,10 +56,6 @@ class AddCmd(Command):
         Then the method executes 'add' for each of the element paths specified.
         """
         args = args.__dict__
-        if args[const.ARG_FILE] is None:
-            raise err.TrestleError(f'Argument "-{const.ARG_FILE_SHORT}" is required')
-        if args[const.ARG_ELEMENT] is None:
-            raise err.TrestleError(f'Argument "-{const.ARG_ELEMENT}" is required')
 
         file_path = pathlib.Path(args[const.ARG_FILE])
 
@@ -66,21 +64,37 @@ class AddCmd(Command):
         parent_object = parent_model.oscal_read(file_path.absolute())
         parent_element = Element(parent_object, utils.classname_to_alias(parent_model.__name__, 'json'))
 
+        add_plan = Plan()
+
         # Do _add for each element_path specified in args
         element_paths: list[str] = args[const.ARG_ELEMENT].split(',')
         for elm_path_str in element_paths:
             element_path = ElementPath(elm_path_str)
-            self.add(file_path, element_path, parent_model, parent_element)
+            update_action, parent_element = self.add(element_path, parent_model, parent_element)
+            add_plan.add_action(update_action)
+
+        create_action = CreatePathAction(file_path.absolute(), True)
+        write_action = WriteFileAction(
+            file_path.absolute(), parent_element, FileContentType.to_content_type(file_path.suffix)
+        )
+
+        add_plan.add_action(create_action)
+        add_plan.add_action(write_action)
+
+        add_plan.simulate()
+        add_plan.execute()
+
 
     @classmethod
-    def add(cls, file_path, element_path, parent_model, parent_element):
-        """For a file_path and element_path, add a child model to the parent_element of a given parent_model.
+    def add(cls, element_path, parent_model, parent_element):
+        """For a element_path, add a child model to the parent_element of a given parent_model.
 
         First we find the child model at the specified element path and instantiate it with default values.
         Then we check if there's already existing element at that path, in which case we append the child model
         to the existing list of dict.
         Then we set up an action plan to update the model (specified by file_path) in memory, create a file
         at the same location and write the file.
+        We update the parent_element to prepare for next adds in the chain
         """
         element_path_list = element_path.get_full_path_parts()
         if '*' in element_path_list:
@@ -106,15 +120,6 @@ class AddCmd(Command):
         update_action = UpdateAction(
             sub_element=child_object, dest_element=parent_element, sub_element_path=element_path
         )
-        create_action = CreatePathAction(file_path.absolute(), True)
-        write_action = WriteFileAction(
-            file_path.absolute(), parent_element, FileContentType.to_content_type(file_path.suffix)
-        )
-
-        add_plan = Plan()
-        add_plan.add_action(update_action)
-        add_plan.add_action(create_action)
-        add_plan.add_action(write_action)
-        add_plan.simulate()
-
-        add_plan.execute()
+        parent_element = parent_element.set_at(element_path, child_object)
+        
+        return update_action, parent_element

--- a/trestle/core/commands/add.py
+++ b/trestle/core/commands/add.py
@@ -84,7 +84,6 @@ class AddCmd(Command):
         add_plan.simulate()
         add_plan.execute()
 
-
     @classmethod
     def add(cls, element_path, parent_model, parent_element):
         """For a element_path, add a child model to the parent_element of a given parent_model.
@@ -121,5 +120,5 @@ class AddCmd(Command):
             sub_element=child_object, dest_element=parent_element, sub_element_path=element_path
         )
         parent_element = parent_element.set_at(element_path, child_object)
-        
+
         return update_action, parent_element


### PR DESCRIPTION
Add now creates one action plan for all given element paths instead of individual plans for each element paths provided with -e flag.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[x\] All commits are signed.