### PR TITLE
Utility to transform OSCO yaml data into OSCAL observations json data.

### DIFF
--- a/tests/data/tasks/osco/output/osco-pod-oscal-arp.json
+++ b/tests/data/tasks/osco/output/osco-pod-oscal-arp.json
@@ -1,0 +1,8756 @@
+{
+  "assessment-results-partial": {
+    "observations": [
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+        "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notselected"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+        "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+        "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+        "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_configure_network_policies"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+        "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+        "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+        "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_service"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+        "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_controller_use_service_account"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+        "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_controller_bind_address"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+        "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+        "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_controller_service_account_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+        "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+        "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+        "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+        "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+        "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+        "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+        "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+        "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+        "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notselected"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_unique_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_cert_file"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_auto_tls"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+        "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_etcd_key_file"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+        "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "notchecked"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_port"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cert"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_client_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_profiling"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_token_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_request_timeout"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_basic_auth"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_key"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "pass"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+        "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+        "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+        "methods": [
+          "TEST-AUTOMATED"
+        ],
+        "subjects": [
+          {
+            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "component",
+            "title": "Red Hat OpenShift Kubernetes"
+          },
+          {
+            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+            "type": "inventory-item",
+            "title": "Pod",
+            "props": [
+              {
+                "name": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              },
+              {
+                "name": "cluster-name",
+                "value": "ROKS-OpenSCAP-1"
+              },
+              {
+                "name": "cluster-type",
+                "value": "openshift"
+              },
+              {
+                "name": "cluster-region",
+                "value": "us-south"
+              }
+            ]
+          }
+        ],
+        "relevant-evidence": [
+          {
+            "href": "https://github.mycorp.com/degenaro/evidence-locker",
+            "description": "Evidence location.",
+            "props": [
+              {
+                "name": "rule",
+                "ns": "dns://xccdf",
+                "class": "id",
+                "value": "xccdf_org.ssgproject.content_rule_api_server_secure_port"
+              },
+              {
+                "name": "time",
+                "ns": "dns://xccdf",
+                "class": "timestamp",
+                "value": "2020-08-03T02:26:26+00:00"
+              },
+              {
+                "name": "result",
+                "ns": "dns://xccdf",
+                "class": "result",
+                "value": "fail"
+              },
+              {
+                "name": "target",
+                "ns": "dns://xccdf",
+                "class": "target",
+                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/data/tasks/osco/output/osco-pod-oscal.json
+++ b/tests/data/tasks/osco/output/osco-pod-oscal.json
@@ -1,8756 +1,8754 @@
 {
-  "assessment-results-partial": {
-    "observations": [
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
-        "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notselected"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
-        "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
-        "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
-        "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_configure_network_policies"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
-        "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
-        "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
-        "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_service"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
-        "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_controller_use_service_account"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
-        "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_controller_bind_address"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
-        "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
-        "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_controller_service_account_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
-        "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
-        "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
-        "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
-        "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
-        "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
-        "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
-        "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
-        "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
-        "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
-        "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notselected"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_unique_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_cert_file"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_auto_tls"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
-        "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_etcd_key_file"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
-        "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
-        "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "notchecked"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_port"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cert"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_client_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_profiling"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_token_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_request_timeout"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_basic_auth"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_key"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "pass"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
-        "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
-        "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
-        "methods": [
-          "TEST-AUTOMATED"
-        ],
-        "subjects": [
-          {
-            "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-            "type": "component",
-            "title": "Red Hat OpenShift Kubernetes"
-          },
-          {
-            "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-            "type": "inventory-item",
-            "title": "Pod",
-            "props": [
-              {
-                "name": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              },
-              {
-                "name": "cluster-name",
-                "value": "ROKS-OpenSCAP-1"
-              },
-              {
-                "name": "cluster-type",
-                "value": "openshift"
-              },
-              {
-                "name": "cluster-region",
-                "value": "us-south"
-              }
-            ]
-          }
-        ],
-        "relevant-evidence": [
-          {
-            "href": "https://github.mycorp.com/degenaro/evidence-locker",
-            "description": "Evidence location.",
-            "props": [
-              {
-                "name": "rule",
-                "ns": "dns://xccdf",
-                "class": "id",
-                "value": "xccdf_org.ssgproject.content_rule_api_server_secure_port"
-              },
-              {
-                "name": "time",
-                "ns": "dns://xccdf",
-                "class": "timestamp",
-                "value": "2020-08-03T02:26:26+00:00"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "result",
-                "value": "fail"
-              },
-              {
-                "name": "target",
-                "ns": "dns://xccdf",
-                "class": "target",
-                "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+  "observations": [
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+      "description": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_ocp_idp_no_htpasswd"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notselected"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+      "description": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_accounts_restrict_service_account_tokens"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+      "description": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_accounts_unique_service_account"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+      "description": "xccdf_org.ssgproject.content_rule_configure_network_policies",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_configure_network_policies"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+      "description": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_configure_network_policies_namespaces"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+      "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+      "description": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_secrets_no_environment_variables"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_service"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_proxy_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_service",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_service"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubelet_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_worker_service"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_proxy_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_proxy_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_worker_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_worker_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubelet_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kubelet_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+      "description": "xccdf_org.ssgproject.content_rule_controller_use_service_account",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_controller_use_service_account"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+      "description": "xccdf_org.ssgproject.content_rule_controller_bind_address",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_controller_bind_address"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+      "description": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_controller_service_account_private_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+      "description": "xccdf_org.ssgproject.content_rule_controller_service_account_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_controller_service_account_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+      "description": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_controller_rotate_kubelet_server_certs"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_process_id_namespace"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_root_containers"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_privilege_escalation"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_ipc_namespace"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_container_allowed_capabilities"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_net_raw_capability"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_network_namespace"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+      "description": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_drop_container_capabilities"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+      "description": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_scc_limit_privileged_containers"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+      "description": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_general_configure_imagepolicywebhook"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_limit_secrets_access"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_wildcard_use"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_pod_creation_access"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+      "description": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_rbac_limit_cluster_admin"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_client_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_disable_readonly_port"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_anonymous_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_server_cert_rotation"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_streaming_connections"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_authorization_mode"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_event_creation"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_enable_client_cert_rotation"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+      "description": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cert"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+      "description": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_ocp_allowed_registries_for_import"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notselected"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_client_cert_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_key_file"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_cert_file"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_unique_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_unique_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_auto_tls"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_peer_client_cert_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_cert_file",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_cert_file"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_auto_tls",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_auto_tls"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+      "description": "xccdf_org.ssgproject.content_rule_etcd_key_file",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_etcd_key_file"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_cni_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_etcd_member"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_etcd_member"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_scheduler"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_apiserver"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_apiserver"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_openvswitch"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_controller_manager"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_controller_manager_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_scheduler_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_openvswitch"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_var_lib_etcd"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_var_lib_etcd"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_controller_manager_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_scheduler_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kube_controller_manager"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_scheduler"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_controller_manager"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_kube_apiserver"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_cni_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_kube_scheduler"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_permissions_controller_manager_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_cni_conf"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_openvswitch"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+      "description": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_groupowner_etcd_member"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+      "description": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_file_owner_scheduler_kubeconfig"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "notchecked"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_port",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_port"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_private_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cert",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cert"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_client_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_client_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_path"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_tls_cipher_suites"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_EventRateLimit"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_authorization_mode"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxage"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_profiling",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_profiling"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_ServiceAccount"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysAdmit"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_cipher"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_token_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_token_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_anonymous_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_ca"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_encryption_provider_config"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_request_timeout",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_request_timeout"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxsize"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NodeRestriction"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_SecurityContextDeny"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_PodSecurityPolicy"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_basic_auth",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_basic_auth"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_service_account_public_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_key",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_key"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_AlwaysPullImages"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_client_cert"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_audit_log_maxbackup"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_https"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_etcd_cert"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_insecure_bind_address"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "pass"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_kubelet_certificate_authority"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_admission_control_plugin_NamespaceLifecycle"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "d4cf7a88-cea7-4667-9924-8d278dc843df",
+      "title": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+      "description": "xccdf_org.ssgproject.content_rule_api_server_secure_port",
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "type": "component",
+          "title": "Red Hat OpenShift Kubernetes"
+        },
+        {
+          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+          "type": "inventory-item",
+          "title": "Pod",
+          "props": [
+            {
+              "name": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            },
+            {
+              "name": "cluster-name",
+              "value": "ROKS-OpenSCAP-1"
+            },
+            {
+              "name": "cluster-type",
+              "value": "openshift"
+            },
+            {
+              "name": "cluster-region",
+              "value": "us-south"
+            }
+          ]
+        }
+      ],
+      "relevant-evidence": [
+        {
+          "href": "https://github.mycorp.com/degenaro/evidence-locker",
+          "description": "Evidence location.",
+          "props": [
+            {
+              "name": "rule",
+              "ns": "dns://xccdf",
+              "class": "id",
+              "value": "xccdf_org.ssgproject.content_rule_api_server_secure_port"
+            },
+            {
+              "name": "time",
+              "ns": "dns://xccdf",
+              "class": "timestamp",
+              "value": "2020-08-03T02:26:26+00:00"
+            },
+            {
+              "name": "result",
+              "ns": "dns://xccdf",
+              "class": "result",
+              "value": "fail"
+            },
+            {
+              "name": "target",
+              "ns": "dns://xccdf",
+              "class": "target",
+              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tests/trestle/utils/osco_test.py
+++ b/tests/trestle/utils/osco_test.py
@@ -39,9 +39,22 @@ def test_function_osco_get_observations(tmp_path):
     with patch('uuid.uuid4') as mock_uuid4:
         mock_uuid4.return_value = mock_uuid4_value
         observations, analysis = osco.get_observations(idata, metadata)
-    expected = _load_json(stem_out, 'osco-pod-oscal.json')
-    tfile = tmp_path / 'osco-pod-oscal.json'
+    expected = _load_json(stem_out, 'osco-pod-oscal-arp.json')
+    tfile = tmp_path / 'osco-pod-oscal-arp.json'
     observations.oscal_write(tfile)
+    actual = _load_json(tmp_path, 'osco-pod-oscal-arp.json')
+    assert actual == expected
+
+
+def test_function_osco_get_observations_json(tmp_path):
+    """Test OSCO to OSCAL transformation."""
+    idata = _load_yaml(stem_in, 'ssg-ocp4-ds-cis-111.222.333.444-pod.yaml')
+    metadata = _load_yaml(stem_in, 'oscal-metadata.yaml')
+    with patch('uuid.uuid4') as mock_uuid4:
+        mock_uuid4.return_value = mock_uuid4_value
+        observations, analysis = osco.get_observations_json(idata, metadata)
+    expected = _load_json(stem_out, 'osco-pod-oscal.json')
+    _dump_json(tmp_path, 'osco-pod-oscal.json', observations)
     actual = _load_json(tmp_path, 'osco-pod-oscal.json')
     assert actual == expected
 
@@ -137,3 +150,10 @@ def _load_json(stem, filename):
     with open(ifile, 'r', encoding='utf-8') as fp:
         content = json.load(fp)
     return content
+
+
+def _dump_json(stem, filename, content):
+    """Provide utility to dump json."""
+    ifile = pathlib.Path('') / stem / filename
+    with open(ifile, 'w', encoding='utf-8') as fp:
+        content = json.dump(content, fp, indent=2)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x] I have added tests to cover my changes.
- \[x] All new and existing tests passed.
- \[x] All commits are signed-off.

## Description

Provide additional OSCO utility to transform .yaml into OSCAL observations as json. Utility currently provides transformation to trestle objects only, which requires utility user to employ trestle objects perhaps unnecessarily.

- new `trestle.utils.osco.get_observations_json()` wraps existing `get_observations()`.
- unit test case of new function, maintaining 100% coverage.

Closes #347.
