### PR TITLE
fix: Emergency fix for trestle packaging.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,6 @@ python_require= '>=3.7'
 [options]
 packages = find:
 include_package_data = True
-[options.packages.find]
-include = trestle*
-exclude = tests
 
 install_requires =
     attrs~=19.3
@@ -44,6 +41,9 @@ install_requires =
     openpyxl~=3.0
     Jinja2 >= 3.0.1
 
+[options.packages.find]
+include = trestle*
+exclude = tests
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description = Tools to manage & autogenerate python objects representing the OSC
 author = IBM
 author_email = chris.butler@au1.ibm.com
 license = Apache Software License v2
-url = https://github.com/IBM/compliance-trestle
+url = https://ibm.github.io/compliance-trestle
 classifiers =
     Development Status :: 4 - Beta
     Environment :: Console
@@ -20,9 +20,14 @@ classifiers =
     Programming Language :: Python :: 3.9
 long_description_content_type = text/markdown
 long_description = file: README.md
-
+python_require= '>=3.7'
 [options]
-packages = trestle
+packages = find:
+include_package_data = True
+[options.packages.find]
+include = trestle*
+exclude = tests
+
 install_requires =
     attrs~=19.3
     ilcli
@@ -38,14 +43,7 @@ install_requires =
     defusedxml
     openpyxl~=3.0
     Jinja2 >= 3.0.1
-    
-[options.package_data]
-trestle.resources = 
-    *.ini
 
-[options.packages.find]
-exclude =
-    tests
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

This fix is required as 0.25.0 due to some setup.cfg changes excludes trestle submodules (e.g. trestle.core). I've refactored the setup.cfg to include the necessary files only (which includes all python files under trestle/ as well as any data files under trestle/ (data files are non-python files such as py.typed).

Closes #749 

Opened long term solution to ensure this does not happen: #750 

# How to manually verify
- Clone / pull code
- cd compliance-trestle
- python setup.py bdist_wheel
- cd dist
- unzip compliance-trestle*.whl
- examine files within the expanded directories.


