### PR TITLE
fix: all Alter/Add of prop by_id

### DIFF
--- a/tests/data/json/profile_with_alter_props.json
+++ b/tests/data/json/profile_with_alter_props.json
@@ -51,6 +51,16 @@
                   "remarks": "good stuff"
                 }
               ]
+            },
+            {
+              "by_id": "ac-1_prm_2",
+              "props": [
+                {
+                  "name": "foo",
+                  "value": "bar",
+                  "remarks": "good stuff"
+                }
+              ]
             }
           ]
         },

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -96,8 +96,8 @@ def test_fail_when_reference_id_is_not_given_after_or_before(tmp_trestle_dir: pa
         ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
 
 
-def test_fail_when_props_added(tmp_trestle_dir: pathlib.Path) -> None:
-    """Test when by_id is not given and position is set to after or before it fails."""
+def test_ok_when_props_added(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test when by_id is not given and position is set to after or before it defaults to after."""
     cat_path = test_utils.JSON_NIST_DATA_PATH / test_utils.JSON_NIST_CATALOG_NAME
     repo = Repository(tmp_trestle_dir)
     repo.load_and_import_model(cat_path, 'nist_cat')
@@ -109,7 +109,7 @@ def test_fail_when_props_added(tmp_trestle_dir: pathlib.Path) -> None:
 
 
 def test_profile_missing_position(tmp_trestle_dir: pathlib.Path) -> None:
-    """Test when alter adds parts is missing position."""
+    """Test when alter adds parts is missing position it defaults to after."""
     cat_path = test_utils.JSON_NIST_DATA_PATH / test_utils.JSON_NIST_CATALOG_NAME
     repo = Repository(tmp_trestle_dir)
     repo.load_and_import_model(cat_path, 'nist_cat')
@@ -166,24 +166,20 @@ def test_profile_resolver_failures() -> None:
     """Test failure modes of profile resolver."""
     profile = gens.generate_sample_model(prof.Profile)
     modify = ProfileResolver.Modify(profile)
-    with pytest.raises(TrestleError):
-        modify._add_to_parts_given_position([], 'foo', [], 'bar')
-    with pytest.raises(TrestleError):
-        modify._add_to_parts_given_position([], None, [], 'before')
     control = gens.generate_sample_model(cat.Control)
     # this should not cause error
-    modify._add_to_parts(control, 'foo', [], 'before')
-    with pytest.raises(TrestleError):
-        modify._add_to_parts(control, 'foo', ['x'], 'before')
     add = prof.Add()
+    catalog_interface = CatalogInterface()
+    handle = CatalogInterface.ControlHandle(group_id='foo', path=['bar'], control=control)
+    catalog_interface._control_dict = {control.id: handle}
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control)
+        modify._add_to_control(add, control, catalog_interface)
     add.parts = []
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control)
+        modify._add_to_control(add, control, catalog_interface)
     add.position = prof.Position.before
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control)
+        modify._add_to_control(add, control, catalog_interface)
 
 
 @pytest.mark.parametrize(

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -169,17 +169,14 @@ def test_profile_resolver_failures() -> None:
     control = gens.generate_sample_model(cat.Control)
     # this should not cause error
     add = prof.Add()
-    catalog_interface = CatalogInterface()
-    handle = CatalogInterface.ControlHandle(group_id='foo', path=['bar'], control=control)
-    catalog_interface._control_dict = {control.id: handle}
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control, catalog_interface)
+        modify._add_to_control(add, control)
     add.parts = []
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control, catalog_interface)
+        modify._add_to_control(add, control)
     add.position = prof.Position.before
     with pytest.raises(TrestleError):
-        modify._add_to_control(add, control, catalog_interface)
+        modify._add_to_control(add, control)
 
 
 @pytest.mark.parametrize(

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -434,7 +434,7 @@ class ProfileResolver():
                 raise TrestleError(f'Did not find param for add props: control {control.id} param {add.by_id}')
 
         @staticmethod
-        def _add_to_control(add: prof.Add, control: cat.Control, catalog_interface: CatalogInterface) -> None:
+        def _add_to_control(add: prof.Add, control: cat.Control) -> None:
             """Add altered parts and properties to the control."""
             if not add.parts and not add.props:
                 raise TrestleError('Alter must add parts or props, however none were given.')
@@ -453,8 +453,6 @@ class ProfileResolver():
                 elif not control.props:
                     control.props = []
                     control.props.extend(add.props)
-
-            catalog_interface.replace_control(control)
 
         def _modify_controls(self, catalog: cat.Catalog) -> cat.Catalog:
             """Modify the controls based on the profile."""
@@ -487,7 +485,7 @@ class ProfileResolver():
                                 logger.warning(msg)
                                 add.position = prof.Position.after
                             control = self._catalog_interface.get_control(alter.control_id)
-                            self._add_to_control(add, control, self._catalog_interface)
+                            self._add_to_control(add, control)
                             self._catalog_interface.replace_control(control)
             # use the param_dict to apply all modifys
             control_ids = self._catalog_interface.get_control_ids()


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Allow Alter/Add to add prop by_id, where the id is a param_id in the control

Also changed all add.position to use the Enum form of profile.Position

closes #818

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
