### PR TITLE
Allow assemble to succeed when no model is found.

### DIFF
--- a/tests/trestle/core/commands/assemble_test.py
+++ b/tests/trestle/core/commands/assemble_test.py
@@ -134,6 +134,7 @@ def test_assemble_catalog_all(testdata_dir: pathlib.Path, tmp_trestle_dir: pathl
         assert actual_model == expected_model
 
     testargs = ['trestle', 'assemble', 'profile', '-t', '-x', 'json']
+    # Tests should pass on empty set of directories.
     with mock.patch.object(sys, 'argv', testargs):
         rc = Trestle().run()
-        assert rc == 1
+        assert rc == 0

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -172,8 +172,8 @@ class AssembleCmd(Command):
             nmodels = len(model_names)
             logger.info(f'Assembling {nmodels} found models of type {model_alias}.')
         if len(model_names) == 0:
-            logger.error(f'No models found to assemble of type {model_alias}.')
-            return 1
+            logger.info(f'No models found to assemble of type {model_alias}.')
+            return 0
 
         for model_name in model_names:
             # contruct path to the model file name


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[x\] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[x\] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[x\] All commits are signed-off.

This fix is relatively simple. The purpose is to improve the usability of assemble for use within a CI/CD pipeline. Specifically lack of a model is not a failure criteria. This allows for standardized models / scripts to be used rather than boutique 'per usecase' scripts.
