### PR TITLE
issue #344 check rc in tests and remove dependency on dictdiffer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ dev =
     python-semantic-release
     pep8-naming
     pytest-random-order
-    dictdiffer
     python-dateutil
     mypy
     # # Docs website

--- a/tests/trestle/core/commands/add_test.py
+++ b/tests/trestle/core/commands/add_test.py
@@ -151,7 +151,7 @@ def test_run(tmp_path, sample_catalog_minimal):
     ]
 
     with patch.object(sys, 'argv', testargs):
-        Trestle().run()
+        assert Trestle().run() == 0
 
     actual_catalog = Catalog.oscal_read(catalog_def_file)
     assert expected_catalog_roles2_rp == actual_catalog
@@ -170,7 +170,7 @@ def test_striped_model(tmp_path, sample_catalog_minimal):
     os.chdir(catalog_def_dir)
     testargs = ['trestle', 'split', '-f', 'catalog.json', '-e', 'catalog.metadata']
     with patch.object(sys, 'argv', testargs):
-        Trestle().run()
+        assert Trestle().run() == 0
 
     # Now that the metadata has been split, add of catalog.metadata.roles will error,
     # but add of catalog.back-matter will pass
@@ -188,7 +188,7 @@ def test_striped_model(tmp_path, sample_catalog_minimal):
     expected_catalog = current_catalog
 
     with patch.object(sys, 'argv', testargs):
-        Trestle().run()
+        assert Trestle().run() == 0
 
     actual_model, _ = get_stripped_contextual_model()
     actual_catalog = actual_model.oscal_read(pathlib.Path('catalog.json'))

--- a/tests/trestle/core/commands/create_test.py
+++ b/tests/trestle/core/commands/create_test.py
@@ -91,7 +91,7 @@ def test_broken_args(tmp_trestle_dir: pathlib.Path) -> None:
     # correct behavior
     with mock.patch.object(sys, 'argv', testargs):
         rc = Trestle().run()
-    assert rc == 0
+        assert rc == 0
     # correct behavior
     testargs[2] = 'bad_name'
     with mock.patch.object(sys, 'argv', testargs):

--- a/tests/trestle/core/commands/merge_test.py
+++ b/tests/trestle/core/commands/merge_test.py
@@ -19,8 +19,6 @@ import os
 import shutil
 from pathlib import Path
 
-from dictdiffer import diff
-
 from tests import test_utils
 
 import trestle.oscal.catalog as oscatalog
@@ -313,7 +311,7 @@ def test_merge_plan_simple_list(testdata_dir, tmp_trestle_dir):
     generated_plan = MergeCmd.merge(ElementPath('metadata.roles'))
 
     # Assert the generated plan matches the expected plan'
-    assert len(list(diff(generated_plan, expected_plan))) == 0
+    assert generated_plan == expected_plan
 
 
 def test_split_merge(testdata_dir, tmp_trestle_dir):

--- a/tests/trestle/core/commands/remove_test.py
+++ b/tests/trestle/core/commands/remove_test.py
@@ -278,7 +278,7 @@ def test_run(tmp_path, sample_catalog_minimal):
     testargs = ['trestle', 'remove', '-f', str(catalog_def_file), '-e', 'catalog.metadata.responsible-parties']
 
     with patch.object(sys, 'argv', testargs):
-        Trestle().run()
+        assert Trestle().run() == 0
 
     actual_catalog = Catalog.oscal_read(catalog_def_file)
     assert expected_catalog_no_rp == actual_catalog
@@ -306,7 +306,7 @@ def test_run(tmp_path, sample_catalog_minimal):
     ]
 
     with patch.object(sys, 'argv', testargs):
-        Trestle().run()
+        assert Trestle().run() == 0
 
     actual_catalog = Catalog.oscal_read(catalog_def_file_2)
     assert expected_catalog_no_rp == actual_catalog

--- a/tests/trestle/core/commands/split_test.py
+++ b/tests/trestle/core/commands/split_test.py
@@ -289,7 +289,7 @@ def test_split_run(tmp_path: pathlib.Path, sample_target_def: ostarget.TargetDef
     )
 
     os.chdir(target_def_dir)
-    cmd._run(args)
+    assert cmd._run(args) == 0
     os.chdir(cwd)
     check_split_files()
 
@@ -302,7 +302,7 @@ def test_split_run(tmp_path: pathlib.Path, sample_target_def: ostarget.TargetDef
         file='target-definition.yaml', element='target-definition.metadata,target-definition.targets.*', verbose=0
     )
     os.chdir(target_def_dir)
-    cmd._run(args)
+    assert cmd._run(args) == 0
     os.chdir(cwd)
     check_split_files()
 

--- a/tests/trestle/utils/load_distributed_test.py
+++ b/tests/trestle/utils/load_distributed_test.py
@@ -18,8 +18,6 @@
 import shutil
 from pathlib import Path
 
-import dictdiffer
-
 from tests import test_utils
 
 from trestle.oscal.catalog import Catalog, ResponsibleParty, Role
@@ -97,7 +95,7 @@ def test_load_dict(testdata_dir, tmp_trestle_dir):
     actual_model_type, actual_model_alias, actual_model_instance = _load_dict(
         catalog_dir / 'metadata/responsible-parties')
 
-    expexted_model_instance = {
+    expected_model_instance = {
         'contact': ResponsibleParty.oscal_read(
             catalog_dir / 'metadata/responsible-parties/contact__responsible-party.json'
         ),
@@ -105,7 +103,7 @@ def test_load_dict(testdata_dir, tmp_trestle_dir):
             catalog_dir / 'metadata/responsible-parties/creator__responsible-party.json'
         )
     }
-    assert len(list(dictdiffer.diff(actual_model_instance, expexted_model_instance))) == 0
+    assert actual_model_instance == expected_model_instance
     assert actual_model_alias == 'catalog.metadata.responsible-parties'
 
     expected_model_type, _ = fs.get_contextual_model_type((catalog_dir / 'metadata/responsible-parties/').absolute())
@@ -135,4 +133,4 @@ def test_load_distributed(testdata_dir, tmp_trestle_dir):
 
     assert actual_model_type == expected_model_type
     assert actual_model_alias == 'catalog'
-    assert len(list(dictdiffer.diff(expected_model_instance, actual_model_instance))) == 0
+    assert expected_model_instance == actual_model_instance


### PR DESCRIPTION

Signed-off-by: FrankSuits <frankst@au1.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[ \] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x] I have added tests to cover my changes.
- \[x] All new and existing tests passed.
- \[x] All commits are signed-off.

Make sure rc in tests is checked whenever a command is run.

Also removed dependency on dictdiffer since tests were only checking for equality of dicts and not the specific differences between dicts.