### PR TITLE
fix: Correct semantic / conventional commit behaviour

### DIFF
--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,16 +1,43 @@
-name: Conventional PR for develop
+name: "Lint PR"
+
 on:
   pull_request:
-    branches:
+    types:
+      - opened
+      - edited
+      - synchronize
+    branch:
       - develop
 
 jobs:
-  hqprs:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: conventional-pr
-        uses: Namchee/conventional-pr@v0.4.1
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v3.*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          access_token: ${{ secrets.ADMIN_PAT }}
-          check_draft: true
-          link_issue: false
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          # Configure which scopes are allowed.
+          scopes: |
+            core
+            ui
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          # For work-in-progress PRs you can typically use draft pull requests 
+          # from Github. However, private repositories on the free plan don't have 
+          # this option and therefore this action allows you to opt-in to using the 
+          # special "[WIP]" prefix to indicate this state. This will avoid the 
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit
+          validateSingleCommit: true

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -24,7 +24,10 @@ jobs:
           # Configure which scopes are allowed.
           scopes: |
             core
-            ui
+            models
+            transformers
+            docs
+            cicd
           # Configure that a scope must always be provided.
           requireScope: false
           # Configure additional validation for the subject based on a regex.

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,0 +1,18 @@
+name: Trestle Deploy
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review] # Currently, this action only support these events
+    branches:
+      - develop
+
+jobs:
+  hqprs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: conventional-pr
+        uses: Namchee/conventional-pr@latest
+        with:
+          access_token: ${{ secrets.ADMIN_PAT }}
+          check_draft: true
+          link_issue: false
+          

--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - develop
   schedule:
     # Run once per day to ensure we have no build failures due to dependency updates.
     # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/trestle-develop-automerge.yml
+++ b/.github/workflows/trestle-develop-automerge.yml
@@ -1,0 +1,42 @@
+name: Automatically squash merge to develop
+
+on:
+  # Try enabling auto-merge for all open pull requests. (Only recommended for testing.)
+  pull_request:
+    branches:
+      - main
+  # Try enabling auto-merge for all open pull requests.
+  schedule:
+    - cron: 0 * * * *
+
+  # Try enabling auto-merge for a pull request when a draft is marked as “ready for review”, when
+  # a required label is applied or when a “do not merge” label is removed, or when a pull request
+  # is updated in any way (opened, synchronized, reopened, edited).
+  pull_request_target:
+    types:
+      - opened
+      - synchronized
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+  # Try enabling auto-merge for the specified pull request or all open pull requests if none is specified.
+  # workflow_dispatch:
+  #   inputs:
+  #     pull-request:
+  #       description: Pull Request Number
+  #       required: false
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: reitermarkus/automerge@v2
+        with:
+          token: ${{ secrets.ADMIN_PAT }}
+          merge-method: squash
+          do-not-merge-labels: never-merge
+          pull-request: ${{ github.event.inputs.pull-request }}
+          dry-run: true

--- a/.github/workflows/trestle-develop-automerge.yml
+++ b/.github/workflows/trestle-develop-automerge.yml
@@ -26,7 +26,7 @@ jobs:
         enable-prlabel-automation: true
         enable-prreviewer-frontmatter: false
         enable-welcomemessage: true
-        welcome-message: "Thanks for opening an issue! When you are ready for the pr to be reviewed / merged add the pr-ready label.
+        welcome-message: "Thanks for opening an issue! When you are ready for the pr to be reviewed / merged add the pr-ready label."
         prmerge-requireallchecks: true
         prmerge-requirereviewcount: 1
         prmerge-method: 'squash'

--- a/.github/workflows/trestle-main-automerge.yml
+++ b/.github/workflows/trestle-main-automerge.yml
@@ -1,0 +1,42 @@
+name: Automatically merge merge to develop
+
+on:
+  # Try enabling auto-merge for all open pull requests. (Only recommended for testing.)
+  pull_request:
+    branches:
+      - main
+  # Try enabling auto-merge for all open pull requests.
+  schedule:
+    - cron: 0 * * * *
+
+  # Try enabling auto-merge for a pull request when a draft is marked as “ready for review”, when
+  # a required label is applied or when a “do not merge” label is removed, or when a pull request
+  # is updated in any way (opened, synchronized, reopened, edited).
+  pull_request_target:
+    types:
+      - opened
+      - synchronized
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+  # Try enabling auto-merge for the specified pull request or all open pull requests if none is specified.
+  # workflow_dispatch:
+  #   inputs:
+  #     pull-request:
+  #       description: Pull Request Number
+  #       required: false
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: reitermarkus/automerge@v2
+        with:
+          token: ${{ secrets.ADMIN_PAT }}
+          merge-method: merge
+          do-not-merge-labels: never-merge
+          pull-request: ${{ github.event.inputs.pull-request }}
+          dry-run: true


### PR DESCRIPTION
Original intent was to ensure that conventional commits blocked merges to ensure user would edit the commit.

