### PR TITLE
Validation to test for duplicates added to trestle import

### DIFF
--- a/tests/trestle/core/commands/import__test.py
+++ b/tests/trestle/core/commands/import__test.py
@@ -115,8 +115,7 @@ def test_import_run_rollback(tmp_trestle_dir: pathlib.Path) -> None:
     j = importcmd.ImportCmd()
     args = argparse.Namespace(file=dup_file_name, output=f'dup-{rand_str}', verbose=True)
     with patch('trestle.core.models.plans.Plan.rollback') as rollback_mock:
-        # For some reason, simulate() call incorrectly takes this mock side_effect.
-        rollback_mock.side_effect = err.TrestleError('rollback error')
+        rollback_mock.side_effect = [None, err.TrestleError('rollback error')]
         rc = j._run(args)
         assert rc > 0
 

--- a/tests/trestle/core/commands/import__test.py
+++ b/tests/trestle/core/commands/import__test.py
@@ -59,7 +59,7 @@ def test_import_cmd(tmp_trestle_dir: pathlib.Path) -> None:
 
 
 def test_import_run(tmp_trestle_dir: pathlib.Path) -> None:
-    """Test successful _run() on valid and invalid."""
+    """Test successful _run() on valid input."""
     rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
     catalog_file = f'{tmp_trestle_dir.parent}/{rand_str}.json'
     catalog_data = generators.generate_sample_model(trestle.oscal.catalog.Catalog)
@@ -68,6 +68,57 @@ def test_import_run(tmp_trestle_dir: pathlib.Path) -> None:
     args = argparse.Namespace(file=catalog_file, output='imported', verbose=True)
     rc = i._run(args)
     assert rc == 0
+
+
+def test_import_run_rollback(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test successful _run() on invalid input with good or failed rollback."""
+    dup_cat = {
+        'catalog': {
+            'uuid': '525f94af-8007-4376-8069-aa40179e0f6e',
+            'metadata': {
+                'title': 'Generic catalog created by trestle.',
+                'last-modified': '2020-12-11T02:04:51.053+00:00',
+                'version': '0.0.0',
+                'oscal-version': 'v1.0.0-milestone3'
+            },
+            'back-matter': {
+                'resources': [
+                    {
+                        'uuid': 'b1101385-9e36-44a3-ba03-98b6ebe0a367'
+                    }, {
+                        'uuid': 'b1101385-9e36-44a3-ba03-98b6ebe0a367'
+                    }
+                ]
+            }
+        }
+    }
+    rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
+    dup_file_name = f'{tmp_trestle_dir.parent}/dup-{rand_str}.json'
+    dup_file = pathlib.Path(dup_file_name).open('w+', encoding='utf8')
+    dup_file.write(json.dumps(dup_cat))
+    dup_file.close()
+    j = importcmd.ImportCmd()
+    args = argparse.Namespace(file=dup_file_name, output=f'dup-{rand_str}', verbose=True)
+    # 1. Validation rejects above import, which results in non-zero exit code for import.
+    rc = j._run(args)
+    assert rc > 0
+    rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
+    # 2. ValidateCmd raises run (mocked), so import returns non-zero exit code.
+    j = importcmd.ImportCmd()
+    args = argparse.Namespace(file=dup_file_name, output=f'dup-{rand_str}', verbose=True)
+    with patch('trestle.core.commands.validate.ValidateCmd._run') as validate_import_mock:
+        validate_import_mock.side_effect = err.TrestleError('validate run error')
+        rc = j._run(args)
+        assert rc > 0
+    rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
+    # 3. Rollback raises exception, so import returns non-zero exit code:
+    j = importcmd.ImportCmd()
+    args = argparse.Namespace(file=dup_file_name, output=f'dup-{rand_str}', verbose=True)
+    with patch('trestle.core.models.plans.Plan.rollback') as rollback_mock:
+        # For some reason, simulate() call incorrectly takes this mock side_effect.
+        rollback_mock.side_effect = err.TrestleError('rollback error')
+        rc = j._run(args)
+        assert rc > 0
 
 
 def test_import_clash_on_output(tmp_trestle_dir: pathlib.Path) -> None:

--- a/trestle/core/commands/import_.py
+++ b/trestle/core/commands/import_.py
@@ -21,9 +21,8 @@ from json.decoder import JSONDecodeError
 
 from ilcli import Command  # type: ignore
 
-import trestle.core.validator_factory as vfact
-from trestle.core import parser
 import trestle.core.commands.validate as validatecmd
+from trestle.core import parser
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
@@ -175,7 +174,7 @@ class ImportCmd(Command):
             rc = validatecmd.ValidateCmd()._run(args)
         except TrestleError as err:
             logger.debug(f'validator.validate() raised exception: {err}')
-            logger.error(f'Import of input file {str(input_file.absolute())} failed, validation failed with error: {err}')
+            logger.error(f'Import of {str(input_file.absolute())} failed, validation failed with error: {err}')
             rollback = True
         else:
             if rc > 0:
@@ -183,13 +182,13 @@ class ImportCmd(Command):
                 logger.error(f'Validation of imported file {desired_model_path.absolute()} failed')
                 rollback = True
 
-        if rollback == True:
+        if rollback:
             logger.debug(f'Rolling back import of {str(input_file.absolute())} to {desired_model_path.absolute()}')
             try:
                 import_plan.rollback()
             except TrestleError as err:
                 logger.debug(f'Failed rollback attempt with error: {err}')
-                logger.error(f'Failed to rollback: {err}. Remove {desired_model_path.absolute()} to resolve inconsistent state.')
+                logger.error(f'Failed to rollback: {err}. Remove {desired_model_path.absolute()} to resolve state.')
             return 1
         else:
             logger.debug(f'Successful rollback of import to {desired_model_path.absolute()}')

--- a/trestle/core/commands/import_.py
+++ b/trestle/core/commands/import_.py
@@ -21,7 +21,9 @@ from json.decoder import JSONDecodeError
 
 from ilcli import Command  # type: ignore
 
+import trestle.core.validator_factory as vfact
 from trestle.core import parser
+import trestle.core.commands.validate as validatecmd
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
@@ -166,5 +168,31 @@ class ImportCmd(Command):
             logger.error(f'Import failed, error in actual import operation: {err}')
             return 1
 
-        # 7. Leave the rest to trestle split
+        # 7. Validate the imported file, rollback if unsuccessful:
+        args = argparse.Namespace(file=desired_model_path.absolute(), mode='duplicates', item='uuid', verbose=True)
+        rollback = False
+        try:
+            rc = validatecmd.ValidateCmd()._run(args)
+        except TrestleError as err:
+            logger.debug(f'validator.validate() raised exception: {err}')
+            logger.error(f'Import of input file {str(input_file.absolute())} failed, validation failed with error: {err}')
+            rollback = True
+        else:
+            if rc > 0:
+                logger.debug(f'validator.validate() found duplicates in {desired_model_path.absolute()}')
+                logger.error(f'Validation of imported file {desired_model_path.absolute()} failed')
+                rollback = True
+
+        if rollback == True:
+            logger.debug(f'Rolling back import of {str(input_file.absolute())} to {desired_model_path.absolute()}')
+            try:
+                import_plan.rollback()
+            except TrestleError as err:
+                logger.debug(f'Failed rollback attempt with error: {err}')
+                logger.error(f'Failed to rollback: {err}. Remove {desired_model_path.absolute()} to resolve inconsistent state.')
+            return 1
+        else:
+            logger.debug(f'Successful rollback of import to {desired_model_path.absolute()}')
+        # 8. Leave the rest to trestle split
+
         return 0


### PR DESCRIPTION
An import will use a trestle validation to roll back if the latter rejects the imported content. There is some inefficiency in the way validation only works on in-project content, but that's all we have at present. The alternative is to write separate validation code prior to import. Additionally, validation only checks for uuid duplicates. Should other modes become available, trestle import should be modified to use them.

## Types of changes

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x\] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[x\] All commits are signed-off.

This PR, if merged, closes #263.