### PR TITLE
get_oscal() implemented in base class, and tested

### DIFF
--- a/tests/trestle/core/settings_test.py
+++ b/tests/trestle/core/settings_test.py
@@ -53,7 +53,8 @@ def test_settings_env_file():
     assert (env_file_path.is_file())
 
     settings = Settings(_env_file=env_file_path)
-    assert(len(settings.GITHUB_TOKENS) == 1)
+    assert (len(settings.GITHUB_TOKENS) == 1)
+
 
 def test_settings_env_variable():
     """Test ability to override .env file settings with environment variable."""
@@ -63,4 +64,4 @@ def test_settings_env_variable():
     token = str(uuid4())
     os.environ["TRESTLE_GITHUB_TOKENS"] = f'{{ "github.com": "{token}" }}'
     settings = Settings(_env_file=env_file_path)
-    assert(settings.GITHUB_TOKENS["github.com"] == token)
+    assert (settings.GITHUB_TOKENS["github.com"] == token)

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -29,7 +29,6 @@ import re
 import shutil
 import sys
 from abc import ABC, abstractmethod
-from json.decoder import JSONDecodeError
 from typing import Any, Dict, Type
 from urllib import parse
 

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import sys
 from abc import ABC, abstractmethod
+from json.decoder import JSONDecodeError
 from typing import Any, Dict, Type
 from urllib import parse
 
@@ -37,11 +38,15 @@ import requests
 from furl import furl
 from requests.auth import HTTPBasicAuth
 from trestle.core import const
+from trestle.core import parser
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.err import TrestleError
 from trestle.core.settings import Settings
+from trestle.oscal.catalog import Catalog
+from trestle.utils import fs
 
 logger = logging.getLogger(__name__)
+
 
 class FetcherBase(ABC):
     """FetcherBase - base class for fetching remote oscal objects."""
@@ -102,7 +107,17 @@ class FetcherBase(ABC):
 
     def get_oscal(self, model_type: Type[OscalBaseModel]) -> OscalBaseModel:
         """Retrieve the cached file as a particular OSCAL model."""
-        pass
+        cache_file = self._inst_cache_path / pathlib.Path(pathlib.Path(self._uri).name)
+        if cache_file.exists():
+            try:
+                return model_type.oscal_read(cache_file)
+            except Exception as e:
+                logger.error(f'get_oscal failed, JSON error loading cache file for {self._uri} as {model_type}')
+                logger.debug(e)
+                raise TrestleError(f'get_oscal failure for {self._uri}') from e
+        else:
+            logger.error(f'get_oscal error, no cached file for {self._uri}')
+            raise TrestleError(f'get_oscal failure for {self._uri}')
 
     def in_cache(self) -> bool:
         """Return whether object is contained within the cache or not."""
@@ -170,21 +185,33 @@ class HTTPSFetcher(FetcherBase):
         password = self._furl.password
         if username is not None:
             if not username.startswith("{{") or not username.endswith("}}"):
-                logger.error(f'Malformed URI, username must refer to an environment variable using moustache {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: username must refer to an environment variable using moustache {self._uri}')
+                logger.error(
+                    f'Malformed URI, username must refer to an environment variable using moustache {self._uri}'
+                )
+                raise TrestleError(
+                    f'Cache request for invalid input URI: username must refer to an environment variable using moustache {self._uri}'
+                )
             username = username[2:-2]
             if username not in os.environ:
                 logger.error(f'Malformed URI, username not found in the environment {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: username not found in the environment {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: username not found in the environment {self._uri}'
+                )
             self._username = os.environ[username]
         if password is not None:
             if not password.startswith("{{") or not password.endswith("}}"):
-                logger.error(f'Malformed URI, password must refer to an environment variable using moustache {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: password must refer to an environment variable using moustache {self._uri}')
+                logger.error(
+                    f'Malformed URI, password must refer to an environment variable using moustache {self._uri}'
+                )
+                raise TrestleError(
+                    f'Cache request for invalid input URI: password must refer to an environment variable using moustache {self._uri}'
+                )
             password = password[2:-2]
             if password not in os.environ:
                 logger.error(f'Malformed URI, password not found in the environment {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: password not found in the environment {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: password not found in the environment {self._uri}'
+                )
             self._password = os.environ[password]
         if self._username and not self._password:
             logger.error(f'Malformed URI, username found but password missing in URL {self._uri}')
@@ -195,7 +222,9 @@ class HTTPSFetcher(FetcherBase):
         if self._username is not None or self._password is not None:
             if self._furl.scheme != "https":
                 logger.error(f'Malformed URI, basic authentication requires https {self._uri}')
-                raise TrestleError(f'Cache request for invalid input URI: basic authentication requires https {self._uri}')
+                raise TrestleError(
+                    f'Cache request for invalid input URI: basic authentication requires https {self._uri}'
+                )
         self._furl.username = None
         self._furl.password = None
 
@@ -216,6 +245,7 @@ class HTTPSFetcher(FetcherBase):
         # else:
         #     raise TrestleError(f"Query failed to run by returning code of "
         #                        f"{request.status_code}. {self._query}")
+
 
 class SFTPFetcher(FetcherBase):
     """Fetcher for https content."""
@@ -320,6 +350,7 @@ class SFTPFetcher(FetcherBase):
 # or https://gist.github.com/gbaman/b3137e18c739e0cf98539bf4ec4366ad#gistcomment-2752081
 # or https://gist.github.com/gbaman/b3137e18c739e0cf98539bf4ec4366ad#gistcomment-2865053
 
+
 class GithubFetcher(HTTPSFetcher):
     """Github fetcher which supports both github and GHE URLs."""
 
@@ -340,8 +371,7 @@ class GithubFetcher(HTTPSFetcher):
         params = self._furl.query.params
         #
         if self._furl.username is not None or self._furl.password is not None:
-            raise TrestleError(f"Username/password authentication"
-                               f"is not supported for Github URIs {uri}")
+            raise TrestleError(f"Username/password authentication" f"is not supported for Github URIs {uri}")
         if len(path) < 5:
             raise TrestleError(f"Path in uri appears to be invalid {uri}")
         if params.get("token") != None:
@@ -353,8 +383,7 @@ class GithubFetcher(HTTPSFetcher):
         rev = path[3]
         #
         src_filepath = pathlib.Path("/".join(path[4:]))
-        dst_directory = pathlib.Path(self._trestle_cache_path /
-            host / owner / name).absolute()
+        dst_directory = pathlib.Path(self._trestle_cache_path / host / owner / name).absolute()
         dst_directory.mkdir(parents=True, exist_ok=True)
         self._inst_cache_path = dst_directory / src_filepath
         #
@@ -383,28 +412,27 @@ class GithubFetcher(HTTPSFetcher):
                 }
             }
             """
-        self._variables = {
-            "owner": owner, "name": name, "rev": rev + ":" + str(src_filepath)
-        }
+        self._variables = {"owner": owner, "name": name, "rev": rev + ":" + str(src_filepath)}
 
     def _sync_cache(self) -> None:
-        request = requests.post(self._api,
-            json={"query": self._query, "variables": self._variables},
-            headers={"Authorization": "Bearer " + self._token }
+        request = requests.post(
+            self._api,
+            json={
+                "query": self._query, "variables": self._variables
+            },
+            headers={"Authorization": "Bearer " + self._token}
         )
         if request.status_code == 200:
             result = request.json()
             result = result["data"]["repository"]["object"]
             if result is None:
-                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT),
-                    str(self._inst_cache_path))
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(self._inst_cache_path))
             if result["isBinary"]:
                 raise NotImplementedError("Binary files are not supported!")
             else:
                 self._inst_cache_path.write_text(result["text"])
         else:
-            raise TrestleError(f"Query failed to run by returning code of "
-                               f"{request.status_code}. {self._query}")
+            raise TrestleError(f"Query failed to run by returning code of " f"{request.status_code}. {self._query}")
 
 
 class FetcherFactory(object):

--- a/trestle/core/settings.py
+++ b/trestle/core/settings.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, BaseSettings, Field
 class Settings(BaseSettings):
     tmp_dir: str = './tmp'
     GITHUB_TOKENS: Optional[Dict[str, str]] = {}
+
     # [catalog]
     # decomposition_rules: List[str] = ['catalog.groups.*.controls.*']
     # create_number_of_groups: int = 2


### PR DESCRIPTION
get_oscal() simply users oscal_read() for the given model_type. Basic validation for:
* existence of the cache_file pointed to by the *self._uri* base (file) name inside *self._inst_cache_path*
* success of oscal_read()

Caveat 1: It is arguable whether it is desirable to have *_update_cache()* update *self._inst_cache_path* with the final cache file rather than just the containing directory. At this point, I am assuming the latter. If we go with the former, then this code will need to change.

Caveat 2: From the current commit 3dfe3b91c0 of `feature/remote`, I did not touch code except *get_oscal()*. However, I think make code-format updated *settings.py* and *settings_test.py*, as well as other parts of *cache.py* that I did not edit, such as the *HTTPSFetcher()* and the *GithubFetcher* classes.

## Types of changes

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[ \] All new and existing tests passed.
- \[ \] All commits are signed-off.
