### PR TITLE
fix: move unreachable debug statement

### DIFF
--- a/trestle/core/commands/split.py
+++ b/trestle/core/commands/split.py
@@ -67,8 +67,8 @@ class SplitCmd(CommandPlusDocs):
 
     def _run(self, args: argparse.Namespace) -> int:
         """Split an OSCAL file into elements."""
-        logger.debug('Entering trestle split.')
         log.set_log_level_from_args(args)
+        logger.debug('Entering trestle split.')
         # get the Model
         args_raw = args.__dict__
         if args_raw[const.ARG_FILE] is None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x\] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x\] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[ \] I have added tests to cover my changes.
- \[ \] All new and existing tests passed.
- \[ \] All commits are signed-off.

Debug statement indicating start of split command was before logging level set - therefore the only way this debug statement is displayed is by editing cli.py to set the logging level, or editing utils/log.py to change the default level. Moving debug statement after logging level is set per argument results in this statement being printed when `trestle split -v ....` is specified.