### PR TITLE
Handling bad file extension in arg to trestle remove with clean error message

### DIFF
--- a/trestle/core/commands/remove.py
+++ b/trestle/core/commands/remove.py
@@ -74,7 +74,7 @@ class RemoveCmd(Command):
 
         try:
             parent_object = parent_model.oscal_read(file_path.absolute())
-        except FileNotFoundError as err:
+        except Exception as err:
             logger.debug(f'parent_model.oscal_read() failed: {err}')
             logger.error(f'Remove failed (parent_model.oscal_read()): {err}')
             return 1


### PR DESCRIPTION
## Types of changes

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[ \] All commits are signed.

Previously, supplying **trestle remove** with a file argument using an unsupported extension would raise a SystemExit after *parent_mode.oscal_read()* with messy complaints because it was not handled properly in *RemoveCmd*. It was previously ready only for a *FileNotFoundError*. The change in this PR was to generalize that handling so any error is handled neatly.

This closes #244.
