### PR TITLE
Improving documentation for commands in trestle CLI

### DIFF
--- a/trestle/cli.py
+++ b/trestle/cli.py
@@ -15,11 +15,10 @@
 """Starting point for the Trestle CLI."""
 import logging
 
-from ilcli import Command  # type: ignore
-
 from trestle import __version__
 from trestle.core.commands.add import AddCmd
 from trestle.core.commands.assemble import AssembleCmd
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.create import CreateCmd
 from trestle.core.commands.import_ import ImportCmd
 from trestle.core.commands.init import InitCmd
@@ -34,7 +33,7 @@ from trestle.utils import log
 logger = logging.getLogger('trestle')
 
 
-class Trestle(Command):
+class Trestle(CommandPlusDocs):
     """Manage OSCAL files in a human friendly manner."""
 
     subcommands = [

--- a/trestle/core/commands/add.py
+++ b/trestle/core/commands/add.py
@@ -19,12 +19,11 @@ import logging
 import pathlib
 from typing import List
 
-from ilcli import Command  # type: ignore
-
 import trestle.core.const as const
 import trestle.core.err as err
 import trestle.core.generators as gens
 from trestle.core import utils
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.models.actions import CreatePathAction, UpdateAction, WriteFileAction
 from trestle.core.models.elements import Element, ElementPath
 from trestle.core.models.file_content_type import FileContentType
@@ -35,7 +34,7 @@ from trestle.utils import log
 logger = logging.getLogger(__name__)
 
 
-class AddCmd(Command):
+class AddCmd(CommandPlusDocs):
     """Add a subcomponent to an existing model."""
 
     name = 'add'

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -20,9 +20,8 @@ import logging
 from pathlib import Path
 from typing import Type, TypeVar
 
-from ilcli import Command  # type: ignore
-
 from trestle.core import const
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
 from trestle.core.models.file_content_type import FileContentType
@@ -54,7 +53,7 @@ TLO = TypeVar(
 )
 
 
-class CatalogCmd(Command):
+class CatalogCmd(CommandPlusDocs):
     """Assemble a catalog."""
 
     name = 'catalog'
@@ -64,7 +63,7 @@ class CatalogCmd(Command):
         return AssembleCmd.assemble_model(self.name, catalog.Catalog, args)
 
 
-class ProfileCmd(Command):
+class ProfileCmd(CommandPlusDocs):
     """Assemble a profile."""
 
     name = 'profile'
@@ -73,7 +72,7 @@ class ProfileCmd(Command):
         return AssembleCmd.assemble_model(self.name, profile.Profile, args)
 
 
-class TargetDefinitionCmd(Command):
+class TargetDefinitionCmd(CommandPlusDocs):
     """Assemble a target definition."""
 
     name = 'target-definition'
@@ -82,7 +81,7 @@ class TargetDefinitionCmd(Command):
         return AssembleCmd.assemble_model(self.name, target.TargetDefinition, args)
 
 
-class ComponentDefinitionCmd(Command):
+class ComponentDefinitionCmd(CommandPlusDocs):
     """Assemble a component definition."""
 
     name = 'component-definition'
@@ -91,7 +90,7 @@ class ComponentDefinitionCmd(Command):
         return AssembleCmd.assemble_model(self.name, component.ComponentDefinition, args)
 
 
-class SystemSecurityPlanCmd(Command):
+class SystemSecurityPlanCmd(CommandPlusDocs):
     """Assemble a system security plan."""
 
     name = 'system-security-plan'
@@ -100,7 +99,7 @@ class SystemSecurityPlanCmd(Command):
         return AssembleCmd.assemble_model(self.name, ssp.SystemSecurityPlan, args)
 
 
-class AssessmentPlanCmd(Command):
+class AssessmentPlanCmd(CommandPlusDocs):
     """Assemble a  assessment plan."""
 
     name = 'assessment-plan'
@@ -109,7 +108,7 @@ class AssessmentPlanCmd(Command):
         return AssembleCmd.assemble_model(self.name, assessment_plan.AssessmentPlan, args)
 
 
-class AssessmentResultCmd(Command):
+class AssessmentResultCmd(CommandPlusDocs):
     """Assemble a  assessment result."""
 
     name = 'assessment-results'
@@ -118,7 +117,7 @@ class AssessmentResultCmd(Command):
         return AssembleCmd.assemble_model(self.name, assessment_results.AssessmentResults, args)
 
 
-class PlanOfActionAndMilestonesCmd(Command):
+class PlanOfActionAndMilestonesCmd(CommandPlusDocs):
     """Assemble a plan of action and milestones."""
 
     name = 'plan-of-action-and-milestones'
@@ -127,7 +126,7 @@ class PlanOfActionAndMilestonesCmd(Command):
         return AssembleCmd.assemble_model(self.name, poam.PlanOfActionAndMilestones, args)
 
 
-class AssembleCmd(Command):
+class AssembleCmd(CommandPlusDocs):
     """Assemble all subcomponents from a specified trestle model into a single JSON/YAML file under dist."""
 
     name = 'assemble'

--- a/trestle/core/commands/command_docs.py
+++ b/trestle/core/commands/command_docs.py
@@ -1,0 +1,30 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2021 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trestle command abstraction.
+
+Improves parsing until such a point as ILCLI is fixed.
+"""
+
+from ilcli import Command
+
+
+class CommandPlusDocs(Command):
+    """Linear extension to the ILCLI interface to use documentation string more."""
+
+    def __init__(self, parser=None, parent=None, name=None, out=None, err=None) -> None:
+        """Override default ILCLI behaviour to include class documentation in command help description."""
+        super(CommandPlusDocs, self).__init__(parser, parent, name, out, err)
+        self.parser.description = self.__doc__

--- a/trestle/core/commands/create.py
+++ b/trestle/core/commands/create.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Trestle Create Command."""
+"""Trestle Create CommandPlusDocs."""
 
 import argparse
 import logging
@@ -21,10 +21,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Type, TypeVar
 
-from ilcli import Command  # type: ignore
-
 import trestle.oscal
 from trestle.core import generators
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
 from trestle.core.models.file_content_type import FileContentType
@@ -55,7 +54,7 @@ TLO = TypeVar(
 )
 
 
-class CatalogCmd(Command):
+class CatalogCmd(CommandPlusDocs):
     """Create a sample catalog in the trestle directory structure, given an OSCAL schema."""
 
     name = 'catalog'
@@ -66,7 +65,7 @@ class CatalogCmd(Command):
         return CreateCmd.create_object(self.name, catalog.Catalog, args)
 
 
-class ProfileCmd(Command):
+class ProfileCmd(CommandPlusDocs):
     """Create a sample profile."""
 
     name = 'profile'
@@ -76,7 +75,7 @@ class ProfileCmd(Command):
         return CreateCmd.create_object(self.name, profile.Profile, args)
 
 
-class TargetDefinitionCmd(Command):
+class TargetDefinitionCmd(CommandPlusDocs):
     """Create a sample target definition."""
 
     name = 'target-definition'
@@ -85,7 +84,7 @@ class TargetDefinitionCmd(Command):
         return CreateCmd.create_object(self.name, target.TargetDefinition, args)
 
 
-class ComponentDefinitionCmd(Command):
+class ComponentDefinitionCmd(CommandPlusDocs):
     """Create a sample component definition."""
 
     name = 'component-definition'
@@ -94,7 +93,7 @@ class ComponentDefinitionCmd(Command):
         return CreateCmd.create_object(self.name, component.ComponentDefinition, args)
 
 
-class SystemSecurityPlanCmd(Command):
+class SystemSecurityPlanCmd(CommandPlusDocs):
     """Create a sample system security plan."""
 
     name = 'system-security-plan'
@@ -103,7 +102,7 @@ class SystemSecurityPlanCmd(Command):
         return CreateCmd.create_object(self.name, ssp.SystemSecurityPlan, args)
 
 
-class AssessmentPlanCmd(Command):
+class AssessmentPlanCmd(CommandPlusDocs):
     """Create a sample assessment plan."""
 
     name = 'assessment-plan'
@@ -112,7 +111,7 @@ class AssessmentPlanCmd(Command):
         return CreateCmd.create_object(self.name, assessment_plan.AssessmentPlan, args)
 
 
-class AssessmentResultCmd(Command):
+class AssessmentResultCmd(CommandPlusDocs):
     """Create a sample assessment result."""
 
     name = 'assessment-results'
@@ -121,7 +120,7 @@ class AssessmentResultCmd(Command):
         return CreateCmd.create_object(self.name, assessment_results.AssessmentResults, args)
 
 
-class PlanOfActionAndMilestonesCmd(Command):
+class PlanOfActionAndMilestonesCmd(CommandPlusDocs):
     """Create a sample plan of action and milestones."""
 
     name = 'plan-of-action-and-milestones'
@@ -130,7 +129,7 @@ class PlanOfActionAndMilestonesCmd(Command):
         return CreateCmd.create_object(self.name, poam.PlanOfActionAndMilestones, args)
 
 
-class CreateCmd(Command):
+class CreateCmd(CommandPlusDocs):
     """Create a sample OSCAL model in trestle project."""
 
     name = 'create'

--- a/trestle/core/commands/import_.py
+++ b/trestle/core/commands/import_.py
@@ -19,10 +19,9 @@ import logging
 import pathlib
 from json.decoder import JSONDecodeError
 
-from ilcli import Command  # type: ignore
-
 import trestle.core.commands.validate as validatecmd
 from trestle.core import parser
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
@@ -34,7 +33,7 @@ from trestle.utils import log
 logger = logging.getLogger(__name__)
 
 
-class ImportCmd(Command):
+class ImportCmd(CommandPlusDocs):
     """Import an existing full OSCAL model into the trestle project."""
 
     # The line above comes with the doc string

--- a/trestle/core/commands/init.py
+++ b/trestle/core/commands/init.py
@@ -20,17 +20,16 @@ import os
 import pathlib
 from shutil import copyfile
 
-from ilcli import Command  # type: ignore
-
 from pkg_resources import resource_filename
 
 import trestle.core.const as const
 import trestle.utils.log as log
+from trestle.core.commands.command_docs import CommandPlusDocs
 
 logger = logging.getLogger(__name__)
 
 
-class InitCmd(Command):
+class InitCmd(CommandPlusDocs):
     """Initialize a trestle working directory."""
 
     name = 'init'

--- a/trestle/core/commands/merge.py
+++ b/trestle/core/commands/merge.py
@@ -19,9 +19,8 @@ import logging
 import os
 from pathlib import Path
 
-from ilcli import Command  # type: ignore
-
 from trestle.core import const, utils
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, RemovePathAction, WriteFileAction
 from trestle.core.models.elements import Element, ElementPath
@@ -33,7 +32,7 @@ from trestle.utils import log
 logger = logging.getLogger(__name__)
 
 
-class MergeCmd(Command):
+class MergeCmd(CommandPlusDocs):
     """Merge subcomponents on a trestle model."""
 
     name = 'merge'

--- a/trestle/core/commands/remove.py
+++ b/trestle/core/commands/remove.py
@@ -19,12 +19,11 @@ import logging
 import pathlib
 from typing import List, Tuple, Type
 
-from ilcli import Command  # type: ignore
-
 import trestle.core.const as const
 import trestle.core.err as err
 from trestle.core import utils
 from trestle.core.base_model import OscalBaseModel
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, RemoveAction, WriteFileAction
 from trestle.core.models.elements import Element, ElementPath
@@ -36,7 +35,7 @@ from trestle.utils import log
 logger = logging.getLogger(__name__)
 
 
-class RemoveCmd(Command):
+class RemoveCmd(CommandPlusDocs):
     """Remove a subcomponent to an existing model."""
 
     name = 'remove'

--- a/trestle/core/commands/replicate.py
+++ b/trestle/core/commands/replicate.py
@@ -20,8 +20,7 @@ import pathlib
 from json.decoder import JSONDecodeError
 from typing import Type, TypeVar
 
-from ilcli import Command  # type: ignore
-
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element
@@ -54,7 +53,7 @@ TLO = TypeVar(
 )
 
 
-class CatalogCmd(Command):
+class CatalogCmd(CommandPlusDocs):
     """Replicate a catalog within the trestle directory structure."""
 
     name = 'catalog'
@@ -65,7 +64,7 @@ class CatalogCmd(Command):
         return ReplicateCmd.replicate_object(self.name, catalog.Catalog, args)
 
 
-class ProfileCmd(Command):
+class ProfileCmd(CommandPlusDocs):
     """Replicate a profile within the trestle directory structure."""
 
     name = 'profile'
@@ -75,7 +74,7 @@ class ProfileCmd(Command):
         return ReplicateCmd.replicate_object(self.name, profile.Profile, args)
 
 
-class TargetDefinitionCmd(Command):
+class TargetDefinitionCmd(CommandPlusDocs):
     """Replicate a target within the trestle directory structure."""
 
     name = 'target-definition'
@@ -84,7 +83,7 @@ class TargetDefinitionCmd(Command):
         return ReplicateCmd.replicate_object(self.name, target.TargetDefinition, args)
 
 
-class ComponentDefinitionCmd(Command):
+class ComponentDefinitionCmd(CommandPlusDocs):
     """Replicate a component definition within the trestle directory structure."""
 
     name = 'component-definition'
@@ -93,7 +92,7 @@ class ComponentDefinitionCmd(Command):
         return ReplicateCmd.replicate_object(self.name, component.ComponentDefinition, args)
 
 
-class SystemSecurityPlanCmd(Command):
+class SystemSecurityPlanCmd(CommandPlusDocs):
     """Replicate a system security plan within the trestle directory structure."""
 
     name = 'system-security-plan'
@@ -102,7 +101,7 @@ class SystemSecurityPlanCmd(Command):
         return ReplicateCmd.replicate_object(self.name, ssp.SystemSecurityPlan, args)
 
 
-class AssessmentPlanCmd(Command):
+class AssessmentPlanCmd(CommandPlusDocs):
     """Replicate an assessment plan within the trestle directory structure."""
 
     name = 'assessment-plan'
@@ -111,7 +110,7 @@ class AssessmentPlanCmd(Command):
         return ReplicateCmd.replicate_object(self.name, assessment_plan.AssessmentPlan, args)
 
 
-class AssessmentResultCmd(Command):
+class AssessmentResultCmd(CommandPlusDocs):
     """Replicate an assessment result within the trestle directory structure."""
 
     name = 'assessment-results'
@@ -120,7 +119,7 @@ class AssessmentResultCmd(Command):
         return ReplicateCmd.replicate_object(self.name, assessment_results.AssessmentResults, args)
 
 
-class PlanOfActionAndMilestonesCmd(Command):
+class PlanOfActionAndMilestonesCmd(CommandPlusDocs):
     """Replicate a plan of action and milestones within the trestle directory structure."""
 
     name = 'plan-of-action-and-milestones'
@@ -129,7 +128,7 @@ class PlanOfActionAndMilestonesCmd(Command):
         return ReplicateCmd.replicate_object(self.name, poam.PlanOfActionAndMilestones, args)
 
 
-class ReplicateCmd(Command):
+class ReplicateCmd(CommandPlusDocs):
     """Replicate a top level model within the trestle directory structure."""
 
     name = 'replicate'

--- a/trestle/core/commands/split.py
+++ b/trestle/core/commands/split.py
@@ -19,13 +19,12 @@ import logging
 import pathlib
 from typing import Dict, List
 
-from ilcli import Command
-
 import trestle.utils.log as log
 from trestle.core import const
 from trestle.core import utils
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.commands import cmd_utils
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.err import TrestleError
 from trestle.core.models.actions import Action, CreatePathAction, WriteFileAction
 from trestle.core.models.elements import Element, ElementPath
@@ -36,7 +35,7 @@ from trestle.utils import fs, trash
 logger = logging.getLogger(__name__)
 
 
-class SplitCmd(Command):
+class SplitCmd(CommandPlusDocs):
     """Split subcomponents on a trestle model."""
 
     name = 'split'

--- a/trestle/core/commands/task.py
+++ b/trestle/core/commands/task.py
@@ -23,18 +23,17 @@ import pkgutil
 import sys
 from typing import Dict, Optional, Type
 
-from ilcli import Command  # type: ignore
-
 import trestle.core.const
 import trestle.tasks
 import trestle.utils.fs as fs
 import trestle.utils.log as log
+from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.tasks.base_task import TaskBase, TaskOutcome
 
 logger = logging.getLogger(__name__)
 
 
-class TaskCmd(Command):
+class TaskCmd(CommandPlusDocs):
     """Run arbitrary trestle tasks in a simple and extensible methodology."""
 
     name = 'task'

--- a/trestle/core/commands/validate.py
+++ b/trestle/core/commands/validate.py
@@ -18,15 +18,14 @@
 import argparse
 import logging
 
-from ilcli import Command
-
 import trestle.core.validator_factory as vfact
 import trestle.utils.log as log
+from trestle.core.commands.command_docs import CommandPlusDocs
 
 logger = logging.getLogger(__name__)
 
 
-class ValidateCmd(Command):
+class ValidateCmd(CommandPlusDocs):
     """Validate contents of a trestle model in different modes."""
 
     name = 'validate'


### PR DESCRIPTION

Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[x\] All commits are signed-off.

The ILCLI interface has a bit of a flaw from a documentation perspective: The 'Command' class docs are only used for sub-command hints on help.

This PR generalizes the use of docstrings for CLI documentantion to improve user experience.

(to see run trestle -h or any other command in the same fashion).


