### PR TITLE
feat: Adding capability to allowing generator to generate optional fields.

### DIFF
--- a/tests/trestle/core/generator_test.py
+++ b/tests/trestle/core/generator_test.py
@@ -148,7 +148,7 @@ def test_get_all_sample_models_optional() -> None:
             # This removes some enums and other objects.
             # add check that it is not OscalBaseModel
             if issubclass(oscal_cls, OscalBaseModel):
-                _ = gens.generate_sample_model(oscal_cls, optional=True, depth=-1)
+                _ = gens.generate_sample_model(oscal_cls, include_optional=True, depth=-1)
 
 
 def test_gen_date_authorized() -> None:
@@ -164,10 +164,10 @@ def test_gen_moo() -> None:
 
 def test_gen_control() -> None:
     """Make sure recursion is not going crazy."""
-    _ = gens.generate_sample_model(catalog.Control, optional=True, depth=100)
+    _ = gens.generate_sample_model(catalog.Control, include_optional=True, depth=100)
 
 
 def test_ensure_optional_exists() -> None:
     """Explicit test to ensure that optional variables are populated."""
-    my_catalog = gens.generate_sample_model(catalog.Catalog, optional=True, depth=-1)
+    my_catalog = gens.generate_sample_model(catalog.Catalog, include_optional=True, depth=-1)
     assert type(my_catalog.controls[0]) == catalog.Control

--- a/tests/trestle/core/generator_test.py
+++ b/tests/trestle/core/generator_test.py
@@ -137,6 +137,20 @@ def test_get_all_sample_models() -> None:
                 gens.generate_sample_model(oscal_cls)
 
 
+def test_get_all_sample_models_optional() -> None:
+    """Test we can get all models which exist."""
+    pkgpath = os.path.dirname(oscal.__file__)
+    for _, name, _ in pkgutil.iter_modules([pkgpath]):
+        __import__(f'trestle.oscal.{name}')
+        clsmembers = inspect.getmembers(sys.modules[f'trestle.oscal.{name}'], inspect.isclass)
+        for _, oscal_cls in clsmembers:
+
+            # This removes some enums and other objects.
+            # add check that it is not OscalBaseModel
+            if issubclass(oscal_cls, OscalBaseModel):
+                _ = gens.generate_sample_model(oscal_cls, optional=True, depth=-1)
+
+
 def test_gen_date_authorized() -> None:
     """Corner case test for debugging."""
     model = gens.generate_sample_model(ssp.DateAuthorized)
@@ -146,3 +160,14 @@ def test_gen_date_authorized() -> None:
 def test_gen_moo() -> None:
     """Member of organisation is the one case where __root__ is a uuid constr."""
     _ = gens.generate_sample_model(common.MemberOfOrganization)
+
+
+def test_gen_control() -> None:
+    """Make sure recursion is not going crazy."""
+    _ = gens.generate_sample_model(catalog.Control, optional=True, depth=100)
+
+
+def test_ensure_optional_exists() -> None:
+    """Explicit test to ensure that optional variables are populated."""
+    my_catalog = gens.generate_sample_model(catalog.Catalog, optional=True, depth=-1)
+    assert type(my_catalog.controls[0]) == catalog.Control

--- a/trestle/core/base_model.py
+++ b/trestle/core/base_model.py
@@ -229,7 +229,7 @@ class OscalBaseModel(BaseModel):
         result[classname_to_alias(class_name, 'json')] = self.dict(by_alias=True, exclude_none=True)
         return result
 
-    def oscal_serialize_json(self, pretty: Optional[bool] = False) -> str:
+    def oscal_serialize_json(self, pretty: bool = False) -> str:
         """
         Return an 'oscal wrapped' json object serialized in a compressed form.
 

--- a/trestle/core/generators.py
+++ b/trestle/core/generators.py
@@ -145,9 +145,13 @@ def generate_sample_model(
                     inner_type = utils.get_inner_type(outer_type)
                     if inner_type == model:
                         continue
-                    model_dict[field] = generate_sample_model(outer_type, optional=include_optional, depth=depth - 1)
+                    model_dict[field] = generate_sample_model(
+                        outer_type, include_optional=include_optional, depth=depth - 1
+                    )
                 elif safe_is_sub(outer_type, OscalBaseModel):
-                    model_dict[field] = generate_sample_model(outer_type, optional=include_optional, depth=depth - 1)
+                    model_dict[field] = generate_sample_model(
+                        outer_type, include_optional=include_optional, depth=depth - 1
+                    )
                 else:
                     # Hacking here:
                     # Root models should ideally not exist, however, sometimes we are stuck with them.

--- a/trestle/core/generators.py
+++ b/trestle/core/generators.py
@@ -104,7 +104,7 @@ def generate_sample_value_by_type(
 
 
 def generate_sample_model(
-    model: Union[Type[TG], List[TG], Dict[str, TG]], optional: bool = False, depth: int = -1
+    model: Union[Type[TG], List[TG], Dict[str, TG]], include_optional: bool = False, depth: int = -1
 ) -> TG:
     """Given a model class, generate an object of that class with sample values.
 
@@ -114,13 +114,13 @@ def generate_sample_model(
 
     Args:
         model: The model type provided. Typically for a user as an OscalBaseModel Subclass.
-        optional: Whether or not to generate optional fields.
+        include_optional: Whether or not to generate optional fields.
         depth: Depth of the tree at which optional fields are generated. Negative values (default) removes the limit.
 
     Returns:
         The generated instance with a pro-forma values filled out as best as possible.
     """
-    effective_optional = optional and not depth == 0
+    effective_optional = include_optional and not depth == 0
 
     model_type = model
     # This block normalizes model type down to
@@ -145,9 +145,9 @@ def generate_sample_model(
                     inner_type = utils.get_inner_type(outer_type)
                     if inner_type == model:
                         continue
-                    model_dict[field] = generate_sample_model(outer_type, optional=optional, depth=depth - 1)
+                    model_dict[field] = generate_sample_model(outer_type, optional=include_optional, depth=depth - 1)
                 elif safe_is_sub(outer_type, OscalBaseModel):
-                    model_dict[field] = generate_sample_model(outer_type, optional=optional, depth=depth - 1)
+                    model_dict[field] = generate_sample_model(outer_type, optional=include_optional, depth=depth - 1)
                 else:
                     # Hacking here:
                     # Root models should ideally not exist, however, sometimes we are stuck with them.


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

Allows the generator to generate optional classes. Nice and safe in terms of what it can generate. More complex object can be generated by chaining this functionality together.

The idea would be to introduce this to `trestle add`.


closes: #599 