### PR TITLE
sftp fetcher testing completed, mostly

### DIFF
--- a/tests/trestle/core/remote/cache_test.py
+++ b/tests/trestle/core/remote/cache_test.py
@@ -15,13 +15,10 @@
 # limitations under the License.
 """Testing for cache functionality."""
 
-import os
 import pathlib
 import random
 import string
-from unittest import mock
 from unittest.mock import patch
-from urllib import parse
 
 import pytest
 
@@ -72,25 +69,21 @@ def test_sftp_fetcher(tmp_trestle_dir):
                     ssh_load_keys_mock.assert_called_once()
                     ssh_connect_mock.assert_called_once()
                     sftp_open_mock.assert_called_once()
-                    # sftp_get_mock.assert_called_once()
 
 
 def test_sftp_fetcher_cache_only(tmp_trestle_dir):
-    """Test sftp fetcher should not update, cache only."""
+    """Test that sftp fetcher does not call update (_sync_cache) when _cache_only is true."""
     uri = 'sftp://some.host//path/to/test.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
     fetcher._cache_only = True
-    try:
+    with patch('trestle.core.remote.cache.SFTPFetcher._sync_cache') as sync_cache_mock:
         fetcher._update_cache()
-    except Exception:
-        AssertionError()
-    else:
-        assert True
+        sync_cache_mock.assert_not_called()
 
 
 def test_sftp_fetcher_load_system_keys_fails(tmp_trestle_dir):
-    """Test the sftp fetcher, SSHClient load system host keys should fail."""
+    """Test the sftp fetcher when SSHClient loading of system host keys fails."""
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
@@ -102,7 +95,7 @@ def test_sftp_fetcher_load_system_keys_fails(tmp_trestle_dir):
 
 
 def test_sftp_fetcher_load_keys_fails(tmp_trestle_dir, monkeypatch):
-    """Test the sftp fetcher, SSHClient load host keys specified in env var should fail."""
+    """Test the sftp fetcher when SSHClient load host keys specified in env var fails."""
     monkeypatch.setenv('SSH_KEY', 'some_key_file')
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
@@ -116,7 +109,7 @@ def test_sftp_fetcher_load_keys_fails(tmp_trestle_dir, monkeypatch):
 
 
 def test_sftp_fetcher_connect_fails(tmp_trestle_dir):
-    """Test the sftp fetcher, SSHClient connect should fail."""
+    """Test sftp during SSHClient connect failure."""
     # Password given:
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
@@ -138,7 +131,7 @@ def test_sftp_fetcher_connect_fails(tmp_trestle_dir):
 
 
 def test_sftp_fetcher_open_sftp_fails(tmp_trestle_dir, monkeypatch):
-    """Test the local fetcher."""
+    """Test the exception response during open_sftp failure."""
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
@@ -150,13 +143,13 @@ def test_sftp_fetcher_open_sftp_fails(tmp_trestle_dir, monkeypatch):
                 open_sftp_mock.side_effect = err.TrestleError('stuff')
                 with pytest.raises(err.TrestleError):
                     fetcher._update_cache()
-                    ssh_load_host_keys_mock.assert_called_once()
+                    load_host_keys_mock.assert_called_once()
                     connect_mock.assert_called_once()
                     open_sftp_mock.assert_called_once()
 
 
 def test_sftp_fetcher_getuser_fails(tmp_trestle_dir, monkeypatch):
-    """Test the local fetcher."""
+    """Test the sftp call to getpass.getuser."""
     uri = 'sftp://some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
@@ -166,10 +159,11 @@ def test_sftp_fetcher_getuser_fails(tmp_trestle_dir, monkeypatch):
     with patch('getpass.getuser') as getuser_mock:
         with pytest.raises(err.TrestleError):
             fetcher._update_cache()
+            getuser_mock.assert_called_once()
 
 
 def test_sftp_fetcher_get_fails(tmp_trestle_dir, monkeypatch):
-    """Test the local fetcher."""
+    """Test the sftp fetcher SFTPClient.get() failing."""
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
@@ -184,38 +178,30 @@ def test_sftp_fetcher_get_fails(tmp_trestle_dir, monkeypatch):
                     fetcher._update_cache()
                     load_host_keys_mock.assert_called_once()
                     connect_mock.assert_called_once()
-                    open_sftp_mock.assert_called_once()
                     get_mock.assert_called_once()
 
 
 def test_sftp_fetcher_bad_uri(tmp_trestle_dir):
-    """Test fetcher factory with bad URI."""
-    for uri in [
-                'sftp://blah.com',
+    """Test get_fetcher handling of bad SFTP URI."""
+    for uri in ['sftp://blah.com',
                 'sftp:///path/to/file.json',
                 'sftp://user:pass@hostname.com\\path\\to\\file.json',
-                'sftp://:pass@hostname.com/path/to/file.json'
-    ]:
+                'sftp://:pass@hostname.com/path/to/file.json']:
         with pytest.raises(TrestleError):
             cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
 
 
 def test_fetcher_bad_uri(tmp_trestle_dir):
     """Test fetcher factory with bad URI."""
-    for uri in ['',
-                'https://',
-                'https:///blah.com',
-                'sftp://',
-                '..'
-    ]:
+    for uri in ['', 'https://', 'https:///blah.com', 'sftp://', '..']:
         with pytest.raises(TrestleError):
             cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
 
 
 def test_fetcher_factory(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test that the fetcher factory correctly resolves functionality."""
     settings = Settings()
 
-    """Test that the fetcher factory correctly resolves functionality."""
     local_uri_1 = 'file:///home/user/oscal_file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), local_uri_1, settings, False, False)
     assert type(fetcher) == cache.LocalFetcher

--- a/tests/trestle/core/remote/cache_test.py
+++ b/tests/trestle/core/remote/cache_test.py
@@ -21,6 +21,7 @@ import random
 import string
 from unittest import mock
 from unittest.mock import patch
+from urllib import parse
 
 import pytest
 
@@ -61,19 +62,17 @@ def test_sftp_fetcher(tmp_trestle_dir):
     fetcher._refresh = True
     fetcher._cache_only = False
     with patch('paramiko.SSHClient.load_system_host_keys') as ssh_load_keys_mock:
-        ssh_load_keys_mock.return_value = None
         with patch('paramiko.SSHClient.connect') as ssh_connect_mock:
-            ssh_connect_mock.return_value = None
             with patch('paramiko.SSHClient.open_sftp') as sftp_open_mock:
-                sftp_open_mock.return_value = None
-                with patch('paramiko.sftp_client.SFTPClient.get') as sftp_get_mock:
-                    sftp_get_mock.return_value = None
+                with patch('paramiko.SFTPClient.get') as sftp_get_mock:
                     try:
                         fetcher._update_cache()
                     except Exception:
                         AssertionError()
-                    else:
-                        assert True
+                    ssh_load_keys_mock.assert_called_once()
+                    ssh_connect_mock.assert_called_once()
+                    sftp_open_mock.assert_called_once()
+                    # sftp_get_mock.assert_called_once()
 
 
 def test_sftp_fetcher_cache_only(tmp_trestle_dir):
@@ -102,9 +101,9 @@ def test_sftp_fetcher_load_system_keys_fails(tmp_trestle_dir):
             fetcher._update_cache()
 
 
-@mock.patch.dict(os.environ, {'SSH_KEY': '/tmp/no_ssh_key_here'})
-def test_sftp_fetcher_load_keys_fails(tmp_trestle_dir):
+def test_sftp_fetcher_load_keys_fails(tmp_trestle_dir, monkeypatch):
     """Test the sftp fetcher, SSHClient load host keys specified in env var should fail."""
+    monkeypatch.setenv('SSH_KEY', 'some_key_file')
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
@@ -113,54 +112,92 @@ def test_sftp_fetcher_load_keys_fails(tmp_trestle_dir):
         ssh_load_host_keys_mock.side_effect = OSError('stuff')
         with pytest.raises(err.TrestleError):
             fetcher._update_cache()
+            ssh_load_host_keys_mock.assert_called_once()
 
 
 def test_sftp_fetcher_connect_fails(tmp_trestle_dir):
     """Test the sftp fetcher, SSHClient connect should fail."""
+    # Password given:
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
     fetcher._cache_only = False
     with patch('paramiko.SSHClient.connect') as ssh_connect_mock:
         ssh_connect_mock.side_effect = err.TrestleError('stuff')
-        try:
+        with pytest.raises(err.TrestleError):
             fetcher._update_cache()
-        except Exception:
-            assert True
-        else:
-            AssertionError
+    # Password not given (assumes attempt to use ssh-agent):
+    uri = 'sftp://username@some.host/path/to/file.json'
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
+    fetcher._refresh = True
+    fetcher._cache_only = False
+    with patch('paramiko.SSHClient.connect') as ssh_connect_mock:
+        ssh_connect_mock.side_effect = err.TrestleError('stuff')
+        with pytest.raises(err.TrestleError):
+            fetcher._update_cache()
 
 
-def test_sftp_fetcher_open_sftp_fails(tmp_trestle_dir):
+def test_sftp_fetcher_open_sftp_fails(tmp_trestle_dir, monkeypatch):
     """Test the local fetcher."""
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
     fetcher._cache_only = False
-    with patch('paramiko.SSHClient.open_sftp') as sftp_open_mock:
-        sftp_open_mock.side_effect = err.TrestleError('stuff')
-        try:
+    monkeypatch.setenv('SSH_KEY', 'some_key_file')
+    with patch('paramiko.SSHClient.load_host_keys') as load_host_keys_mock:
+        with patch('paramiko.SSHClient.connect') as connect_mock:
+            with patch('paramiko.SSHClient.open_sftp') as open_sftp_mock:
+                open_sftp_mock.side_effect = err.TrestleError('stuff')
+                with pytest.raises(err.TrestleError):
+                    fetcher._update_cache()
+                    ssh_load_host_keys_mock.assert_called_once()
+                    connect_mock.assert_called_once()
+                    open_sftp_mock.assert_called_once()
+
+
+def test_sftp_fetcher_getuser_fails(tmp_trestle_dir, monkeypatch):
+    """Test the local fetcher."""
+    uri = 'sftp://some.host/path/to/file.json'
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
+    fetcher._refresh = True
+    fetcher._cache_only = False
+    # Force call to paramiko.SSHClient.load_host_keys
+    monkeypatch.setenv('SSH_KEY', 'some_key_file')
+    with patch('getpass.getuser') as getuser_mock:
+        with pytest.raises(err.TrestleError):
             fetcher._update_cache()
-        except Exception:
-            assert True
-        else:
-            AssertionError
 
 
-def test_sftp_fetcher_get_fails(tmp_trestle_dir):
+def test_sftp_fetcher_get_fails(tmp_trestle_dir, monkeypatch):
     """Test the local fetcher."""
     uri = 'sftp://username:password@some.host/path/to/file.json'
     fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
     fetcher._refresh = True
     fetcher._cache_only = False
-    with patch('paramiko.sftp_client.SFTPClient.get') as sftp_get_mock:
-        sftp_get_mock.side_effect = err.TrestleError('stuff')
-        try:
-            fetcher._update_cache()
-        except Exception:
-            assert True
-        else:
-            AssertionError
+    # Force call to paramiko.SSHClient.load_host_keys
+    monkeypatch.setenv('SSH_KEY', 'some_key_file')
+    with patch('paramiko.SSHClient.load_host_keys') as load_host_keys_mock:
+        with patch('paramiko.SSHClient.connect') as connect_mock:
+            with patch('paramiko.SFTPClient.get') as get_mock:
+                get_mock.side_effect = err.TrestleError('get fails')
+                with pytest.raises(TrestleError):
+                    fetcher._update_cache()
+                    load_host_keys_mock.assert_called_once()
+                    connect_mock.assert_called_once()
+                    open_sftp_mock.assert_called_once()
+                    get_mock.assert_called_once()
+
+
+def test_sftp_fetcher_bad_uri(tmp_trestle_dir):
+    """Test fetcher factory with bad URI."""
+    for uri in [
+                'sftp://blah.com',
+                'sftp:///path/to/file.json',
+                'sftp://user:pass@hostname.com\\path\\to\\file.json',
+                'sftp://:pass@hostname.com/path/to/file.json'
+    ]:
+        with pytest.raises(TrestleError):
+            cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
 
 
 def test_fetcher_bad_uri(tmp_trestle_dir):
@@ -169,11 +206,8 @@ def test_fetcher_bad_uri(tmp_trestle_dir):
                 'https://',
                 'https:///blah.com',
                 'sftp://',
-                '..',
-                'sftp://blah.com',
-                'sftp:///path/to/file.json',
-                'sftp://user:pass@hostname.com\\path\\to\\file.json',
-                'sftp://:pass@hostname.com/path/to/file.json']:
+                '..'
+    ]:
         with pytest.raises(TrestleError):
             cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), uri, False, False)
 

--- a/tests/trestle/core/settings_test.py
+++ b/tests/trestle/core/settings_test.py
@@ -53,7 +53,8 @@ def test_settings_env_file():
     assert (env_file_path.is_file())
 
     settings = Settings(_env_file=env_file_path)
-    assert(len(settings.GITHUB_TOKENS) == 1)
+    assert (len(settings.GITHUB_TOKENS) == 1)
+
 
 def test_settings_env_variable():
     """Test ability to override .env file settings with environment variable."""
@@ -63,4 +64,4 @@ def test_settings_env_variable():
     token = str(uuid4())
     os.environ["TRESTLE_GITHUB_TOKENS"] = f'{{ "github.com": "{token}" }}'
     settings = Settings(_env_file=env_file_path)
-    assert(settings.GITHUB_TOKENS["github.com"] == token)
+    assert (settings.GITHUB_TOKENS["github.com"] == token)

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -44,6 +44,7 @@ from trestle.core.settings import Settings
 
 logger = logging.getLogger(__name__)
 
+
 class FetcherBase(ABC):
     """FetcherBase - base class for fetching remote oscal objects."""
 
@@ -171,21 +172,33 @@ class HTTPSFetcher(FetcherBase):
         password = self._furl.password
         if username is not None:
             if not username.startswith("{{") or not username.endswith("}}"):
-                logger.error(f'Malformed URI, username must refer to an environment variable using moustache {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: username must refer to an environment variable using moustache {self._uri}')
+                logger.error(
+                    f'Malformed URI, username must refer to an environment variable using moustache {self._uri}'
+                )
+                raise TrestleError(
+                    f'Cache request for invalid input URI: username must refer to an environment variable using moustache {self._uri}'
+                )
             username = username[2:-2]
             if username not in os.environ:
                 logger.error(f'Malformed URI, username not found in the environment {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: username not found in the environment {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: username not found in the environment {self._uri}'
+                )
             self._username = os.environ[username]
         if password is not None:
             if not password.startswith("{{") or not password.endswith("}}"):
-                logger.error(f'Malformed URI, password must refer to an environment variable using moustache {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: password must refer to an environment variable using moustache {self._uri}')
+                logger.error(
+                    f'Malformed URI, password must refer to an environment variable using moustache {self._uri}'
+                )
+                raise TrestleError(
+                    f'Cache request for invalid input URI: password must refer to an environment variable using moustache {self._uri}'
+                )
             password = password[2:-2]
             if password not in os.environ:
                 logger.error(f'Malformed URI, password not found in the environment {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: password not found in the environment {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: password not found in the environment {self._uri}'
+                )
             self._password = os.environ[password]
         if self._username and not self._password:
             logger.error(f'Malformed URI, username found but password missing in URL {self._uri}')
@@ -196,7 +209,9 @@ class HTTPSFetcher(FetcherBase):
         if self._username is not None or self._password is not None:
             if self._furl.scheme != "https":
                 logger.error(f'Malformed URI, basic authentication requires https {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: basic authentication requires https {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: basic authentication requires https {self._uri}'
+                )
         self._furl.username = None
         self._furl.password = None
 
@@ -217,6 +232,7 @@ class HTTPSFetcher(FetcherBase):
         # else:
         #     raise TrestleError(f"Query failed to run by returning code of "
         #                        f"{request.status_code}. {self._query}")
+
 
 class SFTPFetcher(FetcherBase):
     """Fetcher for SFTP content."""
@@ -316,6 +332,7 @@ class SFTPFetcher(FetcherBase):
 # or https://gist.github.com/gbaman/b3137e18c739e0cf98539bf4ec4366ad#gistcomment-2752081
 # or https://gist.github.com/gbaman/b3137e18c739e0cf98539bf4ec4366ad#gistcomment-2865053
 
+
 class GithubFetcher(HTTPSFetcher):
     """Github fetcher which supports both github and GHE URLs."""
 
@@ -336,8 +353,7 @@ class GithubFetcher(HTTPSFetcher):
         params = self._furl.query.params
         #
         if self._furl.username is not None or self._furl.password is not None:
-            raise TrestleError(f"Username/password authentication"
-                               f"is not supported for Github URIs {uri}")
+            raise TrestleError(f"Username/password authentication" f"is not supported for Github URIs {uri}")
         if len(path) < 5:
             raise TrestleError(f"Path in uri appears to be invalid {uri}")
         if params.get("token") != None:
@@ -349,8 +365,7 @@ class GithubFetcher(HTTPSFetcher):
         rev = path[3]
         #
         src_filepath = pathlib.Path("/".join(path[4:]))
-        dst_directory = pathlib.Path(self._trestle_cache_path /
-            host / owner / name).absolute()
+        dst_directory = pathlib.Path(self._trestle_cache_path / host / owner / name).absolute()
         dst_directory.mkdir(parents=True, exist_ok=True)
         self._inst_cache_path = dst_directory / src_filepath
         #
@@ -379,28 +394,27 @@ class GithubFetcher(HTTPSFetcher):
                 }
             }
             """
-        self._variables = {
-            "owner": owner, "name": name, "rev": rev + ":" + str(src_filepath)
-        }
+        self._variables = {"owner": owner, "name": name, "rev": rev + ":" + str(src_filepath)}
 
     def _sync_cache(self) -> None:
-        request = requests.post(self._api,
-            json={"query": self._query, "variables": self._variables},
-            headers={"Authorization": "Bearer " + self._token }
+        request = requests.post(
+            self._api,
+            json={
+                "query": self._query, "variables": self._variables
+            },
+            headers={"Authorization": "Bearer " + self._token}
         )
         if request.status_code == 200:
             result = request.json()
             result = result["data"]["repository"]["object"]
             if result is None:
-                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
-                    str(self._inst_cache_path))
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(self._inst_cache_path))
             if result["isBinary"]:
                 raise NotImplementedError("Binary files are not supported!")
             else:
                 self._inst_cache_path.write_text(result["text"])
         else:
-            raise TrestleError(f"Query failed to run by returning code of "
-                               f"{request.status_code}. {self._query}")
+            raise TrestleError(f"Query failed to run by returning code of " f"{request.status_code}. {self._query}")
 
 
 class FetcherFactory(object):

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -39,6 +39,7 @@ from requests.auth import HTTPBasicAuth
 from trestle.core import const
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.err import TrestleError
+from trestle.core.remote import cache
 from trestle.core.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -218,7 +219,7 @@ class HTTPSFetcher(FetcherBase):
         #                        f"{request.status_code}. {self._query}")
 
 class SFTPFetcher(FetcherBase):
-    """Fetcher for https content."""
+    """Fetcher for SFTP content."""
 
     # STFP method: https://stackoverflow.com/questions/7563496/open-a-remote-file-using-paramiko-in-python-slow#7563551
     # For SFTP fetch into memory.

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -249,12 +249,7 @@ class SFTPFetcher(FetcherBase):
         # Skip any number of back- or forward slashes preceding the url path (u.path)
         path_parent = pathlib.Path(u.path[re.search('[^/\\\\]', u.path).span()[0]:]).parent
         localhost_cached_dir = localhost_cached_dir / path_parent
-        try:
-            localhost_cached_dir.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            logger.error(f'Error creating cache directory {localhost_cached_dir} for {self._uri}')
-            logger.debug(e)
-            raise TrestleError(f'Cache update failure for {self._uri}')
+        localhost_cached_dir.mkdir(parents=True, exist_ok=True)
         self._inst_cache_path = localhost_cached_dir
 
     def _sync_cache(self) -> None:
@@ -270,7 +265,7 @@ class SFTPFetcher(FetcherBase):
                 logger.debug(e)
                 raise TrestleError(f'Cache update failure for {self._uri}')
 
-        elif self._inst_cache_path.exists() and self._refresh:
+        elif 'SSH_KEY' not in os.environ and self._inst_cache_path.exists() and self._refresh:
             try:
                 client.load_system_host_keys()
             except Exception as e:

--- a/trestle/core/settings.py
+++ b/trestle/core/settings.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, BaseSettings, Field
 class Settings(BaseSettings):
     tmp_dir: str = './tmp'
     GITHUB_TOKENS: Optional[Dict[str, str]] = {}
+
     # [catalog]
     # decomposition_rules: List[str] = ['catalog.groups.*.controls.*']
     # create_number_of_groups: int = 2


### PR DESCRIPTION
This completes unit tests for the sftp fetcher -- as far as I could take it a least. Three lines of exception handling are covered only with real SFTP sessions (via ssh-agent, so no passwords) but this test is not portable outside my workstation, so that is not include here. There is a separate issue for integration testing: #316.

Taken as a whole, trestle.core.remote.cache does not pass test and code format/lint due to other remote fetching code, which I did not touch, in the current version of `feature/remote`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[ \] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[ \] All new and existing tests passed.
- \[ \] All commits are signed-off.
