### PR TITLE
New caching code and unit tests, and bringing remote work up to sync with develop today

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,7 +59,7 @@ def verify_file_content(file_path: pathlib.Path, model: OscalBaseModel):
 def ensure_trestle_config_dir(sub_dir: pathlib.Path):
     """Ensure that the sub_dir has trestle config dir."""
     trestle_dir = pathlib.Path.joinpath(sub_dir, const.TRESTLE_CONFIG_DIR)
-    trestle_dir.mkdir(exist_ok=True)
+    fs.ensure_directory(trestle_dir)
 
 
 def prepare_element_paths(base_dir, element_args) -> List[ElementPath]:
@@ -83,7 +83,7 @@ def prepare_trestle_project_dir(
     file_ext = FileContentType.to_file_extension(content_type)
     models_full_path = tmp_dir / models_dir_name / 'my_test_model'
     model_def_file = models_full_path / f'{model_alias}{file_ext}'
-    models_full_path.mkdir(exists_ok=True)
+    fs.ensure_directory(models_full_path)
     model_obj.oscal_write(model_def_file)
 
     return models_full_path, model_def_file

--- a/tests/trestle/conftest.py
+++ b/tests/trestle/conftest.py
@@ -28,6 +28,7 @@ from tests import test_utils
 from trestle.cli import Trestle
 from trestle.oscal.catalog import Catalog
 from trestle.oscal.target import TargetDefinition
+from trestle.utils import fs
 
 TEST_CONFIG: dict = {}
 
@@ -44,7 +45,7 @@ def tmp_dir(rand_str) -> pathlib.Path:
     """Return a path for a tmp directory."""
     tmp_dir = pathlib.Path.joinpath(test_utils.BASE_TMP_DIR, rand_str)
     assert tmp_dir.parent == test_utils.BASE_TMP_DIR
-    tmp_dir.mkdir(exist_ok=True)
+    fs.ensure_directory(tmp_dir)
     yield tmp_dir
 
     # tear down

--- a/tests/trestle/core/remote/cache_test.py
+++ b/tests/trestle/core/remote/cache_test.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """Testing for cache functionality."""
 
+import pathlib
+
 from trestle.core.remote import cache
 
 
@@ -28,40 +30,40 @@ def test_github_fetcher():
     pass
 
 
-def test_fetcher_factory():
+def test_fetcher_factory(tmp_trestle_dir: pathlib.Path) -> None:
     """Test that the fetcher factory correctly resolves functionality."""
     local_uri_1 = 'file:///home/user/oscal_file.json'
-    fetcher = cache.FetcherFactory.get_fetcher(local_uri_1, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), local_uri_1, False, False)
     assert type(fetcher) == cache.LocalFetcher
 
     local_uri_2 = '/home/user/oscal_file.json'
-    fetcher = cache.FetcherFactory.get_fetcher(local_uri_2, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), local_uri_2, False, False)
     assert type(fetcher) == cache.LocalFetcher
 
     local_uri_3 = '../../file.json'
-    fetcher = cache.FetcherFactory.get_fetcher(local_uri_3, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), local_uri_3, False, False)
     assert type(fetcher) == cache.LocalFetcher
 
     sftp_uri = 'sftp://user@hostname:/path/to/file.json'
-    fetcher = cache.FetcherFactory.get_fetcher(sftp_uri, False, False)
-    assert type(fetcher) == cache.LocalFetcher
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), sftp_uri, False, False)
+    assert type(fetcher) == cache.SFTPFetcher
 
     sftp_uri_2 = 'sftp://user@hostname:2000/path/to/file.json'
-    fetcher = cache.FetcherFactory.get_fetcher(sftp_uri_2, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), sftp_uri_2, False, False)
     assert type(fetcher) == cache.SFTPFetcher
 
     https_uri = 'https://host.com/path/to/json.json'
-    fetcher = cache.FetcherFactory.get_fetcher(https_uri, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), https_uri, False, False)
     assert type(fetcher) == cache.HTTPSFetcher
 
     https_basic_auth = 'https://user:pass@host.com/path/to/json.json'
-    fetcher = cache.FetcherFactory.get_fetcher(https_basic_auth, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), https_basic_auth, False, False)
     assert type(fetcher) == cache.HTTPSFetcher
 
     github_url_1 = 'https://github.com/some/url.json'
-    fetcher = cache.FetcherFactory.get_fetcher(github_url_1, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), github_url_1, False, False)
     assert type(fetcher) == cache.GithubFetcher
 
     github_url_2 = 'https://user:auth@github.com/some/url.json'
-    fetcher = cache.FetcherFactory.get_fetcher(github_url_2, False, False)
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), github_url_2, False, False)
     assert type(fetcher) == cache.GithubFetcher

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -19,6 +19,7 @@ Trestle cache operations library.
 Allows for using uris to reference external directories and then expand.
 """
 
+import logging
 import pathlib
 import shutil
 from abc import ABC, abstractmethod
@@ -27,9 +28,8 @@ from typing import Any, Dict, Type
 from trestle.core import const
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.err import TrestleError
-from trestle.utils import log
 
-logger = log.get_logger()
+logger = logging.getLogger(__name__)
 
 
 class FetcherBase(ABC):
@@ -53,7 +53,7 @@ class FetcherBase(ABC):
         self._refresh = refresh
         self._fail_hard = fail_hard
         self._cache_only = cache_only
-        self._trestle_cache_path = trestle_root / const.TRESTLE_CONFIG_DIR / 'cache'
+        self._trestle_cache_path: pathlib.Path = trestle_root / const.TRESTLE_CONFIG_DIR / 'cache'
 
         # ensure trestle cache directory exists.
         self._trestle_cache_path.mkdir(exist_ok=True)
@@ -92,7 +92,7 @@ class LocalFetcher(FetcherBase):
         cache_only: bool = False
     ) -> None:
         """Initialize local fetcher."""
-        super.__init__(uri, refresh, fail_hard, cache_only)
+        super().__init__(trestle_root, uri, refresh, fail_hard, cache_only)
         # Normalize uri to a root file.
         if 'file:///' == uri[0:8]:
             uri = uri[7:]
@@ -129,7 +129,7 @@ class HTTPSFetcher(FetcherBase):
         cache_only: bool = False
     ) -> None:
         """Initialize HTTPS fetcher."""
-        super.__init__(uri, refresh, fail_hard, cache_only)
+        super().__init__(trestle_root, uri, refresh, fail_hard, cache_only)
 
     def _update_cache(self) -> None:
         pass
@@ -149,7 +149,7 @@ class SFTPFetcher(FetcherBase):
         cache_only: bool = False
     ) -> None:
         """Initialize STFP fetcher."""
-        super.__init__(uri, refresh, fail_hard, cache_only)
+        super().__init__(trestle_root, uri, refresh, fail_hard, cache_only)
 
     def _update_cache(self) -> None:
         pass
@@ -167,7 +167,7 @@ class GithubFetcher(HTTPSFetcher):
         cache_only: bool = False
     ) -> None:
         """Initialize github specific fetcher."""
-        super.__init__(uri, refresh, fail_hard, cache_only)
+        super().__init__(trestle_root, uri, refresh, fail_hard, cache_only)
 
     def _update_cache(self) -> None:
         pass
@@ -189,24 +189,24 @@ class FetcherFactory(object):
         fail_hard: bool = False,
         cache_only: bool = False
     ) -> FetcherBase:
-        """Return an instaciated fetcher object based on the uri."""
+        """Return an instantiated fetcher object based on the uri."""
         # Basic correctness test
         if len(uri) <= 9 or '/' not in uri:
             raise TrestleError(f'Unable to fetch uri as it appears to be invalid {uri}')
 
-        if uri[0] == '/' or 'file:///' == uri[0:8]:
+        if uri[0] == '/' or uri[0:3] == '../' or uri[0:2] == './' or 'file:///' == uri[0:8]:
             # Note assumption here is that relative paths are only supported within
             # trestle directories. This simplification is to ensure
-            return LocalFetcher(uri, refresh, fail_hard, cache_only)
-        elif 'stfp://' == uri[0:7]:
-            return SFTPFetcher(uri, refresh, fail_hard, cache_only)
+            return LocalFetcher(trestle_root, uri, refresh, fail_hard, cache_only)
+        elif 'sftp://' == uri[0:7]:
+            return SFTPFetcher(trestle_root, uri, refresh, fail_hard, cache_only)
         elif 'https://' == uri[0:8]:
             # Test for github uri assumption - must be first after basic auth (if it exists)
             cleaned = uri[8:]
             # tests for special scenarios
             if cleaned.split('@')[-1][0:7] == 'github.':
-                return GithubFetcher(uri, refresh, fail_hard, cache_only)
+                return GithubFetcher(trestle_root, uri, refresh, fail_hard, cache_only)
             else:
-                return HTTPSFetcher(uri, refresh, fail_hard, cache_only)
+                return HTTPSFetcher(trestle_root, uri, refresh, fail_hard, cache_only)
         else:
             raise TrestleError(f'Unable to fetch uri: {uri} as the uri did not match a suppported format.')

--- a/trestle/utils/fs.py
+++ b/trestle/utils/fs.py
@@ -40,6 +40,27 @@ def should_ignore(name: str) -> bool:
     return name[0] == '.' or name[0] == '_'
 
 
+def ensure_directory(path: str) -> None:
+    """
+    Ensure the directory ```path``` exists.
+
+    It creates the directories along the path if they do not exist.
+    Arguments:
+        path(str): The path to the directory
+
+    Raises:
+        AssertionError: If the directory path exists but is not a directory
+
+    Returns: None
+    """
+    path = os.path.abspath(path)
+
+    if not os.path.exists(path):
+        os.makedirs(path)
+    elif not os.path.isdir(path):
+        raise AssertionError(f'Path `{path}` exists but is not a directory')
+
+
 def is_valid_project_root(project_root: pathlib.Path) -> bool:
     """Check if the project root is a valid trestle project root."""
     if project_root is None or project_root == '' or len(project_root.parts) <= 0:

--- a/trestle/utils/trash.py
+++ b/trestle/utils/trash.py
@@ -132,7 +132,7 @@ def store_file(file_path: pathlib.Path, delete_source: bool = False) -> None:
         raise AssertionError(f'Specified path "{file_path}" is not a file')
 
     trash_file_path = to_trash_file_path(file_path)
-    trash_file_path.parent.mkdir(exist_ok=True)
+    fs.ensure_directory(trash_file_path.parent)
     copyfile(file_path, trash_file_path)
 
     if delete_source:
@@ -178,7 +178,7 @@ def recover_file(file_path: pathlib.Path, delete_trash: bool = False) -> None:
     if not trash_file_path.exists():
         raise AssertionError(f'Specified path "{file_path}" could not be found in trash')
 
-    file_path.parent.mkdir(exist_ok=True)
+    fs.ensure_directory(file_path.parent)
     copyfile(trash_file_path, file_path)
 
     if delete_trash:


### PR DESCRIPTION
Working with Chris' initial work with caching/remote resources, I've extended the fetcher code with at least valid fetchers that are selected correctly on the basis of the uri given. Working unit testing for that.

Note this is to merge into *feature/remote*, **not** into *develop*.

## Types of changes

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[ \] All commits are signed.

