### PR TITLE
fix: profile resolver issues with alter that has no adds

### DIFF
--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -305,7 +305,7 @@ class ControlIOWriter():
         if control.parts:
             for part in control.parts:
                 prose += ControlIOWriter._get_control_section_part(part, part_name)
-        return prose
+        return prose.strip()
 
     @staticmethod
     def merge_dicts_deep(dest: Dict[Any, Any], src: Dict[Any, Any]) -> None:

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -702,21 +702,27 @@ class ProfileResolver():
                 alters = self._profile.modify.alters
 
             if alters is not None:
+                title = self._profile.metadata.title
                 for alter in alters:
                     if alter.control_id is None:
-                        raise TrestleError('Alters must have control id specified.')
+                        logger.warning(f'Alters must have control id specified in profile {title}.')
+                        continue
+                    id_ = alter.control_id
                     if alter.removes is not None:
-                        raise TrestleError('Alters not supported for removes.')
-                    if alter.adds is None and not self._block_adds:
-                        raise TrestleError('Alter has no adds to perform.')
+                        logger.warning(f'Alters not supported for removes in profile {title} control {id_}')
+                        continue
+                    # we want a warning about adds even if adds are blocked, as in profile generate
+                    if alter.adds is None:
+                        logger.warning(f'Alter has no adds in profile {title} control {id_}')
+                        continue
                     if not self._block_adds:
                         for add in alter.adds:
                             if add.position is None and add.parts is not None:
-                                msg = f'Alter/Add position is not specified in control {alter.control_id}'
+                                msg = f'Alter/Add position is not specified in profile {title} control {id_}'
                                 msg += ' when adding part, so defaulting to ending.'
                                 logger.warning(msg)
                                 add.position = prof.Position.ending
-                            control = self._catalog_interface.get_control(alter.control_id)
+                            control = self._catalog_interface.get_control(id_)
                             self._add_to_control(control, add)
                             self._catalog_interface.replace_control(control)
 

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -705,11 +705,11 @@ class ProfileResolver():
                 title = self._profile.metadata.title
                 for alter in alters:
                     if alter.control_id is None:
-                        logger.warning(f'Alters must have control id specified in profile {title}.')
+                        logger.warning(f'Alter must have control id specified in profile {title}.')
                         continue
                     id_ = alter.control_id
                     if alter.removes is not None:
-                        logger.warning(f'Alters not supported for removes in profile {title} control {id_}')
+                        logger.warning(f'Alter not supported for removes in profile {title} control {id_}')
                         continue
                     # we want a warning about adds even if adds are blocked, as in profile generate
                     if alter.adds is None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Changed TrestleError to warning.  Provide warning when doing profile generate.  Added strip() to captured prose.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
