### PR TITLE
fix: Remove problematic concurrency restrictions in devops pipeline

### DIFF
--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -13,9 +13,6 @@ on:
 
 jobs:
   build:
-    concurrency: 
-      group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}
-      cancel-in-progress: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -103,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     concurrency: 
-      group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}
+      group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}-docs
       cancel-in-progress: true
     # Temporary hack: allow develop as well as master to deploy docs.
     if: github.ref == 'refs/heads/main'
@@ -131,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     concurrency: 
-      group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}
+      group: ${{ github.ref }}-${{ github.workflow }}-${{ github.job }}-main
       cancel-in-progress: true
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[ \] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[x\] All new and existing tests passed.
- \[x\] All commits are signed-off.

The concurrency restrictions affect matrix builds in a really nasty way. I've removed the restriction (designed to accelerate the build process), however, left in critical components - where it ensures that the release process happens serially.