### PR TITLE
fix: ssp section generation failed due to changes due to 1.0.0

### DIFF
--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -51,7 +51,7 @@ def setup_for_ssp(include_header: bool, big_profile: bool,
     )
     assert i._run(args) == 0
     yaml_path = test_utils.YAML_TEST_DATA_PATH / 'good_simple.yaml'
-    sections = 'ImplGuidance:Implementation Guidance,ExpectedEvidence'
+    sections = 'guidance:Implementation Guidance,ExpectedEvidence'
     if include_header:
         args = argparse.Namespace(
             trestle_root=tmp_trestle_dir,

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -239,6 +239,7 @@ class SSPManager():
         self._md_file.set_indent_level(-1)
 
     def _get_control_section(self, control: cat.Control, section: str) -> Optional[str]:
+        # this is where the section prose appears to be in the control.  This appears to have changed with OSCAL 1.0.0
         for part in control.parts:
             if part.name == section:
                 return part.prose

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -239,14 +239,9 @@ class SSPManager():
         self._md_file.set_indent_level(-1)
 
     def _get_control_section(self, control: cat.Control, section: str) -> Optional[str]:
-        for alter in self._alters:
-            if alter.control_id == control.id:
-                if alter.adds is not None:
-                    for add in alter.adds:
-                        if add.parts is not None:
-                            for part in add.parts:
-                                if part.name == section:
-                                    return part.prose
+        for part in control.parts:
+            if part.name == section:
+                return part.prose
         return None
 
     def _add_control_section(self, control: cat.Control, section_tuple: str) -> None:


### PR DESCRIPTION
Signed-off-by: Frank Suits <frankst@au1.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

Minor change needed due to OSCAL 1.0.0
section name was changed in new catalog file, and schema for section name also changed.