### PR TITLE
fix: file compare issue in task xlsx-to-component-definition unit test

### DIFF
--- a/tests/data/tasks/xlsx/output/catalog.json
+++ b/tests/data/tasks/xlsx/output/catalog.json
@@ -4,7 +4,7 @@
     "metadata": {
       "title": "Component Parameters",
       "last-modified": "2021-07-19T14:03:03.000+00:00",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "oscal-version": "1.0.0"
     },
     "params": [

--- a/tests/data/tasks/xlsx/output/component-definition.json
+++ b/tests/data/tasks/xlsx/output/component-definition.json
@@ -4,7 +4,7 @@
     "metadata": {
       "title": "Component definition for NIST Special Publication 800-53 Revision 4 profiles",
       "last-modified": "2021-07-19T14:03:03.000+00:00",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "oscal-version": "1.0.0",
       "roles": [
         {

--- a/tests/trestle/tasks/xlsx_to_component_definition_test.py
+++ b/tests/trestle/tasks/xlsx_to_component_definition_test.py
@@ -25,6 +25,7 @@ from trestle.tasks.base_task import TaskOutcome
 from trestle.utils.fs import text_files_equal
 
 uuid_mock1 = Mock(return_value=uuid.UUID('56666738-0f9a-4e38-9aac-c0fad00a5821'))
+get_trestle_version_mock1 = Mock(return_value='0.20.0')
 
 
 def test_xlsx_print_info(tmp_path):
@@ -53,6 +54,7 @@ def test_xlsx_simulate(tmp_path):
 
 
 @patch(target='uuid.uuid4', new=uuid_mock1)
+@patch(target='trestle.tasks.xlsx_to_oscal_component_definition.get_trestle_version', new=get_trestle_version_mock1)
 def test_xlsx_execute(tmp_path):
     """Test execute call."""
     config = configparser.ConfigParser()

--- a/tests/trestle/tasks/xlsx_to_component_definition_test.py
+++ b/tests/trestle/tasks/xlsx_to_component_definition_test.py
@@ -25,7 +25,7 @@ from trestle.tasks.base_task import TaskOutcome
 from trestle.utils.fs import text_files_equal
 
 uuid_mock1 = Mock(return_value=uuid.UUID('56666738-0f9a-4e38-9aac-c0fad00a5821'))
-get_trestle_version_mock1 = Mock(return_value='0.20.0')
+get_trestle_version_mock1 = Mock(return_value='0.21.0')
 
 
 def test_xlsx_print_info(tmp_path):

--- a/trestle/tasks/xlsx_to_oscal_component_definition.py
+++ b/trestle/tasks/xlsx_to_oscal_component_definition.py
@@ -74,7 +74,7 @@ t_controls = Dict[t_control, t_statements]
 
 
 def get_trestle_version():
-    """Get trestle version."""
+    """Get trestle version wrapper."""
     return __version__
 
 

--- a/trestle/tasks/xlsx_to_oscal_component_definition.py
+++ b/trestle/tasks/xlsx_to_oscal_component_definition.py
@@ -73,6 +73,11 @@ t_work_sheet = Worksheet
 t_controls = Dict[t_control, t_statements]
 
 
+def get_trestle_version():
+    """Get trestle version."""
+    return __version__
+
+
 class XlsxToOscalComponentDefinition(TaskBase):
     """
     Task to create OSCAL ComponentDefinition json.
@@ -246,7 +251,7 @@ class XlsxToOscalComponentDefinition(TaskBase):
             title='Component definition for ' + self._get_catalog_title() + ' profiles',
             last_modified=self._timestamp,
             oscal_version=OSCAL_VERSION,
-            version=__version__,
+            version=get_trestle_version(),
             roles=roles,
             parties=parties,
             responsible_parties=responsible_parties
@@ -546,7 +551,7 @@ class XlsxToOscalComponentDefinition(TaskBase):
                 parameters=self.parameters,
                 timestamp=self._timestamp,
                 oscal_version=OSCAL_VERSION,
-                version=__version__,
+                version=get_trestle_version(),
                 ofile=tfile,
                 verbose=self._verbose,
             )


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Description

trestle version increases with each release, which affects the produced
output but not in any material way with respect to the unit tests at
hand.

fix is to employ local function to get_trestle version which nominally
returns the actual trestle version, but to mock said function in the
unit test.

