### PR TITLE
fix(conftest): Correctly capture return codes (#745).

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from tests import test_utils
 import trestle.core.generators as gens
 import trestle.oscal.common as common
 from trestle.cli import Trestle
+from trestle.core.err import TrestleError
 from trestle.oscal.catalog import Catalog
 from trestle.oscal.component import ComponentDefinition, DefinedComponent
 from trestle.oscal.profile import Profile
@@ -150,11 +151,14 @@ def tmp_trestle_dir(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> Iterato
     os.chdir(tmp_path)
     testargs = ['trestle', 'init']
     monkeypatch.setattr(sys, 'argv', testargs)
-    # FIXME: Correctly capture return codes
-    Trestle().run()
-    yield tmp_path
-
-    os.chdir(pytest_cwd)
+    try:
+        Trestle().run()
+    except BaseException as e:
+        raise TrestleError(f'Initialization failed for temporary trestle directory: {e}.')
+    else:
+        yield tmp_path
+    finally:
+        os.chdir(pytest_cwd)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Capture return codes when trestle init is called in tmp_trestle_dir(). Just added a try block that raises TrestleError() on error with the exception, or else yield the tmp_path initialized. 

Signed-off-by: Jeff Tan <jefferson.tan@gmail.com>

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.


Closes #745.