### PR TITLE
get_raw() in base class implemented

### DIFF
--- a/tests/trestle/core/remote/cache_test.py
+++ b/tests/trestle/core/remote/cache_test.py
@@ -30,11 +30,23 @@ from trestle.core.err import TrestleError
 from trestle.core.remote import cache
 from trestle.core.settings import Settings
 from trestle.oscal.catalog import Catalog
+from trestle.utils import fs
 
 
-def test_fetcher_base():
+def test_fetcher_base(tmp_trestle_dir):
     """Test whether fetcher can get an object from the cache."""
-    pass
+    # Fetch from local content, expecting it to be cached and then fetched.
+    rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
+    catalog_file = pathlib.Path(tmp_trestle_dir / f'{rand_str}.json').__str__()
+    catalog_data = generators.generate_sample_model(Catalog)
+    catalog_data.oscal_write(pathlib.Path(catalog_file))
+    saved_data = fs.load_file(pathlib.Path(catalog_file))
+    fetcher = cache.FetcherFactory.get_fetcher(pathlib.Path(tmp_trestle_dir), catalog_file, False, False)
+    # Create/update the cache copy
+    fetcher._refresh = True
+    fetcher._cache_only = False
+    fetched_data = fetcher.get_raw()
+    assert fetched_data == saved_data
 
 
 def test_github_fetcher():

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -39,7 +39,6 @@ from requests.auth import HTTPBasicAuth
 from trestle.core import const
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.err import TrestleError
-from trestle.core.models.file_content_type import FileContentType
 from trestle.core.settings import Settings
 from trestle.utils import fs
 

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -150,8 +150,6 @@ class LocalFetcher(FetcherBase):
 
     def _sync_cache(self) -> None:
         shutil.copy(self._abs_path, self._inst_cache_path)
-        # Update path attribute:
-        # self._inst_cache_path = self._inst_cache_path / pathlib.Path(self._uri).name
 
 
 class HTTPSFetcher(FetcherBase):


### PR DESCRIPTION
Just implemented *get_raw()* base class method. It will update the cache if not *self.in_cache()* or if *self._refresh*. It uses and returns content via *load_file()* in  *trestle.utils.fs*, which should mean it can handle other formats like yaml, and anything else, e.g., xml, if subsequently supported by that module.

Linting, formatting and testing only cover the change. I am not touching other parts of cache.py and its unit tests, e.g., github. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[ \] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[ \] All new and existing tests passed.
- \[ \] All commits are signed-off.
