### PR TITLE
Feature/trestle tasks transform osco

### DIFF
--- a/tests/data/tasks/osco/demo-osco-to-oscal.config
+++ b/tests/data/tasks/osco/demo-osco-to-oscal.config
@@ -1,0 +1,5 @@
+[task.osco-to-oscal]
+
+input-dir =  /home/degenaro/git/degenaro.evidence-locker/osco/input
+output-dir = /home/degenaro/git/degenaro.evidence-locker/osco/output
+output-overwrite = true

--- a/tests/data/tasks/osco/demo-osco-to-oscal.config
+++ b/tests/data/tasks/osco/demo-osco-to-oscal.config
@@ -1,5 +1,5 @@
 [task.osco-to-oscal]
 
-input-dir =  /home/degenaro/git/degenaro.evidence-locker/osco/input
-output-dir = /home/degenaro/git/degenaro.evidence-locker/osco/output
+input-dir =  tests/data/tasks/osco/input
+output-dir = tests/data/tasks/osco/runtime
 output-overwrite = true

--- a/tests/data/tasks/osco/input/oscal-metadata.yaml
+++ b/tests/data/tasks/osco/input/oscal-metadata.yaml
@@ -1,5 +1,7 @@
  
 ssg-ocp4-ds-cis-10.221.139.104-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
@@ -16,6 +18,8 @@ ssg-ocp4-ds-cis-10.221.139.104-pod:
             cluster-region: us-south
             
 ssg-ocp4-ds-cis-10.221.139.105-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
@@ -32,6 +36,8 @@ ssg-ocp4-ds-cis-10.221.139.105-pod:
             cluster-region: us-south
             
 ssg-ocp4-ds-cis-10.221.139.107-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
@@ -48,6 +54,8 @@ ssg-ocp4-ds-cis-10.221.139.107-pod:
             cluster-region: us-south
          
 ssg-rhel7-ds-cis-10.221.139.104-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
@@ -64,6 +72,8 @@ ssg-rhel7-ds-cis-10.221.139.104-pod:
             cluster-region: us-south
             
 ssg-rhel7-ds-cis-10.221.139.105-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
@@ -80,6 +90,8 @@ ssg-rhel7-ds-cis-10.221.139.105-pod:
             cluster-region: us-south
             
 ssg-rhel7-ds-cis-10.221.139.107-pod:
+   locker: https://github.ibm.com/degenaro/evidence-locker
+   namespace: xccdf
    subject-references:
       component:
          uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001

--- a/tests/data/tasks/osco/input/oscal-metadata.yaml
+++ b/tests/data/tasks/osco/input/oscal-metadata.yaml
@@ -1,0 +1,97 @@
+ 
+ssg-ocp4-ds-cis-10.221.139.104-pod:
+   subject-references:
+      component:
+         uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
+         type: component
+         title: Red Hat OpenShift Kubernetes
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e
+         type: inventory-item
+         title: Pod
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+            
+ssg-ocp4-ds-cis-10.221.139.105-pod:
+   subject-references:
+      component:
+         uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
+         type: component
+         title: Red Hat OpenShift Kubernetes
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4f
+         type: inventory-item
+         title: Pod
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-000001fe.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+            
+ssg-ocp4-ds-cis-10.221.139.107-pod:
+   subject-references:
+      component:
+         uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
+         type: component
+         title: Red Hat OpenShift Kubernetes
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4e
+         type: inventory-item
+         title: Pod
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-00000338.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+         
+ssg-rhel7-ds-cis-10.221.139.104-pod:
+   subject-references:
+      component:
+         uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
+         type: component
+         title: RedHat Enterprise Linux 7.8
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e
+         type: inventory-item
+         title: VM
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+            
+ssg-rhel7-ds-cis-10.221.139.105-pod:
+   subject-references:
+      component:
+         uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
+         type: component
+         title: RedHat Enterprise Linux 7.8
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4f
+         type: inventory-item
+         title: VM
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-000001fe.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+            
+ssg-rhel7-ds-cis-10.221.139.107-pod:
+   subject-references:
+      component:
+         uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
+         type: component
+         title: RedHat Enterprise Linux 7.8
+      inventory-item:
+         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4e
+         type: inventory-item
+         title: VM
+         properties:
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-00000338.iks.ibm
+            cluster-name: ROKS-OpenSCAP-1
+            cluster-type: openshift
+            cluster-region: us-south
+   

--- a/tests/data/tasks/osco/input/oscal-metadata.yaml
+++ b/tests/data/tasks/osco/input/oscal-metadata.yaml
@@ -16,43 +16,7 @@ ssg-ocp4-ds-cis-10.221.139.104-pod:
             cluster-name: ROKS-OpenSCAP-1
             cluster-type: openshift
             cluster-region: us-south
-            
-ssg-ocp4-ds-cis-10.221.139.105-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
-   namespace: xccdf
-   subject-references:
-      component:
-         uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
-         type: component
-         title: Red Hat OpenShift Kubernetes
-      inventory-item:
-         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4f
-         type: inventory-item
-         title: Pod
-         properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-000001fe.iks.ibm
-            cluster-name: ROKS-OpenSCAP-1
-            cluster-type: openshift
-            cluster-region: us-south
-            
-ssg-ocp4-ds-cis-10.221.139.107-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
-   namespace: xccdf
-   subject-references:
-      component:
-         uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
-         type: component
-         title: Red Hat OpenShift Kubernetes
-      inventory-item:
-         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4e
-         type: inventory-item
-         title: Pod
-         properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-00000338.iks.ibm
-            cluster-name: ROKS-OpenSCAP-1
-            cluster-type: openshift
-            cluster-region: us-south
-         
+                    
 ssg-rhel7-ds-cis-10.221.139.104-pod:
    locker: https://github.ibm.com/degenaro/evidence-locker
    namespace: xccdf
@@ -71,39 +35,3 @@ ssg-rhel7-ds-cis-10.221.139.104-pod:
             cluster-type: openshift
             cluster-region: us-south
             
-ssg-rhel7-ds-cis-10.221.139.105-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
-   namespace: xccdf
-   subject-references:
-      component:
-         uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
-         type: component
-         title: RedHat Enterprise Linux 7.8
-      inventory-item:
-         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4f
-         type: inventory-item
-         title: VM
-         properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-000001fe.iks.ibm
-            cluster-name: ROKS-OpenSCAP-1
-            cluster-type: openshift
-            cluster-region: us-south
-            
-ssg-rhel7-ds-cis-10.221.139.107-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
-   namespace: xccdf
-   subject-references:
-      component:
-         uuid-ref: 89cfe7a7-ce6b-4699-aa7b-2f5739c72001
-         type: component
-         title: RedHat Enterprise Linux 7.8
-      inventory-item:
-         uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d4e
-         type: inventory-item
-         title: VM
-         properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-00000338.iks.ibm
-            cluster-name: ROKS-OpenSCAP-1
-            cluster-type: openshift
-            cluster-region: us-south
-   

--- a/tests/data/tasks/osco/input/oscal-metadata.yaml
+++ b/tests/data/tasks/osco/input/oscal-metadata.yaml
@@ -1,6 +1,6 @@
  
-ssg-ocp4-ds-cis-10.221.139.104-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
+ssg-ocp4-ds-cis-111.222.333.444-pod:
+   locker: https://github.mycorp.com/degenaro/evidence-locker
    namespace: xccdf
    subject-references:
       component:
@@ -12,13 +12,13 @@ ssg-ocp4-ds-cis-10.221.139.104-pod:
          type: inventory-item
          title: Pod
          properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp
             cluster-name: ROKS-OpenSCAP-1
             cluster-type: openshift
             cluster-region: us-south
                     
-ssg-rhel7-ds-cis-10.221.139.104-pod:
-   locker: https://github.ibm.com/degenaro/evidence-locker
+ssg-rhel7-ds-cis-111.222.333.444-pod:
+   locker: https://github.mycorp.com/degenaro/evidence-locker
    namespace: xccdf
    subject-references:
       component:
@@ -30,7 +30,7 @@ ssg-rhel7-ds-cis-10.221.139.104-pod:
          type: inventory-item
          title: VM
          properties:
-            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+            target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp
             cluster-name: ROKS-OpenSCAP-1
             cluster-type: openshift
             cluster-region: us-south

--- a/tests/data/tasks/osco/input/ssg-ocp4-ds-cis-10.221.139.104-pod.yaml
+++ b/tests/data/tasks/osco/input/ssg-ocp4-ds-cis-10.221.139.104-pod.yaml
@@ -1,0 +1,689 @@
+apiVersion: v1
+data:
+  exit-code: "2"
+  results: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <TestResult xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_cis" start-time="2020-08-03T02:26:26+00:00" end-time="2020-08-03T02:26:26+00:00" version="0.1.52" test-system="cpe:/a:redhat:openscap:1.3.3">
+              <benchmark href="/content/ssg-ocp4-ds.xml" id="xccdf_org.ssgproject.content_benchmark_OCP-4"/>
+              <title>OSCAP Scan Result</title>
+              <profile idref="xccdf_org.ssgproject.content_profile_cis"/>
+              <target>kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm</target>
+              <target-facts>
+                <fact name="urn:xccdf:fact:identifier" type="string">chroot:///host</fact>
+                <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+                <fact name="urn:xccdf:fact:scanner:version" type="string">1.3.3</fact>
+              </target-facts>
+              <target-id-ref system="http://scap.nist.gov/schema/asset-identification/1.1" name="asset0" href=""/>
+              <platform idref="cpe:/a:redhat:openshift_container_platform:4.1"/>
+              <platform idref="cpe:/a:machine"/>
+              <set-value idref="xccdf_org.ssgproject.content_value_ocp_data_root">/kubernetes-api-resources</set-value>
+              <set-value idref="xccdf_org.ssgproject.content_value_var_kube_authorization_mode">Webhook</set-value>
+              <set-value idref="xccdf_org.ssgproject.content_value_var_streaming_connection_timeouts">5m</set-value>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notselected</result>
+                <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-84209-6</ident>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_accounts_unique_service_account" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_configure_network_policies" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scheduler_profiling_argument" time="2020-08-03T02:26:26+00:00" severity="low" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-scheduler_profiling_argument:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_secrets_no_environment_variables" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_worker_service" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_worker_service:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_worker_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_worker_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_worker_service" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_worker_service:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_kubelet_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_worker_service" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_worker_service:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_worker_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_worker_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_worker_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_kubelet_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_kubelet_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_controller_use_service_account" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-controller_use_service_account:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_controller_bind_address" time="2020-08-03T02:26:26+00:00" severity="low" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-controller_bind_address:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_controller_service_account_private_key" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_controller_service_account_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-controller_rotate_kubelet_server_certs:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_root_containers" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_network_namespace" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-general_configure_imagepolicywebhook:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_rbac_wildcard_use" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_rbac_pod_creation_access" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_configure_client_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_disable_readonly_port:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_enable_server_cert_rotation:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_configure_tls_key:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_authorization_mode" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_configure_event_creation:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_enable_client_cert_rotation:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-kubelet_configure_tls_cert:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notselected</result>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_client_cert_auth" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_client_cert_auth:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_peer_key_file" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_peer_key_file:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_peer_cert_file" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_peer_cert_file:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_unique_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_unique_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_peer_auto_tls:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_peer_client_cert_auth:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_cert_file" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_cert_file:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_auto_tls" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_auto_tls:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_etcd_key_file" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-etcd_key_file:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_cni_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_cni_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_etcd_member" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_etcd_member" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_openvswitch" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_openvswitch:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_controller_manager_kubeconfig:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_openvswitch" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_openvswitch:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_var_lib_etcd:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_var_lib_etcd:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_owner_controller_manager_kubeconfig:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_cni_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_cni_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_permissions_controller_manager_kubeconfig:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_cni_conf:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-file_groupowner_openvswitch:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>notchecked</result>
+                <message severity="info">No candidate or applicable check found.</message>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_insecure_port" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_insecure_port:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_tls_private_key" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_tls_private_key:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_tls_cert" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_tls_cert:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_client_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_client_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_path" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_audit_log_path:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_tls_cipher_suites:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_EventRateLimit:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_authorization_mode" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_authorization_mode:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_audit_log_maxage:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_profiling" time="2020-08-03T02:26:26+00:00" severity="low" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_profiling:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_ServiceAccount:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_AlwaysAdmit:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_encryption_provider_cipher:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_token_auth" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_token_auth:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_anonymous_auth" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_anonymous_auth:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_etcd_ca" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_etcd_ca:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_encryption_provider_config:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_request_timeout" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_request_timeout:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_audit_log_maxsize:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_NodeRestriction:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_SecurityContextDeny:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_PodSecurityPolicy:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_basic_auth" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_basic_auth:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_kubelet_client_key:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_service_account_public_key" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_service_account_public_key:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_etcd_key" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_etcd_key:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_AlwaysPullImages:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_kubelet_client_cert:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup" time="2020-08-03T02:26:26+00:00" severity="low" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_audit_log_maxbackup:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_https" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_kubelet_https:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_etcd_cert" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_etcd_cert:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>pass</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_insecure_bind_address:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority" time="2020-08-03T02:26:26+00:00" severity="high" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_kubelet_certificate_authority:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_admission_control_plugin_NamespaceLifecycle:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <rule-result idref="xccdf_org.ssgproject.content_rule_api_server_secure_port" time="2020-08-03T02:26:26+00:00" severity="medium" weight="1.000000">
+                <result>fail</result>
+                <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+                  <check-content-ref name="oval:ssg-api_server_secure_port:def:1" href="#oval0"/>
+                </check>
+              </rule-result>
+              <score system="urn:xccdf:scoring:default" maximum="100.000000">15.670996</score>
+            </TestResult>
+kind: ConfigMap
+metadata:
+  annotations:
+    compliance-remediations/processed: ""
+    compliance.openshift.io/scan-error-msg: ""
+    compliance.openshift.io/scan-result: NON-COMPLIANT
+    openscap-scan-result/node: 10.221.139.104
+  creationTimestamp: "2020-08-03T02:26:34Z"
+  labels:
+    compliance-scan: ssg-ocp4-ds-cis
+  name: ssg-ocp4-ds-cis-10.221.139.104-pod
+  namespace: openshift-compliance
+  resourceVersion: "22693328"
+  selfLink: /api/v1/namespaces/openshift-compliance/configmaps/ssg-ocp4-ds-cis-10.221.139.104-pod
+  uid: 1da3ea81-0a25-4512-ad86-7ac360246b5d

--- a/tests/data/tasks/osco/input/ssg-ocp4-ds-cis-111.222.333.444-pod.yaml
+++ b/tests/data/tasks/osco/input/ssg-ocp4-ds-cis-111.222.333.444-pod.yaml
@@ -7,7 +7,7 @@ data:
               <benchmark href="/content/ssg-ocp4-ds.xml" id="xccdf_org.ssgproject.content_benchmark_OCP-4"/>
               <title>OSCAP Scan Result</title>
               <profile idref="xccdf_org.ssgproject.content_profile_cis"/>
-              <target>kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm</target>
+              <target>kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp</target>
               <target-facts>
                 <fact name="urn:xccdf:fact:identifier" type="string">chroot:///host</fact>
                 <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
@@ -678,12 +678,12 @@ metadata:
     compliance-remediations/processed: ""
     compliance.openshift.io/scan-error-msg: ""
     compliance.openshift.io/scan-result: NON-COMPLIANT
-    openscap-scan-result/node: 10.221.139.104
+    openscap-scan-result/node: 111.222.333.444
   creationTimestamp: "2020-08-03T02:26:34Z"
   labels:
     compliance-scan: ssg-ocp4-ds-cis
-  name: ssg-ocp4-ds-cis-10.221.139.104-pod
+  name: ssg-ocp4-ds-cis-111.222.333.444-pod
   namespace: openshift-compliance
   resourceVersion: "22693328"
-  selfLink: /api/v1/namespaces/openshift-compliance/configmaps/ssg-ocp4-ds-cis-10.221.139.104-pod
+  selfLink: /api/v1/namespaces/openshift-compliance/configmaps/ssg-ocp4-ds-cis-111.222.333.444-pod
   uid: 1da3ea81-0a25-4512-ad86-7ac360246b5d

--- a/tests/data/tasks/osco/output/osco-pod-oscal.json
+++ b/tests/data/tasks/osco/output/osco-pod-oscal.json
@@ -7,7 +7,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -31,7 +31,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -47,7 +47,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -65,7 +65,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -89,7 +89,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -105,7 +105,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -123,7 +123,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -147,7 +147,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -163,7 +163,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -181,7 +181,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -205,7 +205,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -221,7 +221,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -239,7 +239,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -263,7 +263,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -279,7 +279,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -297,7 +297,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -321,7 +321,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -337,7 +337,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -355,7 +355,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -379,7 +379,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -395,7 +395,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -413,7 +413,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -437,7 +437,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -453,7 +453,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -471,7 +471,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -495,7 +495,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -511,7 +511,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -529,7 +529,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -553,7 +553,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -569,7 +569,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -587,7 +587,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -611,7 +611,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -627,7 +627,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -645,7 +645,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -669,7 +669,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -685,7 +685,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -703,7 +703,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -727,7 +727,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -743,7 +743,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -761,7 +761,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -785,7 +785,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -801,7 +801,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -819,7 +819,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -843,7 +843,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -859,7 +859,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -877,7 +877,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -901,7 +901,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -917,7 +917,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -935,7 +935,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -959,7 +959,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -975,7 +975,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -993,7 +993,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1017,7 +1017,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1033,7 +1033,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1051,7 +1051,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1075,7 +1075,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1091,7 +1091,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1109,7 +1109,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1133,7 +1133,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1149,7 +1149,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1167,7 +1167,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1191,7 +1191,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1207,7 +1207,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1225,7 +1225,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1249,7 +1249,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1265,7 +1265,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1283,7 +1283,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1307,7 +1307,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1323,7 +1323,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1341,7 +1341,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1365,7 +1365,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1381,7 +1381,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1399,7 +1399,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1423,7 +1423,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1439,7 +1439,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1457,7 +1457,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1481,7 +1481,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1497,7 +1497,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1515,7 +1515,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1539,7 +1539,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1555,7 +1555,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1573,7 +1573,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1597,7 +1597,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1613,7 +1613,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1631,7 +1631,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1655,7 +1655,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1671,7 +1671,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1689,7 +1689,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1713,7 +1713,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1729,7 +1729,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1747,7 +1747,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1771,7 +1771,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1787,7 +1787,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1805,7 +1805,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1829,7 +1829,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1845,7 +1845,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1863,7 +1863,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1887,7 +1887,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1903,7 +1903,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1921,7 +1921,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -1945,7 +1945,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -1961,7 +1961,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -1979,7 +1979,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2003,7 +2003,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2019,7 +2019,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2037,7 +2037,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2061,7 +2061,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2077,7 +2077,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2095,7 +2095,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2119,7 +2119,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2135,7 +2135,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2153,7 +2153,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2177,7 +2177,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2193,7 +2193,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2211,7 +2211,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2235,7 +2235,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2251,7 +2251,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2269,7 +2269,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2293,7 +2293,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2309,7 +2309,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2327,7 +2327,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2351,7 +2351,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2367,7 +2367,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2385,7 +2385,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2409,7 +2409,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2425,7 +2425,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2443,7 +2443,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2467,7 +2467,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2483,7 +2483,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2501,7 +2501,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2525,7 +2525,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2541,7 +2541,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2559,7 +2559,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2583,7 +2583,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2599,7 +2599,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2617,7 +2617,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2641,7 +2641,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2657,7 +2657,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2675,7 +2675,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2699,7 +2699,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2715,7 +2715,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2733,7 +2733,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2757,7 +2757,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2773,7 +2773,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2791,7 +2791,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2815,7 +2815,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2831,7 +2831,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2849,7 +2849,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2873,7 +2873,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2889,7 +2889,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2907,7 +2907,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2931,7 +2931,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -2947,7 +2947,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -2965,7 +2965,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -2989,7 +2989,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3005,7 +3005,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3023,7 +3023,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3047,7 +3047,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3063,7 +3063,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3081,7 +3081,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3105,7 +3105,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3121,7 +3121,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3139,7 +3139,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3163,7 +3163,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3179,7 +3179,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3197,7 +3197,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3221,7 +3221,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3237,7 +3237,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3255,7 +3255,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3279,7 +3279,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3295,7 +3295,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3313,7 +3313,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3337,7 +3337,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3353,7 +3353,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3371,7 +3371,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3395,7 +3395,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3411,7 +3411,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3429,7 +3429,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3453,7 +3453,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3469,7 +3469,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3487,7 +3487,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3511,7 +3511,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3527,7 +3527,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3545,7 +3545,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3569,7 +3569,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3585,7 +3585,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3603,7 +3603,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3627,7 +3627,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3643,7 +3643,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3661,7 +3661,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3685,7 +3685,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3701,7 +3701,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3719,7 +3719,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3743,7 +3743,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3759,7 +3759,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3777,7 +3777,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3801,7 +3801,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3817,7 +3817,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3835,7 +3835,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3859,7 +3859,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3875,7 +3875,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3893,7 +3893,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3917,7 +3917,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3933,7 +3933,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -3951,7 +3951,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -3975,7 +3975,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -3991,7 +3991,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4009,7 +4009,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4033,7 +4033,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4049,7 +4049,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4067,7 +4067,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4091,7 +4091,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4107,7 +4107,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4125,7 +4125,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4149,7 +4149,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4165,7 +4165,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4183,7 +4183,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4207,7 +4207,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4223,7 +4223,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4241,7 +4241,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4265,7 +4265,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4281,7 +4281,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4299,7 +4299,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4323,7 +4323,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4339,7 +4339,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4357,7 +4357,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4381,7 +4381,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4397,7 +4397,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4415,7 +4415,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4439,7 +4439,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4455,7 +4455,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4473,7 +4473,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4497,7 +4497,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4513,7 +4513,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4531,7 +4531,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4555,7 +4555,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4571,7 +4571,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4589,7 +4589,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4613,7 +4613,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4629,7 +4629,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4647,7 +4647,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4671,7 +4671,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4687,7 +4687,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4705,7 +4705,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4729,7 +4729,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4745,7 +4745,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4763,7 +4763,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4787,7 +4787,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4803,7 +4803,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4821,7 +4821,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4845,7 +4845,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4861,7 +4861,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4879,7 +4879,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4903,7 +4903,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4919,7 +4919,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4937,7 +4937,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -4961,7 +4961,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -4977,7 +4977,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -4995,7 +4995,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5019,7 +5019,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5035,7 +5035,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5053,7 +5053,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5077,7 +5077,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5093,7 +5093,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5111,7 +5111,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5135,7 +5135,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5151,7 +5151,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5169,7 +5169,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5193,7 +5193,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5209,7 +5209,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5227,7 +5227,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5251,7 +5251,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5267,7 +5267,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5285,7 +5285,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5309,7 +5309,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5325,7 +5325,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5343,7 +5343,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5367,7 +5367,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5383,7 +5383,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5401,7 +5401,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5425,7 +5425,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5441,7 +5441,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5459,7 +5459,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5483,7 +5483,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5499,7 +5499,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5517,7 +5517,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5541,7 +5541,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5557,7 +5557,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5575,7 +5575,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5599,7 +5599,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5615,7 +5615,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5633,7 +5633,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5657,7 +5657,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5673,7 +5673,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5691,7 +5691,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5715,7 +5715,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5731,7 +5731,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5749,7 +5749,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5773,7 +5773,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5789,7 +5789,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5807,7 +5807,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5831,7 +5831,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5847,7 +5847,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5865,7 +5865,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5889,7 +5889,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5905,7 +5905,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5923,7 +5923,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -5947,7 +5947,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -5963,7 +5963,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -5981,7 +5981,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6005,7 +6005,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6021,7 +6021,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6039,7 +6039,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6063,7 +6063,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6079,7 +6079,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6097,7 +6097,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6121,7 +6121,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6137,7 +6137,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6155,7 +6155,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6179,7 +6179,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6195,7 +6195,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6213,7 +6213,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6237,7 +6237,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6253,7 +6253,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6271,7 +6271,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6295,7 +6295,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6311,7 +6311,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6329,7 +6329,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6353,7 +6353,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6369,7 +6369,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6387,7 +6387,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6411,7 +6411,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6427,7 +6427,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6445,7 +6445,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6469,7 +6469,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6485,7 +6485,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6503,7 +6503,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6527,7 +6527,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6543,7 +6543,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6561,7 +6561,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6585,7 +6585,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6601,7 +6601,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6619,7 +6619,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6643,7 +6643,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6659,7 +6659,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6677,7 +6677,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6701,7 +6701,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6717,7 +6717,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6735,7 +6735,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6759,7 +6759,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6775,7 +6775,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6793,7 +6793,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6817,7 +6817,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6833,7 +6833,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6851,7 +6851,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6875,7 +6875,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6891,7 +6891,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6909,7 +6909,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6933,7 +6933,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -6949,7 +6949,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -6967,7 +6967,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -6991,7 +6991,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -7007,7 +7007,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -7025,7 +7025,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -7049,7 +7049,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -7065,7 +7065,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -7083,7 +7083,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -7107,7 +7107,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -7123,7 +7123,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -7141,7 +7141,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -7165,7 +7165,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -7181,7 +7181,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"
@@ -7199,7 +7199,7 @@
       "evidence-group": [
         {
           "description": "Evidence location.",
-          "href": "https://github.ibm.com/degenaro/evidence-locker",
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
           "properties": [
             {
               "ns": "xccdf",
@@ -7223,7 +7223,7 @@
               "ns": "xccdf",
               "class": "target",
               "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
             }
           ]
         }
@@ -7239,7 +7239,7 @@
           "type": "inventory-item",
           "title": "Pod",
           "properties": {
-            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp",
             "cluster-name": "ROKS-OpenSCAP-1",
             "cluster-type": "openshift",
             "cluster-region": "us-south"

--- a/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
+++ b/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
@@ -1,28 +1,34 @@
 {
   "observations": [
     {
-      "uuid": "8b3af6c1-bbbc-4ff7-8db8-0674b2129056",
+      "uuid": "1770a4c2-3701-4a9b-9511-fc6e115fdea5",
       "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
       "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notselected"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -53,28 +59,34 @@
       ]
     },
     {
-      "uuid": "7cc59e9a-43d4-4560-8e40-5ad48703ad08",
+      "uuid": "c7585d84-bce9-440a-ad8d-d4183932a79e",
       "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
       "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -105,28 +117,34 @@
       ]
     },
     {
-      "uuid": "fe3a4232-1318-4fbe-aceb-900736c519b1",
+      "uuid": "e08e5ae9-c02f-46e9-bb0f-cde6a5c85293",
       "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
       "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -157,28 +175,34 @@
       ]
     },
     {
-      "uuid": "5608acd0-5f6d-4a0e-a48b-164615680df3",
+      "uuid": "a22d637e-2e77-4858-af4a-b0037cb3d11a",
       "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
       "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_configure_network_policies"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -209,28 +233,34 @@
       ]
     },
     {
-      "uuid": "e3826f74-8227-4cd7-8f1e-b1fd14d2352f",
+      "uuid": "e6660bde-858f-4870-b9be-4e7b25828cae",
       "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
       "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -261,28 +291,34 @@
       ]
     },
     {
-      "uuid": "9a3ef3e3-a65a-48e4-93ba-5399f5226438",
+      "uuid": "d74f0a9c-df35-4a22-8c2c-c5c743985a4f",
       "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
       "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -313,28 +349,34 @@
       ]
     },
     {
-      "uuid": "5ceb2c35-47fe-405f-8951-0d453410b97f",
+      "uuid": "710462d9-6e4d-4deb-b739-de722c2aa88a",
       "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
       "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -365,28 +407,34 @@
       ]
     },
     {
-      "uuid": "30930ed6-8578-471a-aa00-accb130ec1bd",
+      "uuid": "4117b319-f699-446b-8468-8276874ae63e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -417,28 +465,34 @@
       ]
     },
     {
-      "uuid": "a2156080-a165-4d8b-a049-e7a783adfb64",
+      "uuid": "7188fa89-6845-4193-ba8d-b90de14028bd",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -469,28 +523,34 @@
       ]
     },
     {
-      "uuid": "d22487d1-edd2-40be-8d15-2c5021b5b199",
+      "uuid": "068c0230-9260-45cf-89b9-1f0e46845ae2",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -521,28 +581,34 @@
       ]
     },
     {
-      "uuid": "2413a183-bb6b-4188-b63b-3ac61f1c2057",
+      "uuid": "fa43874c-c9db-4f46-b145-03bed8153f53",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -573,28 +639,34 @@
       ]
     },
     {
-      "uuid": "0be8144f-e4d2-4493-a300-74e7eb301f64",
+      "uuid": "387061c0-f8fc-4261-82af-812a0679d65a",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_service"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -625,28 +697,34 @@
       ]
     },
     {
-      "uuid": "3cf63848-04ee-4878-8863-7f11f0f2696b",
+      "uuid": "07469975-a6bc-4035-8f1c-3b434becde52",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -677,28 +755,34 @@
       ]
     },
     {
-      "uuid": "57a6a7cd-18e3-4f13-8059-42926c23f62c",
+      "uuid": "c800da88-c928-4d8d-a536-05e8a88917f4",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -729,28 +813,34 @@
       ]
     },
     {
-      "uuid": "16fd9568-bef1-41d9-900a-ba73f876440c",
+      "uuid": "15781498-feb8-496d-820a-f501abbffa47",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -781,28 +871,34 @@
       ]
     },
     {
-      "uuid": "539a6060-379f-4dba-b60a-3fb667133a21",
+      "uuid": "c63182da-a73f-4721-8a44-c886bf75b63e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -833,28 +929,34 @@
       ]
     },
     {
-      "uuid": "00cd72ef-55bd-4d24-a825-68ffacbc146f",
+      "uuid": "93e22975-f445-4cab-b15d-ad5e930a35aa",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -885,28 +987,34 @@
       ]
     },
     {
-      "uuid": "060e4a7a-ae97-489b-ad52-60c5d4e0a3b4",
+      "uuid": "a1d6c563-38e0-49dc-8a1b-cf991c348f99",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -937,28 +1045,34 @@
       ]
     },
     {
-      "uuid": "939169e2-c2fd-421d-b4fb-5753a134fef5",
+      "uuid": "be6184a6-1811-4a9d-8a24-ed35ed2ada49",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -989,28 +1103,34 @@
       ]
     },
     {
-      "uuid": "e640d179-a3b3-4919-aa72-758330b56819",
+      "uuid": "5a712db6-dd5c-4bba-b1d7-c8575f3246fd",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1041,28 +1161,34 @@
       ]
     },
     {
-      "uuid": "903718e8-5eab-4ee0-83a1-7213e6631b60",
+      "uuid": "d741c4ce-6a04-4cee-8330-77e20da93154",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1093,28 +1219,34 @@
       ]
     },
     {
-      "uuid": "87288679-f89b-4cec-bddd-2d96fb505f36",
+      "uuid": "e982da4c-f57c-471a-b580-4e47120ce001",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1145,28 +1277,34 @@
       ]
     },
     {
-      "uuid": "b09c14f4-82d3-4698-94fd-126b1e4c85a0",
+      "uuid": "adb11c3a-f6d6-45b8-afa2-d664a25e43a4",
       "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
       "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_controller_use_service_account"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1197,28 +1335,34 @@
       ]
     },
     {
-      "uuid": "98d6bb17-506b-4f1f-96ea-6a093df3ddc6",
+      "uuid": "4ae66f31-e89f-4a80-b13a-0ccc01494e57",
       "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
       "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_controller_bind_address"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1249,28 +1393,34 @@
       ]
     },
     {
-      "uuid": "2079f900-57ef-4e33-a3d4-d8d28992b96a",
+      "uuid": "d9b3f89d-845a-400b-bb37-81cf80b64b9d",
       "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
       "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1301,28 +1451,34 @@
       ]
     },
     {
-      "uuid": "118c8bef-2719-4517-9c43-33d21d2caf61",
+      "uuid": "7d7c160b-ae63-43b9-805f-7d6c27f05bbd",
       "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
       "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_controller_service_account_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1353,28 +1509,34 @@
       ]
     },
     {
-      "uuid": "d3cad875-5462-4557-8872-bc877485a410",
+      "uuid": "866e7ca4-77ed-431f-a385-5315469447a6",
       "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
       "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1405,28 +1567,34 @@
       ]
     },
     {
-      "uuid": "c65ed99d-ded7-4867-abf3-28af733893d3",
+      "uuid": "808ecd11-a6e3-49e5-ab60-905759687f58",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1457,28 +1625,34 @@
       ]
     },
     {
-      "uuid": "63fe37dd-47dd-4006-a8f5-56113c0af8a3",
+      "uuid": "97c794e3-e7b4-40c3-af73-cffa0c08cf7d",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1509,28 +1683,34 @@
       ]
     },
     {
-      "uuid": "aac55b59-f9df-4406-987c-0f8df885870c",
+      "uuid": "84fb98ef-877c-45bf-bd3f-b0d312ebb062",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1561,28 +1741,34 @@
       ]
     },
     {
-      "uuid": "c57b31da-8f15-4109-8e58-03d73db34e38",
+      "uuid": "a6e25832-fba4-4b4b-9a33-14bf95f16f13",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1613,28 +1799,34 @@
       ]
     },
     {
-      "uuid": "96351f3f-38fc-4f18-bc74-518facb5fbeb",
+      "uuid": "def7b3ee-18e8-4b82-bd98-43bb5b93b701",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1665,28 +1857,34 @@
       ]
     },
     {
-      "uuid": "e7ea073f-c817-4812-8893-5be54fe62aa8",
+      "uuid": "4a595cda-5bea-4c85-9e7e-28d5689f85e8",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1717,28 +1915,34 @@
       ]
     },
     {
-      "uuid": "ad85d599-d985-4449-a695-27a0d7b1d2b1",
+      "uuid": "1732ba21-b4d5-4f9b-92c3-6a297f5ce0aa",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1769,28 +1973,34 @@
       ]
     },
     {
-      "uuid": "4ee9aa27-fd2c-4b92-8d79-f62ac01f25b7",
+      "uuid": "a753bfa7-7cc8-4d7a-9d8d-1be038744cf7",
       "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
       "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1821,28 +2031,34 @@
       ]
     },
     {
-      "uuid": "501d0999-7659-46d0-bdae-46ec2df214ba",
+      "uuid": "6f69550f-4ba0-45a0-a7dc-7637a36a2753",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1873,28 +2089,34 @@
       ]
     },
     {
-      "uuid": "307b41c7-91a5-4e8a-8326-066235d200ea",
+      "uuid": "51128c54-04a5-40c5-8acb-d0375edda59a",
       "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
       "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1925,28 +2147,34 @@
       ]
     },
     {
-      "uuid": "2b3b4509-a95c-4f86-b301-7bf2cb7c2836",
+      "uuid": "c713fa3d-0ba1-4d91-b1f5-d3fb55eb394f",
       "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
       "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -1977,28 +2205,34 @@
       ]
     },
     {
-      "uuid": "a576d7d6-4f4d-4670-804e-8900513166c5",
+      "uuid": "63b8e815-98b7-4467-89d7-323344d472fc",
       "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
       "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2029,28 +2263,34 @@
       ]
     },
     {
-      "uuid": "6895a8d4-fac3-436c-8f87-1347335ec71d",
+      "uuid": "422ce38c-25e2-407d-9b84-a9153000db66",
       "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
       "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2081,28 +2321,34 @@
       ]
     },
     {
-      "uuid": "81cf62a2-502f-4555-8ff7-337fcc0572b6",
+      "uuid": "49ecde80-87b7-4926-8a43-30d02b4040e7",
       "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
       "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2133,28 +2379,34 @@
       ]
     },
     {
-      "uuid": "6f8d452d-085d-47b4-bcca-eefbd7a6a05b",
+      "uuid": "a2ad87d1-1615-4d83-aefd-204677b8dfd6",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2185,28 +2437,34 @@
       ]
     },
     {
-      "uuid": "93f17b40-3b5f-4ae6-97ce-ac53df16495f",
+      "uuid": "66ca1224-0d8b-41c1-9409-f1bcd1bdae4a",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2237,28 +2495,34 @@
       ]
     },
     {
-      "uuid": "2b9062ca-ac2e-4377-a0e7-d3f8a4eef0de",
+      "uuid": "84ea8105-36ce-4488-ad4f-05b2ca732965",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2289,28 +2553,34 @@
       ]
     },
     {
-      "uuid": "b8eb3973-94fd-4ac6-9689-b5bb738a5f25",
+      "uuid": "cdea591b-2bc7-4274-8e96-f633c856d33d",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2341,28 +2611,34 @@
       ]
     },
     {
-      "uuid": "d55e4639-8cfc-4604-b7c0-3be02c2d5fd7",
+      "uuid": "1bd17213-3951-4006-8d49-a65b78c63460",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2393,28 +2669,34 @@
       ]
     },
     {
-      "uuid": "955eff8a-ef3c-4695-85fe-00ec59ea1e88",
+      "uuid": "2da774e9-0d55-44f3-82dc-78055e86e909",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2445,28 +2727,34 @@
       ]
     },
     {
-      "uuid": "ed1c96ae-3afc-4fdb-8550-f2fd5c22a63a",
+      "uuid": "4e3267f8-c4d8-4d38-b64e-e09e998b5a6b",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2497,28 +2785,34 @@
       ]
     },
     {
-      "uuid": "872954f7-d7db-42cd-9843-1de785f19cbf",
+      "uuid": "8ef70a71-8f29-48f8-83b9-66031cab19f7",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2549,28 +2843,34 @@
       ]
     },
     {
-      "uuid": "f1813093-1f49-45ff-bff4-f2817cbe2645",
+      "uuid": "75181f76-30d6-48a1-bce1-29fedd4d5ab5",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2601,28 +2901,34 @@
       ]
     },
     {
-      "uuid": "77f1011a-c675-4ef4-80d2-3a8b06d68e63",
+      "uuid": "8682700d-e9b3-401a-b2d3-79473162c0e6",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2653,28 +2959,34 @@
       ]
     },
     {
-      "uuid": "9d062e54-9e42-49d8-920b-4c28abcd95ed",
+      "uuid": "cf32216c-e6f3-4a5e-80c7-61c9578778c1",
       "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
       "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notselected"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2705,28 +3017,34 @@
       ]
     },
     {
-      "uuid": "36b81262-f5c3-419c-9afe-abab515a542c",
+      "uuid": "82d37590-ed26-4e5b-9fbd-ab20a43f7203",
       "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
       "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2757,28 +3075,34 @@
       ]
     },
     {
-      "uuid": "21923029-790f-4b93-9172-aa93d8d885e4",
+      "uuid": "946c8db2-1c8f-4047-a89e-b95e0e5620d5",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2809,28 +3133,34 @@
       ]
     },
     {
-      "uuid": "47c437d8-cf53-4fe1-b9f0-4e3490963508",
+      "uuid": "862f7167-c18d-4a17-995e-3abd18f02188",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2861,28 +3191,34 @@
       ]
     },
     {
-      "uuid": "7f525f98-eedc-4b60-bb4c-8c4fddb7e956",
+      "uuid": "ce68b074-16f9-4162-88e7-2a874ae9aa44",
       "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
       "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_unique_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2913,28 +3249,34 @@
       ]
     },
     {
-      "uuid": "16d64ba9-6b5c-4df4-8c1d-95565519be09",
+      "uuid": "7f32cc58-458d-4af4-a14b-39bdab35667b",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -2965,28 +3307,34 @@
       ]
     },
     {
-      "uuid": "85458bd2-fb51-4f30-9260-2b003a5822dc",
+      "uuid": "8f3d3a1d-87f5-4c7d-beaf-ae7b148b97ec",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3017,28 +3365,34 @@
       ]
     },
     {
-      "uuid": "3942504f-b6f2-4264-95a0-353b4219fded",
+      "uuid": "df05ec4f-bc47-45a6-9651-2ce8dc8a517b",
       "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_cert_file"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3069,28 +3423,34 @@
       ]
     },
     {
-      "uuid": "d7f6eea8-7c2c-4c27-93aa-6285ee7c0b3a",
+      "uuid": "0d9dd36a-6f80-4ea1-9864-0b18e026d321",
       "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
       "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_auto_tls"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3121,28 +3481,34 @@
       ]
     },
     {
-      "uuid": "cf1bf24f-d1b7-428d-b861-3da67e22ed5a",
+      "uuid": "ff6c18ed-bdc9-4cb2-b041-b8dd2abd37cc",
       "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_etcd_key_file"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3173,28 +3539,34 @@
       ]
     },
     {
-      "uuid": "1e34d866-b88e-486f-8c68-7feb85385b5c",
+      "uuid": "bafbf8fd-b914-42e3-902f-aee5fab45c48",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3225,28 +3597,34 @@
       ]
     },
     {
-      "uuid": "d21d8900-3c6c-400c-80e8-2e5c9cafd001",
+      "uuid": "6bf237aa-97a7-4e73-aad3-adee13edc4be",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3277,28 +3655,34 @@
       ]
     },
     {
-      "uuid": "c6b6bc56-4d0b-4165-9757-02cbb0b8db80",
+      "uuid": "d996ef7c-8744-4ea1-ab51-e56e7a73665f",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3329,28 +3713,34 @@
       ]
     },
     {
-      "uuid": "0c01e3a5-3cd5-48ed-8a1e-7bc164850ca8",
+      "uuid": "0f29cd3f-652d-40d6-90ca-247bfce709ac",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3381,28 +3771,34 @@
       ]
     },
     {
-      "uuid": "0b616c4e-4147-4a78-a842-e6461924c775",
+      "uuid": "8840fb57-1a8f-4d33-ac7a-d80f68c5f67e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3433,28 +3829,34 @@
       ]
     },
     {
-      "uuid": "fcca262e-398e-4686-848f-00aec55d76bb",
+      "uuid": "6d778f28-a6be-499c-802e-a0f45cf0fb8a",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3485,28 +3887,34 @@
       ]
     },
     {
-      "uuid": "9fe71e54-7f28-45b2-ab2c-0cd20598e3aa",
+      "uuid": "7104dec1-3e42-4ee0-b9f8-e5b4cf2f7e9d",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3537,28 +3945,34 @@
       ]
     },
     {
-      "uuid": "827f6527-1a22-497b-9b01-60309078ba6c",
+      "uuid": "482b0e31-d2ce-4942-a087-af596c1d761e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3589,28 +4003,34 @@
       ]
     },
     {
-      "uuid": "f6f67fe6-dc5f-4b0d-b2f2-f5e0e31db70d",
+      "uuid": "d7b6f184-cfda-4abe-a52b-e525025cadc7",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3641,28 +4061,34 @@
       ]
     },
     {
-      "uuid": "7fd6f59e-1d7d-4747-9abc-43b6baa25ae2",
+      "uuid": "32483424-87b2-4bf5-b353-406cd8751af1",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3693,28 +4119,34 @@
       ]
     },
     {
-      "uuid": "ae2593ee-6abc-4bb1-bb15-8851090ef459",
+      "uuid": "43dd361f-7dec-4a2a-a30d-239fe3e22416",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3745,28 +4177,34 @@
       ]
     },
     {
-      "uuid": "776f3744-d0e0-4012-ae4b-50755d0be8b1",
+      "uuid": "2c3b9717-75db-4da9-ac0a-fb61af500e18",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3797,28 +4235,34 @@
       ]
     },
     {
-      "uuid": "2b24e474-d47b-4dcb-8907-8eb0c45967c1",
+      "uuid": "c8c4f959-73d4-4c2d-aee2-dbf9eb322192",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3849,28 +4293,34 @@
       ]
     },
     {
-      "uuid": "996bf48d-1194-4086-8d2a-be391135555f",
+      "uuid": "9fb4db10-5413-46c6-b162-e0dd5339eabf",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3901,28 +4351,34 @@
       ]
     },
     {
-      "uuid": "2844804f-1a3a-44fa-ba52-3c1d0120bfbb",
+      "uuid": "8c6009ae-c342-422c-a5b8-2b1399366320",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -3953,28 +4409,34 @@
       ]
     },
     {
-      "uuid": "d2a8d96b-1d7d-4c61-833f-70fd9d5de977",
+      "uuid": "ae1e0bf3-96ec-4dad-8cd2-d92f0b9a8e76",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4005,28 +4467,34 @@
       ]
     },
     {
-      "uuid": "6ce4c179-6485-430c-9e42-e6ed7487c0c8",
+      "uuid": "b6bd4dc7-ae61-4e89-9337-5e7c2c15cb00",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4057,28 +4525,34 @@
       ]
     },
     {
-      "uuid": "7a4c2e97-f16b-4309-a4b6-b4fbe2b15d9e",
+      "uuid": "d7ddbecd-81c0-4d9d-aa8d-cf3a2fc9e309",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4109,28 +4583,34 @@
       ]
     },
     {
-      "uuid": "1ed9ca75-4dc9-43eb-84a3-bfacd7076f64",
+      "uuid": "3e9c0967-3585-4de0-8e6c-c907db03d3c7",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4161,28 +4641,34 @@
       ]
     },
     {
-      "uuid": "3c411b7c-3fd7-4e2b-9ebc-a056e100b0b9",
+      "uuid": "3f537ebf-28b5-4843-87ef-e95eb52e83db",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4213,28 +4699,34 @@
       ]
     },
     {
-      "uuid": "e77f56f7-ba55-41f3-ac46-52f2fa1994a8",
+      "uuid": "9a1c3106-ad9a-4f34-a95e-2f0a8d52e362",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4265,28 +4757,34 @@
       ]
     },
     {
-      "uuid": "29eb5dd3-7539-4051-98d9-823225fc6d75",
+      "uuid": "5687e158-f66d-444d-9bef-424ed0e6e5d5",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4317,28 +4815,34 @@
       ]
     },
     {
-      "uuid": "5454413c-6d21-4ca5-bb29-6891ef86a994",
+      "uuid": "451da959-043c-4bc2-9474-dcd67896ad90",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4369,28 +4873,34 @@
       ]
     },
     {
-      "uuid": "a53acce0-267d-4215-b5a5-aeda0651687b",
+      "uuid": "e3dd5a8c-226a-4974-a433-ddcce823a8ae",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4421,28 +4931,34 @@
       ]
     },
     {
-      "uuid": "6249a58c-d04c-467a-8f91-2bb52a95b731",
+      "uuid": "0189f915-a48f-4719-8742-0d11bfadd193",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4473,28 +4989,34 @@
       ]
     },
     {
-      "uuid": "2d568f83-3fdb-4b88-b278-eedfb913ef7e",
+      "uuid": "0c43347c-2070-425f-ba1e-eda23ab726a5",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4525,28 +5047,34 @@
       ]
     },
     {
-      "uuid": "68b1df23-20e4-4224-9523-3b5c7ad4250c",
+      "uuid": "f9480679-9ae5-43ae-9ff9-d62ad5d18c9c",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4577,28 +5105,34 @@
       ]
     },
     {
-      "uuid": "599ace34-af6a-4818-8a97-6a0ed111b188",
+      "uuid": "a37b9fca-3917-4814-a153-c6154476d781",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4629,28 +5163,34 @@
       ]
     },
     {
-      "uuid": "09c79a71-560e-41bd-a459-be695b2de5cc",
+      "uuid": "a0d3e6ab-9f9a-462f-9d30-28a2caed5d6a",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "notchecked"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4681,28 +5221,34 @@
       ]
     },
     {
-      "uuid": "72f79678-eb6f-4ebf-b1b1-096259f2edbb",
+      "uuid": "94206102-1e1b-4d6c-95fa-d5fb22b43c67",
       "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
       "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_port"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4733,28 +5279,34 @@
       ]
     },
     {
-      "uuid": "dc67f323-2094-4cf6-9214-e9cf0fa78ea9",
+      "uuid": "d623012c-b6d0-43d9-b563-bc13eecf580d",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4785,28 +5337,34 @@
       ]
     },
     {
-      "uuid": "af534a29-3467-4d11-b308-5db426e79e51",
+      "uuid": "49c02da5-bff6-4500-94dd-c840c8968559",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cert"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4837,28 +5395,34 @@
       ]
     },
     {
-      "uuid": "98606e09-34e8-4e76-b6db-54958375993f",
+      "uuid": "6a20a101-d157-4b72-adb5-334dbf79ad40",
       "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
       "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_client_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4889,28 +5453,34 @@
       ]
     },
     {
-      "uuid": "d1de959c-9a60-4eac-af8c-53747405a61e",
+      "uuid": "1994dc03-0849-471b-9249-6a33d5a41de0",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4941,28 +5511,34 @@
       ]
     },
     {
-      "uuid": "2e10f24f-cd69-4941-9882-e3a2fea117f6",
+      "uuid": "e9079ac8-7717-4024-824f-813c007ca61c",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -4993,28 +5569,34 @@
       ]
     },
     {
-      "uuid": "f7e28a0d-71e8-4f42-a75b-7836a33cea13",
+      "uuid": "c347d2ff-575f-43d3-9d86-73bfc48eaf60",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5045,28 +5627,34 @@
       ]
     },
     {
-      "uuid": "1bd802e2-ba1f-4fc5-8707-303e72d49a65",
+      "uuid": "e588752c-e26a-4abe-9e4c-b306a3de4157",
       "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
       "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5097,28 +5685,34 @@
       ]
     },
     {
-      "uuid": "7d155079-4e3a-4d36-aeb7-8dbcb70273ae",
+      "uuid": "46aaa85d-76a1-4b07-9a73-689f54b083e2",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5149,28 +5743,34 @@
       ]
     },
     {
-      "uuid": "0a1aed7f-3641-479d-9297-d3f84c7e54b4",
+      "uuid": "bc23c63e-394d-4119-acc4-e6725dead041",
       "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
       "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_profiling"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5201,28 +5801,34 @@
       ]
     },
     {
-      "uuid": "0c703130-fe2b-4742-91de-191a23bad793",
+      "uuid": "a0463a48-e8cf-4798-8cd5-3f6fa79a5af0",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5253,28 +5859,34 @@
       ]
     },
     {
-      "uuid": "c9fa4e31-e02f-42e1-b241-4e0cb7ef628f",
+      "uuid": "034d70fc-c34a-487b-aa3d-6b9d40159e72",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5305,28 +5917,34 @@
       ]
     },
     {
-      "uuid": "83c0fb5f-4bd4-4fd7-b474-525037325e95",
+      "uuid": "32eea07c-633f-483b-ac8f-bee306f70417",
       "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
       "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5357,28 +5975,34 @@
       ]
     },
     {
-      "uuid": "b43263b0-e891-42f6-8db9-53312b0b7611",
+      "uuid": "a4fdb15e-120b-4954-9770-008eee04139b",
       "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_token_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5409,28 +6033,34 @@
       ]
     },
     {
-      "uuid": "5fd50094-f127-4d33-9e48-0c3648239e3c",
+      "uuid": "ebe3101c-37e1-4143-a40c-7741282aa800",
       "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5461,28 +6091,34 @@
       ]
     },
     {
-      "uuid": "0f6ff793-def9-4c01-a86d-20ca8bbc6b83",
+      "uuid": "ebf6f544-1aae-4b5c-baf3-0f7ab33bebb7",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5513,28 +6149,34 @@
       ]
     },
     {
-      "uuid": "6587441e-c58f-40d1-ac7a-787054f80e04",
+      "uuid": "a3a1b77d-d87e-4b38-829a-c69437a50767",
       "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
       "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5565,28 +6207,34 @@
       ]
     },
     {
-      "uuid": "f139f7d6-7b4a-4192-a0e0-47423652672c",
+      "uuid": "11bf7227-b462-45a1-a145-ed880c429990",
       "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
       "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_request_timeout"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5617,28 +6265,34 @@
       ]
     },
     {
-      "uuid": "f5d1cec9-fadf-4227-ae0b-92c19280bb7a",
+      "uuid": "8eca6a48-2477-4700-a23f-b6349dbd288b",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5669,28 +6323,34 @@
       ]
     },
     {
-      "uuid": "4342c216-254b-4e54-b33c-289f7b6add59",
+      "uuid": "e5b6cc7a-d0f0-4cf1-9e6f-85ca92be31d0",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5721,28 +6381,34 @@
       ]
     },
     {
-      "uuid": "235498da-4c92-447f-a582-0edeac10a47c",
+      "uuid": "ebed7ae5-37a0-467b-a46e-b96fcccf2c7b",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5773,28 +6439,34 @@
       ]
     },
     {
-      "uuid": "4e02469c-d51b-4bb3-8d2c-f2e890422b98",
+      "uuid": "7711ec12-19e1-4e28-aa39-66c685415cae",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5825,28 +6497,34 @@
       ]
     },
     {
-      "uuid": "1e48f6f0-6c58-4166-95c9-5680befbd596",
+      "uuid": "47916d5d-6c19-4d2d-98d9-ecc89d86efa7",
       "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_basic_auth"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5877,28 +6555,34 @@
       ]
     },
     {
-      "uuid": "192cf6b5-0c39-481d-b29a-d1264951ec90",
+      "uuid": "18995710-14c4-45b8-9f7a-ee7fb98f00c2",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5929,28 +6613,34 @@
       ]
     },
     {
-      "uuid": "d9370724-4f86-4e2b-b7f8-6622e6b1d359",
+      "uuid": "64c63dcb-5593-4e7c-b702-91b0aea44bb3",
       "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -5981,28 +6671,34 @@
       ]
     },
     {
-      "uuid": "7bd48205-5fad-4059-b3c2-b20773b3f99f",
+      "uuid": "c52fbbc6-56a0-4064-a986-7bcf0216c3ee",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_key"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6033,28 +6729,34 @@
       ]
     },
     {
-      "uuid": "29115ddc-9d96-4b01-a5f2-447ea5964581",
+      "uuid": "79696a81-1e89-4093-9e0b-5f8b70091a94",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6085,28 +6787,34 @@
       ]
     },
     {
-      "uuid": "f5829867-4a52-4742-9971-3f7220ca98ce",
+      "uuid": "d0d359a5-c024-446b-8539-c9ae80cc90c5",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6137,28 +6845,34 @@
       ]
     },
     {
-      "uuid": "b557e473-2d69-4f7d-a372-fd44e62a2477",
+      "uuid": "97d7022e-ee0d-43ab-b231-5e64bb495379",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6189,28 +6903,34 @@
       ]
     },
     {
-      "uuid": "7eed8b96-96f3-472b-b8b4-8965066ce60c",
+      "uuid": "4a75bd7d-caf0-4130-9a62-3d6e5b169e1f",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6241,28 +6961,34 @@
       ]
     },
     {
-      "uuid": "8f322ef9-74d9-46b2-9176-6cc09e482475",
+      "uuid": "7c215c64-9639-44a2-b6eb-d8d89fb20941",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6293,28 +7019,34 @@
       ]
     },
     {
-      "uuid": "517a3ad3-1584-4f66-88b5-9649d6513ee6",
+      "uuid": "77627382-c004-46a1-9264-254c5f4e394e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
       "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "pass"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6345,28 +7077,34 @@
       ]
     },
     {
-      "uuid": "d5f79be0-8fff-4feb-8c47-df2f6bb5607c",
+      "uuid": "d26d8622-1f97-4a0e-9563-97c9cfe4059b",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6397,28 +7135,34 @@
       ]
     },
     {
-      "uuid": "b956e48c-a541-45f3-b4ef-23453407a239",
+      "uuid": "6fd4dda1-1e28-4ee9-8eb6-5651ca5068d0",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
@@ -6449,28 +7193,34 @@
       ]
     },
     {
-      "uuid": "124491ef-2617-47bc-b6ae-15669f35cf20",
+      "uuid": "4f859376-279f-4799-8d47-87b857698492",
       "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
       "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
       "evidence-group": [
         {
+          "description": "Evidence location.",
+          "href": "https://github.ibm.com/degenaro/evidence-locker",
           "properties": [
             {
+              "ns": "xccdf",
               "class": "id",
               "name": "rule",
               "value": "xccdf_org.ssgproject.content_rule_api_server_secure_port"
             },
             {
+              "ns": "xccdf",
               "class": "timestamp",
               "name": "time",
               "value": "2020-08-03T02:26:26+00:00"
             },
             {
+              "ns": "xccdf",
               "class": "result",
               "name": "result",
               "value": "fail"
             },
             {
+              "ns": "xccdf",
               "class": "target",
               "name": "target",
               "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"

--- a/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
+++ b/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
@@ -1,0 +1,6504 @@
+{
+  "observations": [
+    {
+      "uuid": "8b3af6c1-bbbc-4ff7-8db8-0674b2129056",
+      "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+      "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notselected"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7cc59e9a-43d4-4560-8e40-5ad48703ad08",
+      "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+      "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "fe3a4232-1318-4fbe-aceb-900736c519b1",
+      "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+      "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "5608acd0-5f6d-4a0e-a48b-164615680df3",
+      "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+      "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_configure_network_policies"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "e3826f74-8227-4cd7-8f1e-b1fd14d2352f",
+      "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+      "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "9a3ef3e3-a65a-48e4-93ba-5399f5226438",
+      "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+      "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "5ceb2c35-47fe-405f-8951-0d453410b97f",
+      "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+      "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "30930ed6-8578-471a-aa00-accb130ec1bd",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "a2156080-a165-4d8b-a049-e7a783adfb64",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d22487d1-edd2-40be-8d15-2c5021b5b199",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2413a183-bb6b-4188-b63b-3ac61f1c2057",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0be8144f-e4d2-4493-a300-74e7eb301f64",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_service"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "3cf63848-04ee-4878-8863-7f11f0f2696b",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "57a6a7cd-18e3-4f13-8059-42926c23f62c",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "16fd9568-bef1-41d9-900a-ba73f876440c",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "539a6060-379f-4dba-b60a-3fb667133a21",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "00cd72ef-55bd-4d24-a825-68ffacbc146f",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "060e4a7a-ae97-489b-ad52-60c5d4e0a3b4",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "939169e2-c2fd-421d-b4fb-5753a134fef5",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "e640d179-a3b3-4919-aa72-758330b56819",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "903718e8-5eab-4ee0-83a1-7213e6631b60",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "87288679-f89b-4cec-bddd-2d96fb505f36",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "b09c14f4-82d3-4698-94fd-126b1e4c85a0",
+      "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+      "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_controller_use_service_account"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "98d6bb17-506b-4f1f-96ea-6a093df3ddc6",
+      "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+      "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_controller_bind_address"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2079f900-57ef-4e33-a3d4-d8d28992b96a",
+      "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+      "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "118c8bef-2719-4517-9c43-33d21d2caf61",
+      "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+      "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_controller_service_account_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d3cad875-5462-4557-8872-bc877485a410",
+      "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+      "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "c65ed99d-ded7-4867-abf3-28af733893d3",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "63fe37dd-47dd-4006-a8f5-56113c0af8a3",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "aac55b59-f9df-4406-987c-0f8df885870c",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "c57b31da-8f15-4109-8e58-03d73db34e38",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "96351f3f-38fc-4f18-bc74-518facb5fbeb",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "e7ea073f-c817-4812-8893-5be54fe62aa8",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "ad85d599-d985-4449-a695-27a0d7b1d2b1",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "4ee9aa27-fd2c-4b92-8d79-f62ac01f25b7",
+      "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+      "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "501d0999-7659-46d0-bdae-46ec2df214ba",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "307b41c7-91a5-4e8a-8326-066235d200ea",
+      "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+      "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2b3b4509-a95c-4f86-b301-7bf2cb7c2836",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "a576d7d6-4f4d-4670-804e-8900513166c5",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "6895a8d4-fac3-436c-8f87-1347335ec71d",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "81cf62a2-502f-4555-8ff7-337fcc0572b6",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "6f8d452d-085d-47b4-bcca-eefbd7a6a05b",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "93f17b40-3b5f-4ae6-97ce-ac53df16495f",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2b9062ca-ac2e-4377-a0e7-d3f8a4eef0de",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "b8eb3973-94fd-4ac6-9689-b5bb738a5f25",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d55e4639-8cfc-4604-b7c0-3be02c2d5fd7",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "955eff8a-ef3c-4695-85fe-00ec59ea1e88",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "ed1c96ae-3afc-4fdb-8550-f2fd5c22a63a",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "872954f7-d7db-42cd-9843-1de785f19cbf",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f1813093-1f49-45ff-bff4-f2817cbe2645",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "77f1011a-c675-4ef4-80d2-3a8b06d68e63",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "9d062e54-9e42-49d8-920b-4c28abcd95ed",
+      "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+      "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notselected"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "36b81262-f5c3-419c-9afe-abab515a542c",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "21923029-790f-4b93-9172-aa93d8d885e4",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "47c437d8-cf53-4fe1-b9f0-4e3490963508",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7f525f98-eedc-4b60-bb4c-8c4fddb7e956",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_unique_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "16d64ba9-6b5c-4df4-8c1d-95565519be09",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "85458bd2-fb51-4f30-9260-2b003a5822dc",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "3942504f-b6f2-4264-95a0-353b4219fded",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_cert_file"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d7f6eea8-7c2c-4c27-93aa-6285ee7c0b3a",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_auto_tls"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "cf1bf24f-d1b7-428d-b861-3da67e22ed5a",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_key_file"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "1e34d866-b88e-486f-8c68-7feb85385b5c",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d21d8900-3c6c-400c-80e8-2e5c9cafd001",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "c6b6bc56-4d0b-4165-9757-02cbb0b8db80",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0c01e3a5-3cd5-48ed-8a1e-7bc164850ca8",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0b616c4e-4147-4a78-a842-e6461924c775",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "fcca262e-398e-4686-848f-00aec55d76bb",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "9fe71e54-7f28-45b2-ab2c-0cd20598e3aa",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "827f6527-1a22-497b-9b01-60309078ba6c",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f6f67fe6-dc5f-4b0d-b2f2-f5e0e31db70d",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7fd6f59e-1d7d-4747-9abc-43b6baa25ae2",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "ae2593ee-6abc-4bb1-bb15-8851090ef459",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "776f3744-d0e0-4012-ae4b-50755d0be8b1",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2b24e474-d47b-4dcb-8907-8eb0c45967c1",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "996bf48d-1194-4086-8d2a-be391135555f",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2844804f-1a3a-44fa-ba52-3c1d0120bfbb",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d2a8d96b-1d7d-4c61-833f-70fd9d5de977",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "6ce4c179-6485-430c-9e42-e6ed7487c0c8",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7a4c2e97-f16b-4309-a4b6-b4fbe2b15d9e",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "1ed9ca75-4dc9-43eb-84a3-bfacd7076f64",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "3c411b7c-3fd7-4e2b-9ebc-a056e100b0b9",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "e77f56f7-ba55-41f3-ac46-52f2fa1994a8",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "29eb5dd3-7539-4051-98d9-823225fc6d75",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "5454413c-6d21-4ca5-bb29-6891ef86a994",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "a53acce0-267d-4215-b5a5-aeda0651687b",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "6249a58c-d04c-467a-8f91-2bb52a95b731",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2d568f83-3fdb-4b88-b278-eedfb913ef7e",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "68b1df23-20e4-4224-9523-3b5c7ad4250c",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "599ace34-af6a-4818-8a97-6a0ed111b188",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "09c79a71-560e-41bd-a459-be695b2de5cc",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "notchecked"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "72f79678-eb6f-4ebf-b1b1-096259f2edbb",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_port"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "dc67f323-2094-4cf6-9214-e9cf0fa78ea9",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "af534a29-3467-4d11-b308-5db426e79e51",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cert"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "98606e09-34e8-4e76-b6db-54958375993f",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_client_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d1de959c-9a60-4eac-af8c-53747405a61e",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "2e10f24f-cd69-4941-9882-e3a2fea117f6",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f7e28a0d-71e8-4f42-a75b-7836a33cea13",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "1bd802e2-ba1f-4fc5-8707-303e72d49a65",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7d155079-4e3a-4d36-aeb7-8dbcb70273ae",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0a1aed7f-3641-479d-9297-d3f84c7e54b4",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_profiling"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0c703130-fe2b-4742-91de-191a23bad793",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "c9fa4e31-e02f-42e1-b241-4e0cb7ef628f",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "83c0fb5f-4bd4-4fd7-b474-525037325e95",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "b43263b0-e891-42f6-8db9-53312b0b7611",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_token_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "5fd50094-f127-4d33-9e48-0c3648239e3c",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "0f6ff793-def9-4c01-a86d-20ca8bbc6b83",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "6587441e-c58f-40d1-ac7a-787054f80e04",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f139f7d6-7b4a-4192-a0e0-47423652672c",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_request_timeout"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f5d1cec9-fadf-4227-ae0b-92c19280bb7a",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "4342c216-254b-4e54-b33c-289f7b6add59",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "235498da-4c92-447f-a582-0edeac10a47c",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "4e02469c-d51b-4bb3-8d2c-f2e890422b98",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "1e48f6f0-6c58-4166-95c9-5680befbd596",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_basic_auth"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "192cf6b5-0c39-481d-b29a-d1264951ec90",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d9370724-4f86-4e2b-b7f8-6622e6b1d359",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7bd48205-5fad-4059-b3c2-b20773b3f99f",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_key"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "29115ddc-9d96-4b01-a5f2-447ea5964581",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "f5829867-4a52-4742-9971-3f7220ca98ce",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "b557e473-2d69-4f7d-a372-fd44e62a2477",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "7eed8b96-96f3-472b-b8b4-8965066ce60c",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "8f322ef9-74d9-46b2-9176-6cc09e482475",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "517a3ad3-1584-4f66-88b5-9649d6513ee6",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "pass"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "d5f79be0-8fff-4feb-8c47-df2f6bb5607c",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "b956e48c-a541-45f3-b4ef-23453407a239",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    },
+    {
+      "uuid": "124491ef-2617-47bc-b6ae-15669f35cf20",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+      "evidence-group": [
+        {
+          "properties": [
+            {
+              "class": "id",
+              "name": "rule",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_secure_port"
+            },
+            {
+              "class": "timestamp",
+              "name": "time",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "class": "result",
+              "name": "result",
+              "value": "fail"
+            },
+            {
+              "class": "target",
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm"
+            }
+          ]
+        }
+      ],
+      "subject-references": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "properties": {
+            "target": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm",
+            "cluster-name": "ROKS-OpenSCAP-1",
+            "cluster-type": "openshift",
+            "cluster-region": "us-south"
+          }
+        }
+      ],
+      "observation-methods": [
+        "TEST-AUTOMATED"
+      ]
+    }
+  ]
+}

--- a/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
+++ b/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-10.221.139.104-pod.oscal
@@ -1,7 +1,7 @@
 {
   "observations": [
     {
-      "uuid": "1770a4c2-3701-4a9b-9511-fc6e115fdea5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
       "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
       "evidence-group": [
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "uuid": "c7585d84-bce9-440a-ad8d-d4183932a79e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
       "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
       "evidence-group": [
@@ -117,7 +117,7 @@
       ]
     },
     {
-      "uuid": "e08e5ae9-c02f-46e9-bb0f-cde6a5c85293",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
       "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
       "evidence-group": [
@@ -175,7 +175,7 @@
       ]
     },
     {
-      "uuid": "a22d637e-2e77-4858-af4a-b0037cb3d11a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
       "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
       "evidence-group": [
@@ -233,7 +233,7 @@
       ]
     },
     {
-      "uuid": "e6660bde-858f-4870-b9be-4e7b25828cae",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
       "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
       "evidence-group": [
@@ -291,7 +291,7 @@
       ]
     },
     {
-      "uuid": "d74f0a9c-df35-4a22-8c2c-c5c743985a4f",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
       "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
       "evidence-group": [
@@ -349,7 +349,7 @@
       ]
     },
     {
-      "uuid": "710462d9-6e4d-4deb-b739-de722c2aa88a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
       "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
       "evidence-group": [
@@ -407,7 +407,7 @@
       ]
     },
     {
-      "uuid": "4117b319-f699-446b-8468-8276874ae63e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
       "evidence-group": [
@@ -465,7 +465,7 @@
       ]
     },
     {
-      "uuid": "7188fa89-6845-4193-ba8d-b90de14028bd",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
       "evidence-group": [
@@ -523,7 +523,7 @@
       ]
     },
     {
-      "uuid": "068c0230-9260-45cf-89b9-1f0e46845ae2",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
       "evidence-group": [
@@ -581,7 +581,7 @@
       ]
     },
     {
-      "uuid": "fa43874c-c9db-4f46-b145-03bed8153f53",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
       "evidence-group": [
@@ -639,7 +639,7 @@
       ]
     },
     {
-      "uuid": "387061c0-f8fc-4261-82af-812a0679d65a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
       "evidence-group": [
@@ -697,7 +697,7 @@
       ]
     },
     {
-      "uuid": "07469975-a6bc-4035-8f1c-3b434becde52",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
       "evidence-group": [
@@ -755,7 +755,7 @@
       ]
     },
     {
-      "uuid": "c800da88-c928-4d8d-a536-05e8a88917f4",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
       "evidence-group": [
@@ -813,7 +813,7 @@
       ]
     },
     {
-      "uuid": "15781498-feb8-496d-820a-f501abbffa47",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
       "evidence-group": [
@@ -871,7 +871,7 @@
       ]
     },
     {
-      "uuid": "c63182da-a73f-4721-8a44-c886bf75b63e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
       "evidence-group": [
@@ -929,7 +929,7 @@
       ]
     },
     {
-      "uuid": "93e22975-f445-4cab-b15d-ad5e930a35aa",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
       "evidence-group": [
@@ -987,7 +987,7 @@
       ]
     },
     {
-      "uuid": "a1d6c563-38e0-49dc-8a1b-cf991c348f99",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
       "evidence-group": [
@@ -1045,7 +1045,7 @@
       ]
     },
     {
-      "uuid": "be6184a6-1811-4a9d-8a24-ed35ed2ada49",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
       "evidence-group": [
@@ -1103,7 +1103,7 @@
       ]
     },
     {
-      "uuid": "5a712db6-dd5c-4bba-b1d7-c8575f3246fd",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
       "evidence-group": [
@@ -1161,7 +1161,7 @@
       ]
     },
     {
-      "uuid": "d741c4ce-6a04-4cee-8330-77e20da93154",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
       "evidence-group": [
@@ -1219,7 +1219,7 @@
       ]
     },
     {
-      "uuid": "e982da4c-f57c-471a-b580-4e47120ce001",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
       "evidence-group": [
@@ -1277,7 +1277,7 @@
       ]
     },
     {
-      "uuid": "adb11c3a-f6d6-45b8-afa2-d664a25e43a4",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
       "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
       "evidence-group": [
@@ -1335,7 +1335,7 @@
       ]
     },
     {
-      "uuid": "4ae66f31-e89f-4a80-b13a-0ccc01494e57",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
       "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
       "evidence-group": [
@@ -1393,7 +1393,7 @@
       ]
     },
     {
-      "uuid": "d9b3f89d-845a-400b-bb37-81cf80b64b9d",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
       "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
       "evidence-group": [
@@ -1451,7 +1451,7 @@
       ]
     },
     {
-      "uuid": "7d7c160b-ae63-43b9-805f-7d6c27f05bbd",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
       "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
       "evidence-group": [
@@ -1509,7 +1509,7 @@
       ]
     },
     {
-      "uuid": "866e7ca4-77ed-431f-a385-5315469447a6",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
       "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
       "evidence-group": [
@@ -1567,7 +1567,7 @@
       ]
     },
     {
-      "uuid": "808ecd11-a6e3-49e5-ab60-905759687f58",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
       "evidence-group": [
@@ -1625,7 +1625,7 @@
       ]
     },
     {
-      "uuid": "97c794e3-e7b4-40c3-af73-cffa0c08cf7d",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
       "evidence-group": [
@@ -1683,7 +1683,7 @@
       ]
     },
     {
-      "uuid": "84fb98ef-877c-45bf-bd3f-b0d312ebb062",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
       "evidence-group": [
@@ -1741,7 +1741,7 @@
       ]
     },
     {
-      "uuid": "a6e25832-fba4-4b4b-9a33-14bf95f16f13",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
       "evidence-group": [
@@ -1799,7 +1799,7 @@
       ]
     },
     {
-      "uuid": "def7b3ee-18e8-4b82-bd98-43bb5b93b701",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
       "evidence-group": [
@@ -1857,7 +1857,7 @@
       ]
     },
     {
-      "uuid": "4a595cda-5bea-4c85-9e7e-28d5689f85e8",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
       "evidence-group": [
@@ -1915,7 +1915,7 @@
       ]
     },
     {
-      "uuid": "1732ba21-b4d5-4f9b-92c3-6a297f5ce0aa",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
       "evidence-group": [
@@ -1973,7 +1973,7 @@
       ]
     },
     {
-      "uuid": "a753bfa7-7cc8-4d7a-9d8d-1be038744cf7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
       "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
       "evidence-group": [
@@ -2031,7 +2031,7 @@
       ]
     },
     {
-      "uuid": "6f69550f-4ba0-45a0-a7dc-7637a36a2753",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
       "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
       "evidence-group": [
@@ -2089,7 +2089,7 @@
       ]
     },
     {
-      "uuid": "51128c54-04a5-40c5-8acb-d0375edda59a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
       "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
       "evidence-group": [
@@ -2147,7 +2147,7 @@
       ]
     },
     {
-      "uuid": "c713fa3d-0ba1-4d91-b1f5-d3fb55eb394f",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
       "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
       "evidence-group": [
@@ -2205,7 +2205,7 @@
       ]
     },
     {
-      "uuid": "63b8e815-98b7-4467-89d7-323344d472fc",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
       "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
       "evidence-group": [
@@ -2263,7 +2263,7 @@
       ]
     },
     {
-      "uuid": "422ce38c-25e2-407d-9b84-a9153000db66",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
       "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
       "evidence-group": [
@@ -2321,7 +2321,7 @@
       ]
     },
     {
-      "uuid": "49ecde80-87b7-4926-8a43-30d02b4040e7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
       "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
       "evidence-group": [
@@ -2379,7 +2379,7 @@
       ]
     },
     {
-      "uuid": "a2ad87d1-1615-4d83-aefd-204677b8dfd6",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
       "evidence-group": [
@@ -2437,7 +2437,7 @@
       ]
     },
     {
-      "uuid": "66ca1224-0d8b-41c1-9409-f1bcd1bdae4a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
       "evidence-group": [
@@ -2495,7 +2495,7 @@
       ]
     },
     {
-      "uuid": "84ea8105-36ce-4488-ad4f-05b2ca732965",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
       "evidence-group": [
@@ -2553,7 +2553,7 @@
       ]
     },
     {
-      "uuid": "cdea591b-2bc7-4274-8e96-f633c856d33d",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
       "evidence-group": [
@@ -2611,7 +2611,7 @@
       ]
     },
     {
-      "uuid": "1bd17213-3951-4006-8d49-a65b78c63460",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
       "evidence-group": [
@@ -2669,7 +2669,7 @@
       ]
     },
     {
-      "uuid": "2da774e9-0d55-44f3-82dc-78055e86e909",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
       "evidence-group": [
@@ -2727,7 +2727,7 @@
       ]
     },
     {
-      "uuid": "4e3267f8-c4d8-4d38-b64e-e09e998b5a6b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
       "evidence-group": [
@@ -2785,7 +2785,7 @@
       ]
     },
     {
-      "uuid": "8ef70a71-8f29-48f8-83b9-66031cab19f7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
       "evidence-group": [
@@ -2843,7 +2843,7 @@
       ]
     },
     {
-      "uuid": "75181f76-30d6-48a1-bce1-29fedd4d5ab5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
       "evidence-group": [
@@ -2901,7 +2901,7 @@
       ]
     },
     {
-      "uuid": "8682700d-e9b3-401a-b2d3-79473162c0e6",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
       "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
       "evidence-group": [
@@ -2959,7 +2959,7 @@
       ]
     },
     {
-      "uuid": "cf32216c-e6f3-4a5e-80c7-61c9578778c1",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
       "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
       "evidence-group": [
@@ -3017,7 +3017,7 @@
       ]
     },
     {
-      "uuid": "82d37590-ed26-4e5b-9fbd-ab20a43f7203",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
       "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
       "evidence-group": [
@@ -3075,7 +3075,7 @@
       ]
     },
     {
-      "uuid": "946c8db2-1c8f-4047-a89e-b95e0e5620d5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
       "evidence-group": [
@@ -3133,7 +3133,7 @@
       ]
     },
     {
-      "uuid": "862f7167-c18d-4a17-995e-3abd18f02188",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
       "evidence-group": [
@@ -3191,7 +3191,7 @@
       ]
     },
     {
-      "uuid": "ce68b074-16f9-4162-88e7-2a874ae9aa44",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
       "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
       "evidence-group": [
@@ -3249,7 +3249,7 @@
       ]
     },
     {
-      "uuid": "7f32cc58-458d-4af4-a14b-39bdab35667b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
       "evidence-group": [
@@ -3307,7 +3307,7 @@
       ]
     },
     {
-      "uuid": "8f3d3a1d-87f5-4c7d-beaf-ae7b148b97ec",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
       "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
       "evidence-group": [
@@ -3365,7 +3365,7 @@
       ]
     },
     {
-      "uuid": "df05ec4f-bc47-45a6-9651-2ce8dc8a517b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
       "evidence-group": [
@@ -3423,7 +3423,7 @@
       ]
     },
     {
-      "uuid": "0d9dd36a-6f80-4ea1-9864-0b18e026d321",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
       "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
       "evidence-group": [
@@ -3481,7 +3481,7 @@
       ]
     },
     {
-      "uuid": "ff6c18ed-bdc9-4cb2-b041-b8dd2abd37cc",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
       "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
       "evidence-group": [
@@ -3539,7 +3539,7 @@
       ]
     },
     {
-      "uuid": "bafbf8fd-b914-42e3-902f-aee5fab45c48",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
       "evidence-group": [
@@ -3597,7 +3597,7 @@
       ]
     },
     {
-      "uuid": "6bf237aa-97a7-4e73-aad3-adee13edc4be",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
       "evidence-group": [
@@ -3655,7 +3655,7 @@
       ]
     },
     {
-      "uuid": "d996ef7c-8744-4ea1-ab51-e56e7a73665f",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
       "evidence-group": [
@@ -3713,7 +3713,7 @@
       ]
     },
     {
-      "uuid": "0f29cd3f-652d-40d6-90ca-247bfce709ac",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
       "evidence-group": [
@@ -3771,7 +3771,7 @@
       ]
     },
     {
-      "uuid": "8840fb57-1a8f-4d33-ac7a-d80f68c5f67e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
       "evidence-group": [
@@ -3829,7 +3829,7 @@
       ]
     },
     {
-      "uuid": "6d778f28-a6be-499c-802e-a0f45cf0fb8a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
       "evidence-group": [
@@ -3887,7 +3887,7 @@
       ]
     },
     {
-      "uuid": "7104dec1-3e42-4ee0-b9f8-e5b4cf2f7e9d",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
       "evidence-group": [
@@ -3945,7 +3945,7 @@
       ]
     },
     {
-      "uuid": "482b0e31-d2ce-4942-a087-af596c1d761e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
       "evidence-group": [
@@ -4003,7 +4003,7 @@
       ]
     },
     {
-      "uuid": "d7b6f184-cfda-4abe-a52b-e525025cadc7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
       "evidence-group": [
@@ -4061,7 +4061,7 @@
       ]
     },
     {
-      "uuid": "32483424-87b2-4bf5-b353-406cd8751af1",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
       "evidence-group": [
@@ -4119,7 +4119,7 @@
       ]
     },
     {
-      "uuid": "43dd361f-7dec-4a2a-a30d-239fe3e22416",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
       "evidence-group": [
@@ -4177,7 +4177,7 @@
       ]
     },
     {
-      "uuid": "2c3b9717-75db-4da9-ac0a-fb61af500e18",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
       "evidence-group": [
@@ -4235,7 +4235,7 @@
       ]
     },
     {
-      "uuid": "c8c4f959-73d4-4c2d-aee2-dbf9eb322192",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
       "evidence-group": [
@@ -4293,7 +4293,7 @@
       ]
     },
     {
-      "uuid": "9fb4db10-5413-46c6-b162-e0dd5339eabf",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
       "evidence-group": [
@@ -4351,7 +4351,7 @@
       ]
     },
     {
-      "uuid": "8c6009ae-c342-422c-a5b8-2b1399366320",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
       "evidence-group": [
@@ -4409,7 +4409,7 @@
       ]
     },
     {
-      "uuid": "ae1e0bf3-96ec-4dad-8cd2-d92f0b9a8e76",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
       "evidence-group": [
@@ -4467,7 +4467,7 @@
       ]
     },
     {
-      "uuid": "b6bd4dc7-ae61-4e89-9337-5e7c2c15cb00",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
       "evidence-group": [
@@ -4525,7 +4525,7 @@
       ]
     },
     {
-      "uuid": "d7ddbecd-81c0-4d9d-aa8d-cf3a2fc9e309",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
       "evidence-group": [
@@ -4583,7 +4583,7 @@
       ]
     },
     {
-      "uuid": "3e9c0967-3585-4de0-8e6c-c907db03d3c7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
       "evidence-group": [
@@ -4641,7 +4641,7 @@
       ]
     },
     {
-      "uuid": "3f537ebf-28b5-4843-87ef-e95eb52e83db",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
       "evidence-group": [
@@ -4699,7 +4699,7 @@
       ]
     },
     {
-      "uuid": "9a1c3106-ad9a-4f34-a95e-2f0a8d52e362",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
       "evidence-group": [
@@ -4757,7 +4757,7 @@
       ]
     },
     {
-      "uuid": "5687e158-f66d-444d-9bef-424ed0e6e5d5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
       "evidence-group": [
@@ -4815,7 +4815,7 @@
       ]
     },
     {
-      "uuid": "451da959-043c-4bc2-9474-dcd67896ad90",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
       "evidence-group": [
@@ -4873,7 +4873,7 @@
       ]
     },
     {
-      "uuid": "e3dd5a8c-226a-4974-a433-ddcce823a8ae",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
       "evidence-group": [
@@ -4931,7 +4931,7 @@
       ]
     },
     {
-      "uuid": "0189f915-a48f-4719-8742-0d11bfadd193",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
       "evidence-group": [
@@ -4989,7 +4989,7 @@
       ]
     },
     {
-      "uuid": "0c43347c-2070-425f-ba1e-eda23ab726a5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
       "evidence-group": [
@@ -5047,7 +5047,7 @@
       ]
     },
     {
-      "uuid": "f9480679-9ae5-43ae-9ff9-d62ad5d18c9c",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
       "evidence-group": [
@@ -5105,7 +5105,7 @@
       ]
     },
     {
-      "uuid": "a37b9fca-3917-4814-a153-c6154476d781",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
       "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
       "evidence-group": [
@@ -5163,7 +5163,7 @@
       ]
     },
     {
-      "uuid": "a0d3e6ab-9f9a-462f-9d30-28a2caed5d6a",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
       "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
       "evidence-group": [
@@ -5221,7 +5221,7 @@
       ]
     },
     {
-      "uuid": "94206102-1e1b-4d6c-95fa-d5fb22b43c67",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
       "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
       "evidence-group": [
@@ -5279,7 +5279,7 @@
       ]
     },
     {
-      "uuid": "d623012c-b6d0-43d9-b563-bc13eecf580d",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
       "evidence-group": [
@@ -5337,7 +5337,7 @@
       ]
     },
     {
-      "uuid": "49c02da5-bff6-4500-94dd-c840c8968559",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
       "evidence-group": [
@@ -5395,7 +5395,7 @@
       ]
     },
     {
-      "uuid": "6a20a101-d157-4b72-adb5-334dbf79ad40",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
       "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
       "evidence-group": [
@@ -5453,7 +5453,7 @@
       ]
     },
     {
-      "uuid": "1994dc03-0849-471b-9249-6a33d5a41de0",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
       "evidence-group": [
@@ -5511,7 +5511,7 @@
       ]
     },
     {
-      "uuid": "e9079ac8-7717-4024-824f-813c007ca61c",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
       "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
       "evidence-group": [
@@ -5569,7 +5569,7 @@
       ]
     },
     {
-      "uuid": "c347d2ff-575f-43d3-9d86-73bfc48eaf60",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
       "evidence-group": [
@@ -5627,7 +5627,7 @@
       ]
     },
     {
-      "uuid": "e588752c-e26a-4abe-9e4c-b306a3de4157",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
       "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
       "evidence-group": [
@@ -5685,7 +5685,7 @@
       ]
     },
     {
-      "uuid": "46aaa85d-76a1-4b07-9a73-689f54b083e2",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
       "evidence-group": [
@@ -5743,7 +5743,7 @@
       ]
     },
     {
-      "uuid": "bc23c63e-394d-4119-acc4-e6725dead041",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
       "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
       "evidence-group": [
@@ -5801,7 +5801,7 @@
       ]
     },
     {
-      "uuid": "a0463a48-e8cf-4798-8cd5-3f6fa79a5af0",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
       "evidence-group": [
@@ -5859,7 +5859,7 @@
       ]
     },
     {
-      "uuid": "034d70fc-c34a-487b-aa3d-6b9d40159e72",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
       "evidence-group": [
@@ -5917,7 +5917,7 @@
       ]
     },
     {
-      "uuid": "32eea07c-633f-483b-ac8f-bee306f70417",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
       "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
       "evidence-group": [
@@ -5975,7 +5975,7 @@
       ]
     },
     {
-      "uuid": "a4fdb15e-120b-4954-9770-008eee04139b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
       "evidence-group": [
@@ -6033,7 +6033,7 @@
       ]
     },
     {
-      "uuid": "ebe3101c-37e1-4143-a40c-7741282aa800",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
       "evidence-group": [
@@ -6091,7 +6091,7 @@
       ]
     },
     {
-      "uuid": "ebf6f544-1aae-4b5c-baf3-0f7ab33bebb7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
       "evidence-group": [
@@ -6149,7 +6149,7 @@
       ]
     },
     {
-      "uuid": "a3a1b77d-d87e-4b38-829a-c69437a50767",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
       "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
       "evidence-group": [
@@ -6207,7 +6207,7 @@
       ]
     },
     {
-      "uuid": "11bf7227-b462-45a1-a145-ed880c429990",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
       "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
       "evidence-group": [
@@ -6265,7 +6265,7 @@
       ]
     },
     {
-      "uuid": "8eca6a48-2477-4700-a23f-b6349dbd288b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
       "evidence-group": [
@@ -6323,7 +6323,7 @@
       ]
     },
     {
-      "uuid": "e5b6cc7a-d0f0-4cf1-9e6f-85ca92be31d0",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
       "evidence-group": [
@@ -6381,7 +6381,7 @@
       ]
     },
     {
-      "uuid": "ebed7ae5-37a0-467b-a46e-b96fcccf2c7b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
       "evidence-group": [
@@ -6439,7 +6439,7 @@
       ]
     },
     {
-      "uuid": "7711ec12-19e1-4e28-aa39-66c685415cae",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
       "evidence-group": [
@@ -6497,7 +6497,7 @@
       ]
     },
     {
-      "uuid": "47916d5d-6c19-4d2d-98d9-ecc89d86efa7",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
       "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
       "evidence-group": [
@@ -6555,7 +6555,7 @@
       ]
     },
     {
-      "uuid": "18995710-14c4-45b8-9f7a-ee7fb98f00c2",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
       "evidence-group": [
@@ -6613,7 +6613,7 @@
       ]
     },
     {
-      "uuid": "64c63dcb-5593-4e7c-b702-91b0aea44bb3",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
       "evidence-group": [
@@ -6671,7 +6671,7 @@
       ]
     },
     {
-      "uuid": "c52fbbc6-56a0-4064-a986-7bcf0216c3ee",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
       "evidence-group": [
@@ -6729,7 +6729,7 @@
       ]
     },
     {
-      "uuid": "79696a81-1e89-4093-9e0b-5f8b70091a94",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
       "evidence-group": [
@@ -6787,7 +6787,7 @@
       ]
     },
     {
-      "uuid": "d0d359a5-c024-446b-8539-c9ae80cc90c5",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
       "evidence-group": [
@@ -6845,7 +6845,7 @@
       ]
     },
     {
-      "uuid": "97d7022e-ee0d-43ab-b231-5e64bb495379",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
       "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
       "evidence-group": [
@@ -6903,7 +6903,7 @@
       ]
     },
     {
-      "uuid": "4a75bd7d-caf0-4130-9a62-3d6e5b169e1f",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
       "evidence-group": [
@@ -6961,7 +6961,7 @@
       ]
     },
     {
-      "uuid": "7c215c64-9639-44a2-b6eb-d8d89fb20941",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
       "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
       "evidence-group": [
@@ -7019,7 +7019,7 @@
       ]
     },
     {
-      "uuid": "77627382-c004-46a1-9264-254c5f4e394e",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
       "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
       "evidence-group": [
@@ -7077,7 +7077,7 @@
       ]
     },
     {
-      "uuid": "d26d8622-1f97-4a0e-9563-97c9cfe4059b",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
       "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
       "evidence-group": [
@@ -7135,7 +7135,7 @@
       ]
     },
     {
-      "uuid": "6fd4dda1-1e28-4ee9-8eb6-5651ca5068d0",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
       "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
       "evidence-group": [
@@ -7193,7 +7193,7 @@
       ]
     },
     {
-      "uuid": "4f859376-279f-4799-8d47-87b857698492",
+      "uuid": "a8098c1a-f86e-11da-bd1a-00112444be1e",
       "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
       "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
       "evidence-group": [

--- a/tests/trestle/tasks/osco_test.py
+++ b/tests/trestle/tasks/osco_test.py
@@ -1,0 +1,137 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSCO transformation tests."""
+
+import json
+import pathlib
+import uuid
+from unittest.mock import patch
+
+from trestle.lib import osco
+
+import yaml
+
+encoding = 'utf8'
+loader = yaml.Loader
+stem_in = 'tests/data/tasks/osco/input'
+stem_out = 'tests/data/tasks/osco/output'
+
+mock_uuid4_value = uuid.UUID('a8098c1a-f86e-11da-bd1a-00112444be1e')
+
+
+def test_function_osco_get_observations(tmpdir):
+    """Test OSCO to OSCAL transformation."""
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    metadata = _load_yaml(stem_in, 'oscal-metadata.yaml')
+    with patch('uuid.uuid4') as mock_uuid4:
+        mock_uuid4.return_value = mock_uuid4_value
+        odata, analysis = osco.get_observations(idata, metadata)
+    expected = _load_json(stem_out, 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal')
+    tfile = tmpdir / 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal'
+    _save_json(tfile, odata)
+    actual = _load_json(tmpdir, 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal')
+    assert actual == expected
+
+
+def test_class_osco_rules(tmpdir):
+    """Test class osco.Rules."""
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    rules = osco.Rules(idata)
+    assert len(rules.instances) == 125
+    assert len(rules.benchmark) == 2
+    assert rules.benchmark['href'] == '/content/ssg-ocp4-ds.xml'
+    assert rules.benchmark['id'] == 'xccdf_org.ssgproject.content_benchmark_OCP-4'
+    assert len(rules.metadata) == 2
+    assert rules.metadata['name'] == 'ssg-ocp4-ds-cis-10.221.139.104-pod'
+    assert rules.metadata['namespace'] == 'openshift-compliance'
+    assert len(rules.analysis) == 3
+    assert rules.analysis['config_maps'] == ['ssg-ocp4-ds']
+    assert rules.analysis['dispatched_rules'] == 125
+    assert len(rules.analysis['result_types']) == 4
+    assert rules.analysis['result_types']['notselected'] == 2
+    assert rules.analysis['result_types']['notchecked'] == 47
+    assert rules.analysis['result_types']['fail'] == 64
+    assert rules.analysis['result_types']['pass'] == 12
+
+
+def test_class_osco_observations(tmpdir):
+    """Test class osco.Observations."""
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    rules = osco.Rules(idata)
+    metadata = _load_yaml(stem_in, 'oscal-metadata.yaml')
+    with patch('uuid.uuid4') as mock_uuid4:
+        mock_uuid4.return_value = mock_uuid4_value
+        observations = osco.Observations(rules, metadata)
+    assert len(observations.instances) == 125
+    instance = observations.instances[0]
+    assert len(instance) == 6
+    assert instance['uuid'] == str(mock_uuid4_value)
+    assert instance['description'] == 'xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd'
+    assert instance['title'] == 'xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd'
+    assert len(instance['evidence-group']) == 1
+    assert instance['evidence-group'][0]['description'] == 'Evidence location.'
+    assert instance['evidence-group'][0]['href'] == 'https://github.ibm.com/degenaro/evidence-locker'
+    assert len(instance['evidence-group'][0]['properties']) == 4
+    assert instance['evidence-group'][0]['properties'][0]['ns'] == 'xccdf'
+    assert instance['evidence-group'][0]['properties'][0]['class'] == 'id'
+    assert instance['evidence-group'][0]['properties'][0]['name'] == 'rule'
+    assert instance['evidence-group'][0]['properties'][0]['value'
+                                                          ] == 'xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd'
+    assert instance['evidence-group'][0]['properties'][1]['ns'] == 'xccdf'
+    assert instance['evidence-group'][0]['properties'][1]['class'] == 'timestamp'
+    assert instance['evidence-group'][0]['properties'][1]['name'] == 'time'
+    assert instance['evidence-group'][0]['properties'][1]['value'] == '2020-08-03T02:26:26+00:00'
+    assert instance['evidence-group'][0]['properties'][2]['ns'] == 'xccdf'
+    assert instance['evidence-group'][0]['properties'][2]['class'] == 'result'
+    assert instance['evidence-group'][0]['properties'][2]['name'] == 'result'
+    assert instance['evidence-group'][0]['properties'][2]['value'] == 'notselected'
+    assert instance['evidence-group'][0]['properties'][3]['ns'] == 'xccdf'
+    assert instance['evidence-group'][0]['properties'][3]['class'] == 'target'
+    assert instance['evidence-group'][0]['properties'][3]['name'] == 'target'
+    assert instance['evidence-group'][0]['properties'][3][
+        'value'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm'
+    assert len(instance['subject-references']) == 2
+    assert instance['subject-references'][0]['uuid-ref'] == '56666738-0f9a-4e38-9aac-c0fad00a5821'
+    assert instance['subject-references'][0]['type'] == 'component'
+    assert instance['subject-references'][0]['title'] == 'Red Hat OpenShift Kubernetes'
+    assert instance['subject-references'][1]['uuid-ref'] == '46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e'
+    assert instance['subject-references'][1]['type'] == 'inventory-item'
+    assert instance['subject-references'][1]['title'] == 'Pod'
+    assert len(instance['subject-references'][1]['properties']) == 4
+    assert instance['subject-references'][1]['properties'][
+        'target'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm'
+    assert instance['subject-references'][1]['properties']['cluster-name'] == 'ROKS-OpenSCAP-1'
+    assert instance['subject-references'][1]['properties']['cluster-type'] == 'openshift'
+    assert instance['subject-references'][1]['properties']['cluster-region'] == 'us-south'
+
+
+def _load_yaml(stem, filename):
+    ifile = pathlib.Path('') / stem / filename
+    with open(ifile, 'r+') as fp:
+        data = fp.read()
+        content = yaml.full_load(data)
+    return content
+
+
+def _load_json(stem, filename):
+    ifile = pathlib.Path('') / stem / filename
+    with open(ifile, 'r', encoding='utf-8') as fp:
+        content = json.load(fp)
+    return content
+
+
+def _save_json(ofile, content):
+    with open(ofile, 'w', encoding='utf-8') as fp:
+        json.dump(content, fp, ensure_ascii=False, indent=2)

--- a/tests/trestle/tasks/osco_test.py
+++ b/tests/trestle/tasks/osco_test.py
@@ -33,28 +33,28 @@ mock_uuid4_value = uuid.UUID('a8098c1a-f86e-11da-bd1a-00112444be1e')
 
 def test_function_osco_get_observations(tmpdir):
     """Test OSCO to OSCAL transformation."""
-    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-111.222.333.444-pod.yaml')
     metadata = _load_yaml(stem_in, 'oscal-metadata.yaml')
     with patch('uuid.uuid4') as mock_uuid4:
         mock_uuid4.return_value = mock_uuid4_value
         odata, analysis = osco.get_observations(idata, metadata)
-    expected = _load_json(stem_out, 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal')
-    tfile = tmpdir / 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal'
+    expected = _load_json(stem_out, 'osco-pod-oscal.json')
+    tfile = tmpdir / 'osco-pod-oscal.json'
     _save_json(tfile, odata)
-    actual = _load_json(tmpdir, 'ssg-ocp4-ds-cis-10.221.139.104-pod.oscal')
+    actual = _load_json(tmpdir, 'osco-pod-oscal.json')
     assert actual == expected
 
 
 def test_class_osco_rules(tmpdir):
     """Test class osco.Rules."""
-    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-111.222.333.444-pod.yaml')
     rules = osco.Rules(idata)
     assert len(rules.instances) == 125
     assert len(rules.benchmark) == 2
     assert rules.benchmark['href'] == '/content/ssg-ocp4-ds.xml'
     assert rules.benchmark['id'] == 'xccdf_org.ssgproject.content_benchmark_OCP-4'
     assert len(rules.metadata) == 2
-    assert rules.metadata['name'] == 'ssg-ocp4-ds-cis-10.221.139.104-pod'
+    assert rules.metadata['name'] == 'ssg-ocp4-ds-cis-111.222.333.444-pod'
     assert rules.metadata['namespace'] == 'openshift-compliance'
     assert len(rules.analysis) == 3
     assert rules.analysis['config_maps'] == ['ssg-ocp4-ds']
@@ -68,7 +68,7 @@ def test_class_osco_rules(tmpdir):
 
 def test_class_osco_observations(tmpdir):
     """Test class osco.Observations."""
-    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-10.221.139.104-pod.yaml')
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-111.222.333.444-pod.yaml')
     rules = osco.Rules(idata)
     metadata = _load_yaml(stem_in, 'oscal-metadata.yaml')
     with patch('uuid.uuid4') as mock_uuid4:
@@ -82,7 +82,7 @@ def test_class_osco_observations(tmpdir):
     assert instance['title'] == 'xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd'
     assert len(instance['evidence-group']) == 1
     assert instance['evidence-group'][0]['description'] == 'Evidence location.'
-    assert instance['evidence-group'][0]['href'] == 'https://github.ibm.com/degenaro/evidence-locker'
+    assert instance['evidence-group'][0]['href'] == 'https://github.mycorp.com/degenaro/evidence-locker'
     assert len(instance['evidence-group'][0]['properties']) == 4
     assert instance['evidence-group'][0]['properties'][0]['ns'] == 'xccdf'
     assert instance['evidence-group'][0]['properties'][0]['class'] == 'id'
@@ -101,7 +101,7 @@ def test_class_osco_observations(tmpdir):
     assert instance['evidence-group'][0]['properties'][3]['class'] == 'target'
     assert instance['evidence-group'][0]['properties'][3]['name'] == 'target'
     assert instance['evidence-group'][0]['properties'][3][
-        'value'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm'
+        'value'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp'
     assert len(instance['subject-references']) == 2
     assert instance['subject-references'][0]['uuid-ref'] == '56666738-0f9a-4e38-9aac-c0fad00a5821'
     assert instance['subject-references'][0]['type'] == 'component'
@@ -111,7 +111,7 @@ def test_class_osco_observations(tmpdir):
     assert instance['subject-references'][1]['title'] == 'Pod'
     assert len(instance['subject-references'][1]['properties']) == 4
     assert instance['subject-references'][1]['properties'][
-        'target'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm'
+        'target'] == 'kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp'
     assert instance['subject-references'][1]['properties']['cluster-name'] == 'ROKS-OpenSCAP-1'
     assert instance['subject-references'][1]['properties']['cluster-type'] == 'openshift'
     assert instance['subject-references'][1]['properties']['cluster-region'] == 'us-south'

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -1,0 +1,20 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSCO to OSCAL transformation tests."""
+
+def test_transformation():
+    """Test OSCO to OSCAL transformation."""
+    print('TBD.')

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -1,5 +1,4 @@
 # -*- mode:python; coding:utf-8 -*-
-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""OSCO to OSCAL transformation tests."""
+"""OSCO to OSCAL task tests."""
 
-def test_transformation():
-    """Test OSCO to OSCAL transformation."""
-    print('TBD.')
+from trestle.tasks import osco_to_oscal
+
+def test_print_info(tmpdir):
+    #TODO
+    pass
+
+def test_simulate(tmpdir):
+    #TODO
+    pass
+    
+def test_execute(tmpdir):
+    #TODO
+    pass

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -14,16 +14,128 @@
 # limitations under the License.
 """OSCO to OSCAL task tests."""
 
-from trestle.tasks import osco_to_oscal
+import configparser
+import os
+
+import trestle.tasks.osco_to_oscal as osco_to_oscal
+from trestle.tasks.base_task import TaskOutcome
 
 def test_print_info(tmpdir):
-    #TODO
-    pass
+    """Test print_info call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.print_info()
+    assert retval is None
 
 def test_simulate(tmpdir):
-    #TODO
-    pass
-    
+    """Test simulate call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_SUCCESS
+
+def test_simulate_no_config(tmpdir):
+    """Test simulate no config call."""
+    tgt = osco_to_oscal.OscoToOscal(None)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_FAILURE
+
+def test_simulate_no_overwrite(tmpdir):
+    """Test simulate no overwrite call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
+    assert len(os.listdir(str(tmpdir))) == 6
+    section['output-overwrite'] = 'false'
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_FAILURE
+
+def test_simulate_no_input_dir(tmpdir):
+    """Test simulate with no input dir call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    config.remove_option('task.osco-to-oscal', 'input-dir')
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_FAILURE
+
+def test_simulate_no_ouput_dir(tmpdir):
+    """Test simulate with no output dir call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    config.remove_option('task.osco-to-oscal', 'output-dir')
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_FAILURE
+
 def test_execute(tmpdir):
-    #TODO
-    pass
+    """Test execute call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
+    assert len(os.listdir(str(tmpdir))) == 6
+
+def test_execute_no_config(tmpdir):
+    """Test execute no config call."""
+    tgt = osco_to_oscal.OscoToOscal(None)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.FAILURE
+
+def test_execute_no_overwrite(tmpdir):
+    """Test execute no overwrite call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
+    assert len(os.listdir(str(tmpdir))) == 6
+    section['output-overwrite'] = 'false'
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.FAILURE
+
+def test_execute_no_input_dir(tmpdir):
+    """Test execute with no input dir call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    config.remove_option('task.osco-to-oscal', 'input-dir')
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.FAILURE
+
+def test_execute_no_ouput_dir(tmpdir):
+    """Test execute with no output dir call."""
+    config = configparser.ConfigParser()
+    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config.read(config_path)
+    config.remove_option('task.osco-to-oscal', 'output-dir')
+    section = config['task.osco-to-oscal']
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.FAILURE

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -27,6 +27,7 @@ def test_print_info(tmpdir):
     config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.print_info()
     assert retval is None
@@ -37,6 +38,7 @@ def test_simulate(tmpdir):
     config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.simulate()
     assert retval == TaskOutcome.SIM_SUCCESS
@@ -59,6 +61,7 @@ def test_simulate_no_overwrite(tmpdir):
     assert retval == TaskOutcome.SUCCESS
     assert len(os.listdir(str(tmpdir))) == 1
     section['output-overwrite'] = 'false'
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.simulate()
     assert retval == TaskOutcome.SIM_FAILURE
@@ -70,9 +73,22 @@ def test_simulate_no_input_dir(tmpdir):
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'input-dir')
     section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.simulate()
     assert retval == TaskOutcome.SIM_FAILURE
+
+def test_simulate_no_oscal_metadata_file(tmpdir):
+    """Test simulate with no metadata file call."""
+    config = configparser.ConfigParser()
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    section['input-metadata'] = 'non-existant.yaml'
+    section['output-dir'] = str(tmpdir)
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.simulate()
+    assert retval == TaskOutcome.SIM_SUCCESS
 
 def test_simulate_no_ouput_dir(tmpdir):
     """Test simulate with no output dir call."""
@@ -115,6 +131,7 @@ def test_execute_no_overwrite(tmpdir):
     assert retval == TaskOutcome.SUCCESS
     assert len(os.listdir(str(tmpdir))) == 1
     section['output-overwrite'] = 'false'
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()
     assert retval == TaskOutcome.FAILURE
@@ -126,9 +143,22 @@ def test_execute_no_input_dir(tmpdir):
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'input-dir')
     section = config['task.osco-to-oscal']
+    section['output-dir'] = str(tmpdir)
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()
     assert retval == TaskOutcome.FAILURE
+
+def test_execute_no_oscal_metadata_file(tmpdir):
+    """Test execute with no metadata file call."""
+    config = configparser.ConfigParser()
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
+    config.read(config_path)
+    section = config['task.osco-to-oscal']
+    section['input-metadata'] = 'non-existant.yaml'
+    section['output-dir'] = str(tmpdir)
+    tgt = osco_to_oscal.OscoToOscal(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
 
 def test_execute_no_ouput_dir(tmpdir):
     """Test execute with no output dir call."""

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -56,7 +56,7 @@ def test_simulate_no_overwrite(tmpdir):
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()
     assert retval == TaskOutcome.SUCCESS
-    assert len(os.listdir(str(tmpdir))) == 6
+    assert len(os.listdir(str(tmpdir))) == 1
     section['output-overwrite'] = 'false'
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.simulate()
@@ -94,7 +94,7 @@ def test_execute(tmpdir):
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()
     assert retval == TaskOutcome.SUCCESS
-    assert len(os.listdir(str(tmpdir))) == 6
+    assert len(os.listdir(str(tmpdir))) == 1
 
 def test_execute_no_config(tmpdir):
     """Test execute no config call."""
@@ -112,7 +112,7 @@ def test_execute_no_overwrite(tmpdir):
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()
     assert retval == TaskOutcome.SUCCESS
-    assert len(os.listdir(str(tmpdir))) == 6
+    assert len(os.listdir(str(tmpdir))) == 1
     section['output-overwrite'] = 'false'
     tgt = osco_to_oscal.OscoToOscal(section)
     retval = tgt.execute()

--- a/tests/trestle/tasks/osco_to_oscal_test.py
+++ b/tests/trestle/tasks/osco_to_oscal_test.py
@@ -16,6 +16,7 @@
 
 import configparser
 import os
+import pathlib
 
 import trestle.tasks.osco_to_oscal as osco_to_oscal
 from trestle.tasks.base_task import TaskOutcome
@@ -23,7 +24,7 @@ from trestle.tasks.base_task import TaskOutcome
 def test_print_info(tmpdir):
     """Test print_info call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
     tgt = osco_to_oscal.OscoToOscal(section)
@@ -33,7 +34,7 @@ def test_print_info(tmpdir):
 def test_simulate(tmpdir):
     """Test simulate call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
     tgt = osco_to_oscal.OscoToOscal(section)
@@ -49,7 +50,7 @@ def test_simulate_no_config(tmpdir):
 def test_simulate_no_overwrite(tmpdir):
     """Test simulate no overwrite call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
     section['output-dir'] = str(tmpdir)
@@ -65,7 +66,7 @@ def test_simulate_no_overwrite(tmpdir):
 def test_simulate_no_input_dir(tmpdir):
     """Test simulate with no input dir call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'input-dir')
     section = config['task.osco-to-oscal']
@@ -76,7 +77,7 @@ def test_simulate_no_input_dir(tmpdir):
 def test_simulate_no_ouput_dir(tmpdir):
     """Test simulate with no output dir call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'output-dir')
     section = config['task.osco-to-oscal']
@@ -87,7 +88,7 @@ def test_simulate_no_ouput_dir(tmpdir):
 def test_execute(tmpdir):
     """Test execute call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
     section['output-dir'] = str(tmpdir)
@@ -105,7 +106,7 @@ def test_execute_no_config(tmpdir):
 def test_execute_no_overwrite(tmpdir):
     """Test execute no overwrite call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     section = config['task.osco-to-oscal']
     section['output-dir'] = str(tmpdir)
@@ -121,7 +122,7 @@ def test_execute_no_overwrite(tmpdir):
 def test_execute_no_input_dir(tmpdir):
     """Test execute with no input dir call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'input-dir')
     section = config['task.osco-to-oscal']
@@ -132,7 +133,7 @@ def test_execute_no_input_dir(tmpdir):
 def test_execute_no_ouput_dir(tmpdir):
     """Test execute with no output dir call."""
     config = configparser.ConfigParser()
-    config_path = 'tests/data/tasks/osco/demo-osco-to-oscal.config'
+    config_path = pathlib.Path('tests/data/tasks/osco/demo-osco-to-oscal.config')
     config.read(config_path)
     config.remove_option('task.osco-to-oscal', 'output-dir')
     section = config['task.osco-to-oscal']

--- a/trestle/lib/osco.py
+++ b/trestle/lib/osco.py
@@ -1,0 +1,312 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Facilitate OpenShift Compliance Operator yaml to OSCAL json transformation."""
+
+import base64
+import bz2
+import json
+import logging
+from uuid import uuid4
+from xml.etree import ElementTree
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def transform(ifile, ofile, overwrite, metadata):
+    """
+    Transform ```ifile``` from OSCO yaml to NIST OSCAL json and save as ```ofile```.
+
+    An existing .oscal file is replaced unless the specified value for the
+    ```overwrite``` parameter is ```False```.
+
+    Provide optional ```metadata``` to more completely formulate the observations.
+
+    -----
+    Sample metadata entry:
+    -----
+    ssg-ocp4-ds-cis-10.221.139.104-pod:
+       subject-references:
+          component:
+             uuid-ref: 56666738-0f9a-4e38-9aac-c0fad00a5821
+             type: component
+             title: Red Hat OpenShift Kubernetes
+          inventory-item:
+             uuid-ref: 46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e
+             type: inventory-item
+             title: Pod
+             properties:
+                target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+                cluster-name: ROKS-OpenSCAP-1
+                cluster-type: openshift
+                cluster-region: us-south
+    -----
+    """
+    content = _read_content(ifile)
+    rules = Rules(content)
+    observations = Observations(rules, metadata)
+    output = {'observations': observations.instances}
+    _write_content(ofile, output)
+    return rules.analysis
+
+
+def _read_content(ifile):
+    with open(ifile, 'r+') as fp:
+        data = fp.read()
+        content = yaml.full_load(data)
+    logger.debug('========== <content> ==========')
+    logger.debug(content)
+    logger.debug('========== </content> ==========')
+    return content
+
+
+def _write_content(ofile, content):
+    with open(ofile, 'w', encoding='utf-8') as fp:
+        json.dump(content, fp, ensure_ascii=False, indent=2)
+
+
+class Observations():
+    """Create and accumulate list of OSCAL-like Observations."""
+
+    def __init__(self, rules, metadata):
+        """Initialize given specified args."""
+        # List of observations.
+        self._instances = []
+        # Transform each rule+result into an observation.
+        for rule in rules.instances:
+            observation = self._create_observation(rule, metadata)
+            self._instances.append(observation)
+
+    @property
+    def instances(self):
+        """Get the list of observations."""
+        return self._instances
+
+    def _create_observation(self, rule, metadata):
+        observation = {}
+        observation['uuid'] = str(uuid4())
+        observation['description'] = rule['idref']
+        observation['title'] = rule['idref']
+        observation['evidence-group'] = self._create_evidence_group(rule, metadata)
+        subject_references = self._create_subject_references(rule, metadata)
+        if subject_references is not None:
+            observation['subject-references'] = subject_references
+        observation['observation-methods'] = self._create_observation_methods(rule, metadata)
+        return observation
+
+    def _create_evidence_group(self, rule, metadata):
+        evidence = self._create_evidence(rule, metadata)
+        evidence_group = [evidence]
+        return evidence_group
+
+    def _create_evidence(self, rule, metadata):
+        evidence = {}
+        if 'repo-url' in metadata:
+            evidence['description'] = 'Evidence location.'
+            evidence['href'] = metadata['repo-url']
+        if 'ns' in metadata:
+            ns = metadata['ns']
+        else:
+            ns = None
+        p1 = self._create_property(ns, 'id', 'rule', rule['idref'])
+        p2 = self._create_property(ns, 'timestamp', 'time', rule['time'])
+        p3 = self._create_property(ns, 'result', 'result', rule['result_type'])
+        p4 = self._create_property(ns, 'target', 'target', rule['target'])
+        properties = [p1, p2, p3, p4]
+        evidence['properties'] = properties
+        return evidence
+
+    def _create_property(self, ns, classification, name, value):
+        prop = {}
+        if ns is not None:
+            prop['ns'] = ns
+        prop['class'] = classification
+        prop['name'] = name
+        prop['value'] = value
+        return prop
+
+    def _create_subject_references(self, rule, metadata):
+        subject_references = None
+        try:
+            name = rule['name']
+            entry = metadata[name]
+            if entry is not None:
+                component = entry['subject-references']['component']
+                inventory_item = entry['subject-references']['inventory-item']
+                subject_references = [component, inventory_item]
+        except Exception:
+            logger.debug('missing or invalid subject references')
+        return subject_references
+
+    def _create_observation_methods(self, rule, metadata):
+        observation_methods = ['TEST-AUTOMATED']
+        return observation_methods
+
+
+class Rules():
+    """Create and accumulate list of rule + result pairs with associated metadata."""
+
+    def __init__(self, content):
+        """Initialize given specified args."""
+        # List of extracted rules.
+        self._instances = []
+        # List of unique config_maps.
+        self._config_maps = []
+        # Dict of unique result types.
+        self._result_types = {}
+        # Dict of benchmark for this set of rules.
+        self._benchmark = {}
+        # Dict of metadata for this set of rules.
+        self._metadata = {}
+        # Dict of raw data to be processed.
+        self._content = content
+        # Perform rules extraction.
+        self._extract_rules()
+
+    @property
+    def instances(self):
+        """Get the list of rules."""
+        return self._instances
+
+    @property
+    def benchmark(self):
+        """Get the benchmark info."""
+        return self._benchmark
+
+    @property
+    def metadata(self):
+        """Get the metadata info."""
+        return self._metadata
+
+    @property
+    def analysis(self):
+        """Get the analysis info."""
+        logger.debug('Rules Analysis:')
+        logger.debug(f'config_maps: {self._config_maps}')
+        logger.debug(f'dispatched rules: {len(self._instances)}')
+        logger.debug(f'result types: {self._result_types}')
+        return {
+            'config_maps': self._config_maps,
+            'dispatched_rules': len(self._instances),
+            'result_types': self._result_types
+        }
+
+    def _extract_rules(self):
+        """Extract the rules from the input data."""
+        while True:
+            resource = self._content
+            if resource is None:
+                logger.debug(f'resource: {resource}')
+                break
+            if 'kind' not in resource.keys():
+                logger.debug('kind: not found')
+                break
+            if resource['kind'] != 'ConfigMap':
+                logger.debug(f'kind: {resource["kind"]}')
+                break
+            if 'results' not in resource['data']:
+                logger.debug('results: not found')
+                break
+            if 'metadata' not in resource.keys():
+                logger.debug('metadata: not found')
+                self._metadata['name'] = None
+                self._metadata['namespace'] = None
+            else:
+                self._metadata['name'] = resource['metadata']['name']
+                self._metadata['namespace'] = resource['metadata']['namespace']
+            results = resource['data']['results']
+            if results.startswith('<?xml'):
+                pass
+            else:
+                results = bz2.decompress(base64.b64decode(results))
+            logger.debug('========== <results> ==========')
+            logger.debug(results)
+            logger.debug('========== </results> ==========')
+            self._parse_xml(results, self._metadata['name'])
+            break
+
+    def _parse_xml(self, results, name):
+        """Parse the stringified XML."""
+        root = ElementTree.fromstring(results)
+        target = self._get_target(root)
+        config_map = self._get_config_map(root)
+        stats = {}
+        for lev1 in root:
+            tag = _remove_namespace(lev1.tag)
+            if tag == 'rule-result':
+                idref = lev1.get('idref')
+                time = lev1.get('time')
+                result = self._get_result(lev1)
+                self._post(config_map, idref, time, result, target, name)
+                if result not in stats.keys():
+                    stats[result] = 0
+                stats[result] += 1
+            elif tag == 'benchmark':
+                self._benchmark['href'] = lev1.get('href')
+                self._benchmark['id'] = lev1.get('id')
+
+    def _get_target(self, root):
+        """Extract 'target' info from the stringified XML."""
+        target = None
+        for lev1 in root:
+            tag = _remove_namespace(lev1.tag)
+            if tag == 'target':
+                target = root.find(lev1.tag).text
+                break
+        return target
+
+    def _get_config_map(self, root):
+        """Extract 'config_map' info from the stringified XML."""
+        retval = ''
+        for lev1 in root:
+            tag = _remove_namespace(lev1.tag)
+            if tag == 'benchmark':
+                href = lev1.get('href')
+                retval = href.split('.')[0].rsplit('/', 1)[1]
+                break
+        return retval
+
+    def _get_result(self, lev1):
+        """Extract 'result' info from the stringified XML."""
+        result = None
+        for lev2 in lev1:
+            tag = _remove_namespace(lev2.tag)
+            if tag == 'result':
+                result = lev1.find(lev2.tag).text
+                break
+        return result
+
+    def _post(self, config_map, idref, time, result_type, target, name):
+        """Append a rule entry."""
+        instance = {}
+        instance['config_map'] = config_map
+        instance['idref'] = idref
+        instance['time'] = time
+        instance['result_type'] = result_type
+        instance['target'] = target
+        instance['name'] = name
+        self._instances.append(instance)
+        if config_map not in self._config_maps:
+            self._config_maps.append(config_map)
+        if (result_type not in self._result_types):
+            self._result_types[result_type] = 0
+        self._result_types[result_type] += 1
+        logger.debug(instance)
+
+
+def _remove_namespace(subject):
+    """If a namespace is present in the subject string, remove it."""
+    return subject.rsplit('}').pop()

--- a/trestle/lib/osco.py
+++ b/trestle/lib/osco.py
@@ -114,13 +114,16 @@ class Observations():
 
     def _create_evidence(self, rule, metadata):
         evidence = {}
-        if 'repo-url' in metadata:
-            evidence['description'] = 'Evidence location.'
-            evidence['href'] = metadata['repo-url']
-        if 'ns' in metadata:
-            ns = metadata['ns']
-        else:
-            ns = None
+        name = rule['name']
+        entry = metadata[name]
+        if entry is not None:
+            if 'locker' in entry:
+                evidence['description'] = 'Evidence location.'
+                evidence['href'] = entry['locker']
+            if 'namespace' in entry:
+                ns = entry['namespace']
+            else:
+                ns = None
         p1 = self._create_property(ns, 'id', 'rule', rule['idref'])
         p2 = self._create_property(ns, 'timestamp', 'time', rule['time'])
         p3 = self._create_property(ns, 'result', 'result', rule['result_type'])

--- a/trestle/lib/osco.py
+++ b/trestle/lib/osco.py
@@ -17,7 +17,7 @@
 import base64
 import bz2
 import logging
-from uuid import uuid4
+import uuid
 from xml.etree import ElementTree
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class Observations():
 
     def _create_observation(self, rule, metadata):
         observation = {}
-        observation['uuid'] = str(uuid4())
+        observation['uuid'] = str(uuid.uuid4())
         observation['description'] = rule['idref']
         observation['title'] = rule['idref']
         observation['evidence-group'] = self._create_evidence_group(rule, metadata)

--- a/trestle/lib/osco.py
+++ b/trestle/lib/osco.py
@@ -18,12 +18,13 @@ import base64
 import bz2
 import logging
 import uuid
+from typing import Any, Dict, List
 from xml.etree import ElementTree
 
 logger = logging.getLogger(__name__)
 
 
-def get_observations(idata, oscal_metadata):
+def get_observations(idata: Dict, oscal_metadata: Dict) -> (Dict, Dict):
     """
     Transform OSCO yaml to NIST OSCAL json with statistics.
 
@@ -63,7 +64,7 @@ def get_observations(idata, oscal_metadata):
 class Observations():
     """Create and accumulate list of OSCAL-like Observations."""
 
-    def __init__(self, rules, oscal_metadata):
+    def __init__(self, rules: List, oscal_metadata: Dict) -> Any:
         """Initialize given specified args."""
         # List of observations.
         self._instances = []
@@ -73,7 +74,7 @@ class Observations():
             self._instances.append(observation)
 
     @property
-    def instances(self):
+    def instances(self) -> List:
         """Get the list of observations."""
         return self._instances
 
@@ -150,7 +151,7 @@ class Observations():
 class Rules():
     """Create and accumulate list of rule + result pairs with associated metadata."""
 
-    def __init__(self, content):
+    def __init__(self, content: Dict) -> Any:
         """Initialize given specified args."""
         # List of extracted rules.
         self._instances = []
@@ -168,22 +169,22 @@ class Rules():
         self._extract_rules()
 
     @property
-    def instances(self):
+    def instances(self) -> List:
         """Get the list of rules."""
         return self._instances
 
     @property
-    def benchmark(self):
+    def benchmark(self) -> Dict:
         """Get the benchmark info."""
         return self._benchmark
 
     @property
-    def metadata(self):
+    def metadata(self) -> Dict:
         """Get the metadata info."""
         return self._metadata
 
     @property
-    def analysis(self):
+    def analysis(self) -> Dict:
         """Get the analysis info."""
         logger.debug('Rules Analysis:')
         logger.debug(f'config_maps: {self._config_maps}')

--- a/trestle/lib/osco.py
+++ b/trestle/lib/osco.py
@@ -35,8 +35,8 @@ def get_observations(idata, metadata):
     -----
     Sample metadata entry:
     -----
-    ssg-ocp4-ds-cis-10.221.139.104-pod:
-      locker: https://github.ibm.com/degenaro/evidence-locker
+    ssg-ocp4-ds-cis-111.222.333.444-pod:
+      locker: https://github.mycorp.com/degenaro/evidence-locker
       namespace: xccdf
       subject-references:
          component:
@@ -48,7 +48,7 @@ def get_observations(idata, metadata):
             type: inventory-item
             title: Pod
             properties:
-               target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.ibm
+               target: kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp
                cluster-name: ROKS-OpenSCAP-1
                cluster-type: openshift
                cluster-region: us-south

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -1,0 +1,159 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSCAL transformation tasks."""
+
+import configparser
+import logging
+import os
+import pathlib
+import traceback
+from typing import Optional
+
+import yaml
+
+from trestle.lib import osco
+from trestle.tasks.base_task import TaskBase
+from trestle.tasks.base_task import TaskOutcome
+
+logger = logging.getLogger(__name__)
+
+
+class OscoToOscal(TaskBase):
+    """
+    Task to convert OSCO yaml to OSCAL json.
+
+    Attributes:
+        name: Name of the task.
+    """
+
+    name = 'osco-to-oscal'
+
+    def __init__(self, config_object: Optional[configparser.SectionProxy]) -> None:
+        """
+        Initialize trestle task pass-fail.
+
+        Attributes:
+            config_object: Config section associated with the task.
+        """
+        super().__init__(config_object)
+
+    def print_info(self) -> None:
+        """Print the help string."""
+        logger.info(f'Help information for {self.name} task.')
+        logger.info('Configuration flags sit under [task.osco-to-oscal].')
+        logger.info('input-dir = the path of the input directory comprising .yaml files.')
+        logger.info('output-dir = the path of the output directory comprising synthesized .oscal files.')
+        logger.info('output-overwrite = true [default] or false; replace existing output when true.')
+
+    def simulate(self) -> TaskOutcome:
+        """Provide a simulated outcome."""
+        try:
+            if self._config:
+                idir = self._config.get('input-dir')
+                if idir is None:
+                    logger.error(f'config missing "input-dir"')
+                    return TaskOutcome('simulated-failure')
+                odir = self._config.get('output-dir')
+                if odir is None:
+                    logger.error(f'config missing "output-dir"')
+                    return TaskOutcome('simulated-failure')
+                overwrite = self._config.getboolean('output-overwrite', True)
+                for pfile in sorted(pathlib.Path(idir).iterdir()):
+                    ifile = str(pfile)
+                    if ifile.endswith('oscal-metadata.yaml'):
+                        continue
+                    if ifile.endswith('oscal-metadata.yml'):
+                        continue
+                    ofile = self._calculate_ofile(ifile, odir)
+                    if not overwrite:
+                        if os.path.exists(ofile):
+                            logger.error(f'file exists: {ofile}')
+                            return TaskOutcome('simulated-failure')
+                    mfile = self._calculate_mfile(idir)
+                    metadata = self._get_metadata(mfile)
+                return TaskOutcome('simulated-success')
+            logger.error(f'config missing')
+            return TaskOutcome('simulated-failure')
+        except Exception:
+            traceback.print_exc()
+            return TaskOutcome('simulated-exception')
+
+    def execute(self) -> TaskOutcome:
+        """Provide an actual outcome."""
+        try:
+            if self._config:
+                idir = self._config.get('input-dir')
+                if idir is None:
+                    logger.error(f'config missing "input-dir"')
+                    return TaskOutcome('failure')
+                odir = self._config.get('output-dir')
+                if odir is None:
+                    logger.error(f'config missing "output-dir"')
+                    return TaskOutcome('failure')
+                overwrite = self._config.getboolean('output-overwrite', True)
+                os.makedirs(odir, exist_ok = True) 
+                for pfile in sorted(pathlib.Path(idir).iterdir()):
+                    ifile = str(pfile)
+                    if ifile.endswith('oscal-metadata.yaml'):
+                        continue
+                    if ifile.endswith('oscal-metadata.yml'):
+                        continue
+                    ofile = self._calculate_ofile(ifile, odir)
+                    if not overwrite:
+                        if os.path.exists(ofile):
+                            logger.error(f'file exists: {ofile}')
+                            return TaskOutcome('simulated-failure')
+                    mfile = self._calculate_mfile(idir)
+                    metadata = self._get_metadata(mfile)
+                    logger.info(f'create: {ofile}')
+                    analysis = osco.transform(ifile, ofile, overwrite, metadata)
+                    logger.info(f'Rules Analysis:')
+                    logger.info(f'config_maps: {analysis["config_maps"]}')
+                    logger.info(f'dispatched rules: {analysis["dispatched_rules"]}')
+                    logger.info(f'result types: {analysis["result_types"]}')
+                # outcome, executed
+                return TaskOutcome('success')
+            logger.error(f'config missing')
+            return TaskOutcome('failure')
+        except Exception:
+            traceback.print_exc()
+            return TaskOutcome('exception')
+    
+    def _calculate_ofile(self, ifile, odir):
+        """Synthesize output file path+name."""
+        ofile = ifile
+        ofile = ofile.rsplit('.yaml')[0]
+        ofile = ofile.rsplit('.yml')[0]
+        ofile += '.oscal'
+        if '/' in ofile:
+            ofile = ofile.rsplit('/',1)[1]
+        ofile = odir+'/'+ofile
+        return ofile
+        
+    def _calculate_mfile(self, idir):
+        """Synthesize meta file path+name."""
+        mfile = idir+'/'+'oscal-metadata.yaml'
+        return mfile
+    
+    def _get_metadata(self, mfile):
+        metadata = {}
+        try:
+            with open(mfile, "r") as fp:
+                metadata = yaml.full_load(fp)
+        except:
+            traceback.print_exc()
+        return metadata
+        

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -44,7 +44,7 @@ class OscoToOscal(TaskBase):
 
     def __init__(self, config_object: Optional[configparser.SectionProxy]) -> None:
         """
-        Initialize trestle task pass-fail.
+        Initialize trestle task osco-to-oscal.
 
         Attributes:
             config_object: Config section associated with the task.
@@ -135,7 +135,6 @@ class OscoToOscal(TaskBase):
                     logger.info(f'config_maps: {analysis["config_maps"]}')
                     logger.info(f'dispatched rules: {analysis["dispatched_rules"]}')
                     logger.info(f'result types: {analysis["result_types"]}')
-                # outcome, executed
                 return TaskOutcome('success')
             logger.error(f'config missing')
             return TaskOutcome('failure')

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -98,7 +98,7 @@ class OscoToOscal(TaskBase):
             return TaskOutcome('simulated-failure')
         except Exception:
             traceback.print_exc()
-            return TaskOutcome('simulated-exception')
+            return TaskOutcome('simulated-failure')
 
     def execute(self) -> TaskOutcome:
         """Provide an actual outcome."""
@@ -124,7 +124,7 @@ class OscoToOscal(TaskBase):
                     if not overwrite:
                         if os.path.exists(ofile):
                             logger.error(f'file exists: {ofile}')
-                            return TaskOutcome('simulated-failure')
+                            return TaskOutcome('failure')
                     mfile = self._calculate_mfile(idir)
                     metadata = self._get_metadata(mfile)
                     logger.info(f'create: {ofile}')
@@ -140,7 +140,7 @@ class OscoToOscal(TaskBase):
             return TaskOutcome('failure')
         except Exception:
             traceback.print_exc()
-            return TaskOutcome('exception')
+            return TaskOutcome('failure')
     
     def _read_content(self, ifile):
         with open(ifile, 'r+') as fp:
@@ -174,6 +174,7 @@ class OscoToOscal(TaskBase):
         return mfile
     
     def _get_metadata(self, mfile):
+        """Get metadata, if it exists."""
         metadata = {}
         try:
             with open(mfile, "r") as fp:

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -53,18 +53,25 @@ class OscoToOscal(TaskBase):
     def print_info(self) -> None:
         """Print the help string."""
         logger.info(f'Help information for {self.name} task.')
-        logger.info('Configuration flags sit under [task.osco-to-oscal].')
-        logger.info('input-dir = the path of the input directory comprising .yaml files.')
-        logger.info('input-metadata = the name of the input directory metadata .yaml file, default = oscal-metadata.yaml.')
-        logger.info('output-dir = the path of the output directory comprising synthesized OSCAL .json files.')
-        logger.info('output-overwrite = true [default] or false; replace existing output when true.')
-        logger.info('quiet = true or false [default]; display file creations and rules analysis when false.')
+        logger.info('')
+        logger.info('Purpose: Transform OpenShift Compliance Operator (OSCO) produced .yaml files into Open Security Controls Assessment Language (OSCAL) .json partial results files.')
+        logger.info('')
+        logger.info('Configuration flags sit under [task.osco-to-oscal]:')
+        logger.info('  input-dir = (required) the path of the input directory comprising osco .yaml files.')
+        logger.info('  input-metadata = (optional) the name of the input directory metadata .yaml file, default = oscal-metadata.yaml.')
+        logger.info('  output-dir = (required) the path of the output directory comprising synthesized OSCAL .json files.')
+        logger.info('  output-overwrite = (optional) true [default] or false; replace existing output when true.')
+        logger.info('  quiet = (optional) true or false [default]; display file creations and rules analysis when false.')
+        logger.info('')
+        logger.info('Operation: All the .yaml files in the input-dir are processed, each producing a corresponding .json output-dir file.')
+        logger.info('The exception is the input-metadata .yaml file which, if present, is used to augment all produced .json output directory files.')
+        logger.info('')
 
     def simulate(self) -> TaskOutcome:
         """Provide a simulated outcome."""
         if self._config:
             # initialize
-            metadata = {}
+            default_metadata = {}
             # process config
             idir = self._config.get('input-dir')
             if idir is None:
@@ -83,7 +90,9 @@ class OscoToOscal(TaskBase):
             opth.mkdir(exist_ok=True, parents=True)
             # fetch enhancing oscal metadata
             mfile = ipth / imeta
-            metadata = self._get_metadata(mfile, metadata)
+            metadata = self._get_metadata(mfile, default_metadata)
+            if len(metadata) == 0:
+                logger.debug(f'no metadata: {imeta}.')
             # examine each file in the input folder
             for ifile in sorted(ipth.iterdir()):
                 # skip enhancing oscal metadata
@@ -125,7 +134,7 @@ class OscoToOscal(TaskBase):
         """Provide an actual outcome."""
         if self._config:
             # initialize
-            metadata = {}
+            default_metadata = {}
             # process config
             idir = self._config.get('input-dir')
             if idir is None:
@@ -144,7 +153,9 @@ class OscoToOscal(TaskBase):
             opth.mkdir(exist_ok=True, parents=True)
             # fetch enhancing oscal metadata
             mfile = ipth / imeta
-            metadata = self._get_metadata(mfile, metadata)
+            metadata = self._get_metadata(mfile, default_metadata)
+            if len(metadata) == 0:
+                logger.info(f'no metadata: {imeta}.')
             # examine each file in the input folder
             for ifile in sorted(ipth.iterdir()):
                 # skip enhancing oscal metadata

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -17,7 +17,6 @@
 
 import configparser
 import logging
-import os
 import json
 import pathlib
 import traceback
@@ -82,7 +81,7 @@ class OscoToOscal(TaskBase):
                         continue
                     ofile = self._calculate_ofile(ifn, odir)
                     if not overwrite:
-                        if os.path.exists(ofile):
+                        if ofile.exists():
                             logger.error(f'file exists: {ofile}')
                             return TaskOutcome('simulated-failure')
                     mfile = idir / 'oscal-metadata.yaml'
@@ -99,7 +98,7 @@ class OscoToOscal(TaskBase):
             logger.error(f'config missing')
             return TaskOutcome('simulated-failure')
         except Exception:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             return TaskOutcome('simulated-failure')
 
     def execute(self) -> TaskOutcome:
@@ -116,7 +115,7 @@ class OscoToOscal(TaskBase):
                     return TaskOutcome('failure')
                 overwrite = self._config.getboolean('output-overwrite', True)
                 quiet = self._config.getboolean('quiet', False)
-                os.makedirs(odir, exist_ok = True) 
+                odir.mkdir(exist_ok=True, parents=True)
                 for ifile in sorted(pathlib.Path(idir).iterdir()):
                     parts = ifile.parts
                     ifn = parts[len(parts)-1]
@@ -126,7 +125,7 @@ class OscoToOscal(TaskBase):
                         continue
                     ofile = self._calculate_ofile(ifn, odir)
                     if not overwrite:
-                        if os.path.exists(ofile):
+                        if ofile.exists():
                             logger.error(f'file exists: {ofile}')
                             return TaskOutcome('failure')
                     mfile = idir / 'oscal-metadata.yaml'
@@ -145,7 +144,7 @@ class OscoToOscal(TaskBase):
             logger.error(f'config missing')
             return TaskOutcome('failure')
         except Exception:
-            traceback.print_exc()
+            logger.error(traceback.format_exc())
             return TaskOutcome('failure')
     
     def _read_content(self, ifile):
@@ -179,6 +178,6 @@ class OscoToOscal(TaskBase):
             with open(mfile, "r") as fp:
                 metadata = yaml.full_load(fp)
         except:
-            traceback.print_exc()
+            logger.debug(traceback.format_exc())
         return metadata
         

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -58,6 +58,7 @@ class OscoToOscal(TaskBase):
         logger.info('input-dir = the path of the input directory comprising .yaml files.')
         logger.info('output-dir = the path of the output directory comprising synthesized .oscal files.')
         logger.info('output-overwrite = true [default] or false; replace existing output when true.')
+        logger.info('quiet = true or false [default]; display file creations and rules analysis when false.')
 
     def simulate(self) -> TaskOutcome:
         """Provide a simulated outcome."""
@@ -113,6 +114,7 @@ class OscoToOscal(TaskBase):
                     logger.error(f'config missing "output-dir"')
                     return TaskOutcome('failure')
                 overwrite = self._config.getboolean('output-overwrite', True)
+                quiet = self._config.getboolean('quiet', False)
                 os.makedirs(odir, exist_ok = True) 
                 for pfile in sorted(pathlib.Path(idir).iterdir()):
                     ifile = str(pfile)
@@ -127,14 +129,16 @@ class OscoToOscal(TaskBase):
                             return TaskOutcome('failure')
                     mfile = self._calculate_mfile(idir)
                     metadata = self._get_metadata(mfile)
-                    logger.info(f'create: {ofile}')
+                    if not quiet:
+                        logger.info(f'create: {ofile}')
                     idata = self._read_content(ifile)
                     odata, analysis = osco.get_observations(idata, metadata)
                     self._write_content(ofile, odata)
-                    logger.info(f'Rules Analysis:')
-                    logger.info(f'config_maps: {analysis["config_maps"]}')
-                    logger.info(f'dispatched rules: {analysis["dispatched_rules"]}')
-                    logger.info(f'result types: {analysis["result_types"]}')
+                    if not quiet:
+                        logger.info(f'Rules Analysis:')
+                        logger.info(f'config_maps: {analysis["config_maps"]}')
+                        logger.info(f'dispatched rules: {analysis["dispatched_rules"]}')
+                        logger.info(f'result types: {analysis["result_types"]}')
                 return TaskOutcome('success')
             logger.error(f'config missing')
             return TaskOutcome('failure')

--- a/trestle/tasks/osco_to_oscal.py
+++ b/trestle/tasks/osco_to_oscal.py
@@ -167,7 +167,7 @@ class OscoToOscal(TaskBase):
         ofn = ifn
         ofn = ofn.rsplit('.yaml')[0]
         ofn = ofn.rsplit('.yml')[0]
-        ofn += '.oscal'
+        ofn += '-oscal.json'
         ofile = pathlib.Path(odir, ofn)
         return ofile
     


### PR DESCRIPTION
## Feature: trestle task osco-to-oscal and corresponding function

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x]  New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x] I have added tests to cover my changes.
- \[x] All new and existing tests passed.
- \[x] All commits are signed.

## Description

- Provide transformation function from dict of OSCO YAML (XCCDF) to dict of OSCAL-like JSON (observations list).
- Accept transformation function metadata YAML to enhance produced OSCAL-like JSON.
- Provide trestle task _osco-to-oscal_ to read input OSCO files from input directory and write OSCAL-like transformation data to corresponding files in output directory.
- Provide test-cases covering transformation function and task.

## Comments

The OpenShift Compliance Operator (see https://docs.openshift.com/container-platform/4.6/security/compliance_operator/compliance-operator-understanding.html) employs OpenSCAP, a NIST-certified tool, to scan and enforce security policies. The scan results are available as YAML. The osco-to-oscal function and task perform a transformation from this YAML format to NIST OSCAL-like JSON as a list of observations, each observation conforming to the _observation_ component of Assessment Results (see https://pages.nist.gov/OSCAL/documentation/schema/assessment-results-layer/assessment-results/json-schema/#oscal-ar-json_observation).

 `closes #260` 