### PR TITLE
Added bulk operations for assemble

### DIFF
--- a/tests/trestle/core/commands/assemble_test.py
+++ b/tests/trestle/core/commands/assemble_test.py
@@ -111,3 +111,29 @@ def test_assemble_missing_top_model(testdata_dir: pathlib.Path, tmp_trestle_dir:
     with mock.patch.object(sys, 'argv', testargs):
         rc = Trestle().run()
         assert rc == 1
+
+
+def test_assemble_catalog_all(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path) -> None:
+    """Test assembling all catalogs in trestle dir."""
+    shutil.rmtree(pathlib.Path('dist'))
+    catalogs_dir = pathlib.Path('catalogs')
+    my_names = ['mycatalog1', 'mycatalog2', 'mycatalog3']
+    for my_name in my_names:
+        test_data_source = testdata_dir / 'split_merge/step4_split_groups_array/catalogs/mycatalog'
+        shutil.copytree(test_data_source, catalogs_dir / my_name)
+
+    testargs = ['trestle', 'assemble', 'catalog', '-t', '-x', 'json']
+    with mock.patch.object(sys, 'argv', testargs):
+        rc = Trestle().run()
+        assert rc == 0
+
+    # Read assembled model
+    for my_name in my_names:
+        _, _, expected_model = load_distributed(catalogs_dir / f'{my_name}/catalog.json')
+        actual_model = Catalog.oscal_read(pathlib.Path(f'dist/catalogs/{my_name}.json'))
+        assert actual_model == expected_model
+
+    testargs = ['trestle', 'assemble', 'profile', '-t', '-x', 'json']
+    with mock.patch.object(sys, 'argv', testargs):
+        rc = Trestle().run()
+        assert rc == 1

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -61,7 +61,6 @@ class CatalogCmd(Command):
 
     def _run(self, args: argparse.Namespace) -> int:
         """Assemble a catalog."""
-        logger.info(f'Assembling catalog titled: {args.name}')
         return AssembleCmd.assemble_model(self.name, catalog.Catalog, args)
 
 
@@ -71,7 +70,6 @@ class ProfileCmd(Command):
     name = 'profile'
 
     def _run(self, args: argparse.Namespace) -> int:
-        logger.info(f'Assembling profile titled: {args.name}')
         return AssembleCmd.assemble_model(self.name, profile.Profile, args)
 
 
@@ -146,7 +144,8 @@ class AssembleCmd(Command):
     ]
 
     def _init_arguments(self) -> None:
-        self.add_argument('-n', '--name', help='Name of the model to assemble.', required=True)
+        self.add_argument('-n', '--name', help='Name of a single model to assemble.')
+        self.add_argument('-t', '--type', action='store_true', help='Assemble all models of the given type.')
         self.add_argument(
             '-x', '--extension', help='Type of file output.', choices=['json', 'yaml', 'yml'], default='json'
         )
@@ -155,6 +154,7 @@ class AssembleCmd(Command):
     def assemble_model(cls, model_alias: str, object_type: Type[TLO], args: argparse.Namespace) -> int:
         """Assemble a top level OSCAL model within the trestle dist directory."""
         log.set_log_level_from_args(args)
+        logger.info(f'Assembling models of type {model_alias}.')
         trestle_root = fs.get_trestle_project_root(Path.cwd())
         if not trestle_root:
             logger.error(f'Current working directory {Path.cwd()} is not with a trestle project.')
@@ -163,45 +163,58 @@ class AssembleCmd(Command):
             logger.error(f'Current working directory {Path.cwd()} is not the top level trestle project directory.')
             return 1
 
-        # contruct path to the model file name
-        root_model_dir = Path.cwd() / fs.model_type_to_model_dir(model_alias)
-        try:
-            model_file_type = fs.get_contextual_file_type(root_model_dir / args.name)
-        except Exception as e:
-            logger.error('No files found in the specified model directory.')
-            logger.debug(e)
+        model_names = []
+        if 'name' in args and args.name:
+            model_names = [args.name]
+            logger.info(f'Assembling single model of type {model_alias}: {args.name}.')
+        else:
+            model_names = fs.get_models_of_type(model_alias)
+            nmodels = len(model_names)
+            logger.info(f'Assembling {nmodels} found models of type {model_alias}.')
+        if len(model_names) == 0:
+            logger.error(f'No models found to assemble of type {model_alias}.')
             return 1
 
-        model_file_name = f'{model_alias}{FileContentType.to_file_extension(model_file_type)}'
-        root_model_filepath = root_model_dir / args.name / model_file_name
+        for model_name in model_names:
+            # contruct path to the model file name
+            root_model_dir = Path.cwd() / fs.model_type_to_model_dir(model_alias)
+            try:
+                model_file_type = fs.get_contextual_file_type(root_model_dir / model_name)
+            except Exception as e:
+                logger.error('No files found in the specified model directory.')
+                logger.debug(e)
+                return 1
 
-        if not root_model_filepath.exists():
-            logger.error(f'No top level model file at {root_model_dir}')
-            return 1
+            model_file_name = f'{model_alias}{FileContentType.to_file_extension(model_file_type)}'
+            root_model_filepath = root_model_dir / model_name / model_file_name
 
-        # distributed load
-        _, _, assembled_model = load_distributed(root_model_filepath)
-        plural_alias = fs.model_type_to_model_dir(model_alias)
+            if not root_model_filepath.exists():
+                logger.error(f'No top level model file at {root_model_dir}')
+                return 1
 
-        assembled_model_dir = trestle_root / const.TRESTLE_DIST_DIR / plural_alias
+            # distributed load
+            _, _, assembled_model = load_distributed(root_model_filepath)
+            plural_alias = fs.model_type_to_model_dir(model_alias)
 
-        assembled_model_filepath = assembled_model_dir / f'{args.name}.{args.extension}'
+            assembled_model_dir = trestle_root / const.TRESTLE_DIST_DIR / plural_alias
 
-        plan = Plan()
-        plan.add_action(CreatePathAction(assembled_model_filepath, True))
-        plan.add_action(
-            WriteFileAction(
-                assembled_model_filepath,
-                Element(assembled_model),
-                FileContentType.to_content_type(f'.{args.extension}')
+            assembled_model_filepath = assembled_model_dir / f'{model_name}.{args.extension}'
+
+            plan = Plan()
+            plan.add_action(CreatePathAction(assembled_model_filepath, True))
+            plan.add_action(
+                WriteFileAction(
+                    assembled_model_filepath,
+                    Element(assembled_model),
+                    FileContentType.to_content_type(f'.{args.extension}')
+                )
             )
-        )
 
-        try:
-            plan.simulate()
-            plan.execute()
-            return 0
-        except Exception as e:
-            logger.error('Unknown error executing trestle create operations. Rolling back.')
-            logger.debug(e)
-            return 1
+            try:
+                plan.simulate()
+                plan.execute()
+            except Exception as e:
+                logger.error('Unknown error executing trestle create operations. Rolling back.')
+                logger.debug(e)
+                return 1
+        return 0


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[x] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x] I have added tests to cover my changes.
- \[x] All new and existing tests passed.
- \[x] All commits are signed-off.

Assemble can now perform for all models of specified type.  Currently the Plan created is for each model assembled - rather than for the entire operation.  It can be done for the entire operation, but having it succeed as much as possible is perhaps better.