### PR TITLE
fix: ssp assemble prose, all extraction of general prose for responses

### DIFF
--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -17,6 +17,8 @@ import argparse
 import pathlib
 from typing import Tuple
 
+import pytest
+
 from ruamel.yaml import YAML
 
 from tests import test_utils
@@ -54,7 +56,7 @@ def setup_for_ssp(include_header: bool, big_profile: bool) -> Tuple[argparse.Nam
     return args, sections, yaml_path
 
 
-def insert_prose(trestle_dir: pathlib.Path, statement_id: str, prose:str) -> None:
+def insert_prose(trestle_dir: pathlib.Path, statement_id: str, prose: str) -> None:
     """Insert response prose in for a statement of a control."""
     control_dir = trestle_dir / ssp_name / statement_id.split('-')[0]
     md_file = control_dir / (statement_id.split('_')[0] + '.md')
@@ -143,7 +145,8 @@ def test_ssp_generator_no_header(tmp_trestle_dir: pathlib.Path) -> None:
     assert not header
 
 
-def test_ssp_assemble(tmp_trestle_dir: pathlib.Path) -> None:
+@pytest.mark.parametrize('use_tree', [False, True])
+def test_ssp_assemble(use_tree: bool, tmp_trestle_dir: pathlib.Path) -> None:
     """Test ssp assemble."""
     args, _, _ = setup_for_ssp(True, True)
 
@@ -158,10 +161,8 @@ def test_ssp_assemble(tmp_trestle_dir: pathlib.Path) -> None:
     insert_prose(tmp_trestle_dir, 'ac-1_smt.a', prose_a)
     insert_prose(tmp_trestle_dir, 'ac-1_smt.b', prose_b)
 
-    # then assemble it
-    ssp_assemble = SSPAssemble()
-    args = argparse.Namespace(markdown=ssp_name, output=ssp_name, verbose=True)
-    assert ssp_assemble._run(args) == 0
+    ssp_manager = SSPManager()
+    assert ssp_manager.assemble_ssp(ssp_name, ssp_name, use_tree) == 0
 
 
 def test_ssp_bad_name(tmp_trestle_dir: pathlib.Path) -> None:

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -161,8 +161,15 @@ def test_ssp_assemble(use_tree: bool, tmp_trestle_dir: pathlib.Path) -> None:
     insert_prose(tmp_trestle_dir, 'ac-1_smt.a', prose_a)
     insert_prose(tmp_trestle_dir, 'ac-1_smt.b', prose_b)
 
-    ssp_manager = SSPManager()
-    assert ssp_manager.assemble_ssp(ssp_name, ssp_name, use_tree) == 0
+    # now assemble the edited controls into json ssp
+    # two different invocations modes are used so that use_tree can be overridden
+    if use_tree:
+        ssp_assemble = SSPAssemble()
+        args = argparse.Namespace(markdown=ssp_name, output=ssp_name, verbose=True)
+        assert ssp_assemble._run(args) == 0
+    else:
+        ssp_manager = SSPManager()
+        assert ssp_manager.assemble_ssp(ssp_name, ssp_name, use_tree) == 0
 
 
 def test_ssp_bad_name(tmp_trestle_dir: pathlib.Path) -> None:

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -54,6 +54,23 @@ def setup_for_ssp(include_header: bool, big_profile: bool) -> Tuple[argparse.Nam
     return args, sections, yaml_path
 
 
+def insert_prose(trestle_dir: pathlib.Path, statement_id: str, prose:str) -> None:
+    """Insert response prose in for a statement of a control."""
+    control_dir = trestle_dir / ssp_name / statement_id.split('-')[0]
+    md_file = control_dir / (statement_id.split('_')[0] + '.md')
+
+    with open(md_file, 'r') as md:
+        lines = md.readlines()
+
+    with open(md_file, 'w') as md:
+        for line in lines:
+            # replace the 'Add control implementation' line with the new lines of prose
+            if line.find(statement_id) < 0:
+                md.write(line)
+            else:
+                md.write(prose + '\n')
+
+
 def test_ssp_generator(tmp_trestle_dir: pathlib.Path) -> None:
     """Test the ssp generator."""
     args, sections, yaml_path = setup_for_ssp(True, False)
@@ -129,9 +146,18 @@ def test_ssp_generator_no_header(tmp_trestle_dir: pathlib.Path) -> None:
 def test_ssp_assemble(tmp_trestle_dir: pathlib.Path) -> None:
     """Test ssp assemble."""
     args, _, _ = setup_for_ssp(True, True)
+
     # first create the markdown
     ssp_gen = SSPGenerate()
     assert ssp_gen._run(args) == 0
+
+    prose_a = 'Hello there\n  How are you\n line with more text\n\ndouble line'
+    prose_b = 'This is fun\nline with *bold* text'
+
+    # edit it a bit
+    insert_prose(tmp_trestle_dir, 'ac-1_smt.a', prose_a)
+    insert_prose(tmp_trestle_dir, 'ac-1_smt.b', prose_b)
+
     # then assemble it
     ssp_assemble = SSPAssemble()
     args = argparse.Namespace(markdown=ssp_name, output=ssp_name, verbose=True)

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -130,7 +130,7 @@ class SSPAssemble(AuthorCommonCommand):
             return 1
 
         ssp_manager = SSPManager()
-        return ssp_manager.assemble_ssp(args.markdown, args.output)
+        return ssp_manager.assemble_ssp(args.markdown, args.output, False)
 
 
 class SSPManager():
@@ -378,30 +378,39 @@ class SSPManager():
 
     def _get_label_prose(self, ii: int, tree: List[Dict[str, Any]]) -> Tuple[int, str, str]:
         """Find the statement label and prose in each section of the control markdown parse tree."""
+        # call this repeatedly and get label prose for each part sequentially
+        # this doesn't handle emphasis (e.g. bold) properly.  the direct methods below are preferred
         ntree = len(tree)
         label = ''
-        prose = ''
+        prose_lines = []
+
         while ii < ntree:
             # look for thematic break followed by heading (Part...) and paragraph (Response statement)
             if tree[ii]['type'] == 'thematic_break':
-                ii += 1
                 while ii < ntree and tree[ii]['type'] != 'heading':
                     ii += 1
                 if ii >= ntree:
                     break
-                if tree[ii]['type'] == 'heading':
+                # we are now on a heading line
+                if 'children' in tree[ii] and 'text' in tree[ii]['children'][0]:
                     section: str = tree[ii]['children'][0]['text']
+                    # find start of Part and grab label
                     if section.startswith('Part '):
                         label = section.split(' ')[-1]
                         ii += 1
-                        while ii < ntree and tree[ii]['type'] != 'paragraph':
+                        while ii < ntree and tree[ii]['type'] != 'thematic_break':
+                            if 'children' in tree[ii]:
+                                children = tree[ii]['children']
+                                for child in children:
+                                    if 'text' in child:
+                                        prose_lines.append(child['text'])
                             ii += 1
-                        if ii >= ntree:
-                            break
-                        prose = tree[ii]['children'][0]['text']
                         break
-            ii += 1
-        if prose == '' or label == '':
+            else:
+                ii += 1
+
+        prose = '\n'.join(prose_lines)
+        if not prose_lines or label == '':
             ii = -1
         return ii, label, prose
 
@@ -414,8 +423,8 @@ class SSPManager():
                 new_label += c
         return new_label
 
-    def _get_implementations(self, control_file: pathlib.Path,
-                             component: ossp.SystemComponent) -> List[ossp.ImplementedRequirement]:
+    def _get_implementations_via_tree(self, control_file: pathlib.Path,
+                                      component: ossp.SystemComponent) -> List[ossp.ImplementedRequirement]:
         # get implementation requirements associated with a given control and link them to the one component we created
         control_id = control_file.stem
         parse_tree = MarkdownValidator.load_markdown_parsetree(control_file)
@@ -449,8 +458,75 @@ class SSPManager():
 
         return imp_reqs
 
-    def assemble_ssp(self, md_name, ssp_name) -> int:
+    def _trim_prose_lines(self, lines: List[str]) -> str:
+        # trim dead space at start and end
+        ii = 0
+        while lines[ii].strip(' \r\n') == '':
+            ii += 1
+        jj = len(lines) - 1
+        while jj >= 0 and lines[jj].strip(' \r\n') == '':
+            jj -= 1
+        if jj < ii:
+            return ''
+        return '\n'.join(lines[ii:(jj + 1)])
+
+    def _get_label_prose_direct(self, ii: int, lines: List[str]) -> str:
+        # ii should point to start of file or directly at a new Part
+        nlines = len(lines)
+        prose_lines: List[str] = []
+        part_label = ''
+        while ii < nlines:
+            if lines[ii].startswith('### Part'):
+                part_label = lines[ii].strip().split(' ')[-1]
+                ii += 1
+                while ii < nlines:
+                    if lines[ii].startswith('### Part') or lines[ii].startswith('---'):
+                        return ii, part_label, self._trim_prose_lines(prose_lines)
+                    prose_lines.append(lines[ii])
+                    ii += 1
+            ii += 1
+        return -1, part_label, '\n'.join(prose_lines)
+
+    def _get_implementations_direct(self, control_file: pathlib.Path,
+                                    component: ossp.SystemComponent) -> List[ossp.ImplementedRequirement]:
+        # get implementation requirements associated with a given control and link them to the one component we created
+        control_id = control_file.stem
+        imp_reqs: list[ossp.ImplementedRequirement] = []
+        ii = 0
+        lines: List[str] = []
+        with open(control_file, 'r') as f:
+            raw_lines = f.readlines()
+        lines = [line.strip('\r\n') for line in raw_lines]
+
+        # keep moving down through the tree picking up labels and prose for the imp requirements
+        while True:
+            ii, part_label, prose = self._get_label_prose_direct(ii, lines)
+            if ii < 0:
+                break
+            # create a new by-component to hold this statement
+            by_comp: ossp.ByComponent = gens.generate_sample_model(ossp.ByComponent)
+            # link it to the one dummy component uuid
+            by_comp.component_uuid = component.uuid
+            # add the response prose to the description
+            by_comp.description = prose
+            # create a statement to hold the by-component and assign the statement id
+            statement: ossp.Statement = gens.generate_sample_model(ossp.Statement)
+            # strip badchars from label
+            clean_label = self._strip_bad_chars(part_label)
+            statement.statement_id = f'{control_id}_smt.{clean_label}'
+            statement.by_components = [by_comp]
+            # create a new implemented requirement linked to the control id to hold the statement
+            imp_req: ossp.ImplementedRequirement = gens.generate_sample_model(ossp.ImplementedRequirement)
+            imp_req.control_id = control_id
+            imp_req.statements = [statement]
+            imp_reqs.append(imp_req)
+
+        return imp_reqs
+
+    def assemble_ssp(self, md_name: str, ssp_name: str, use_tree: bool) -> int:
         """Assemble the markdown directory into an ssp."""
+        # use_tree dictates which code to use to extract prose from the .md files
+        # default is not to use tree and parse directly
         # find all groups in the markdown dir
         group_ids = []
         trestle_root = fs.get_trestle_project_root(pathlib.Path.cwd())
@@ -472,7 +548,10 @@ class SSPManager():
         for group_id in group_ids:
             group_path = md_dir / group_id
             for control_file in group_path.glob('*.md'):
-                imp_reqs.extend(self._get_implementations(control_file, component))
+                if not use_tree:
+                    imp_reqs.extend(self._get_implementations_direct(control_file, component))
+                else:
+                    imp_reqs.extend(self._get_implementations_via_tree(control_file, component))
 
         # create a control implementation to hold the implementation requirements
         control_imp: ossp.ControlImplementation = gens.generate_sample_model(ossp.ControlImplementation)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- \[x] Bug fix (non-breaking change which fixes an issue)
- \[ \] New feature (non-breaking change which adds functionality)
- \[ \] Breaking change (fix or feature that would cause existing functionality to change)
- \[x] My code follows the code style of this project.
- \[ \] My change requires a change to the documentation.
- \[ \] I have updated the documentation accordingly.
- \[x] I have added tests to cover my changes.
- \[x] All new and existing tests passed.
- \[x] All commits are signed-off.

Improved handling of general prose for responses used in ssp-assemble.

closes #578 

Will need separate issue to determine exactly what is allowed in the text, but this change will extract all text between ###Part X and --- (horizontal rule) - after first removing any leading and trailing blank lines.