### PR TITLE
feat: Add yaml header to various trestle author docs in a safe manner.

### DIFF
--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -74,7 +74,7 @@ def test_catalog_generate_assemble(
         if add_header:
             yaml = YAML(typ='safe')
             yaml_header = yaml.load(yaml_header_path.open('r'))
-        catalog_generate.generate_markdown(tmp_trestle_dir, catalog_path, markdown_path, yaml_header)
+        catalog_generate.generate_markdown(tmp_trestle_dir, catalog_path, markdown_path, yaml_header, False)
         assert (markdown_path / 'ac/ac-1.md').exists()
         assert test_utils.insert_text_in_file(ac1_path, 'ac-1_prm_6', f'- \\[d\\] {new_prose}')
         if dir_exists:

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -119,7 +119,7 @@ def test_profile_generate_assemble(
         if add_header:
             yaml = YAML(typ='safe')
             yaml_header = yaml.load(yaml_header_path.open('r'))
-        profile_generate.generate_markdown(tmp_trestle_dir, profile_path, markdown_path, yaml_header)
+        profile_generate.generate_markdown(tmp_trestle_dir, profile_path, markdown_path, yaml_header, False)
         assert ac1_path.exists()
         assert test_utils.insert_text_in_file(ac1_path, guid_dict['ref'], guid_dict['text'])
         if dir_exists:

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -117,7 +117,7 @@ def test_profile_generate_assemble(
         profile_generate = ProfileGenerate()
         yaml_header = {}
         if add_header:
-            yaml = YAML(typ='safe')
+            yaml = YAML()
             yaml_header = yaml.load(yaml_header_path.open('r'))
         profile_generate.generate_markdown(tmp_trestle_dir, profile_path, markdown_path, yaml_header, False)
         assert ac1_path.exists()

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -96,7 +96,7 @@ def test_ssp_generate(import_cat, tmp_trestle_dir: pathlib.Path) -> None:
     assert ac_2.stat().st_size > 2000
 
     with open(yaml_path, 'r', encoding=const.FILE_ENCODING) as f:
-        yaml = YAML(typ='safe')
+        yaml = YAML()
         expected_header = yaml.load(f)
     md_api = MarkdownAPI()
     header, tree = md_api.processor.process_markdown(ac_1)
@@ -168,7 +168,7 @@ def test_ssp_generate_header_edit(yaml_header: bool, tmp_trestle_dir: pathlib.Pa
     ac_1 = ac_dir / 'ac-1.md'
 
     with open(yaml_path, 'r', encoding=const.FILE_ENCODING) as f:
-        yaml = YAML(typ='safe')
+        yaml = YAML()
         expected_header = yaml.load(f)
 
     md_api = MarkdownAPI()
@@ -176,7 +176,7 @@ def test_ssp_generate_header_edit(yaml_header: bool, tmp_trestle_dir: pathlib.Pa
     assert tree is not None
     assert expected_header == header
 
-    assert test_utils.insert_text_in_file(ac_1, 'System Specific', '- My new edits\n')
+    assert test_utils.insert_text_in_file(ac_1, 'System Specific', '  - My new edits\n')
     assert test_utils.delete_line_in_file(ac_1, 'Corporate')
 
     # if the yaml header is not written out, the new header should be the one currently in the control

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -45,7 +45,12 @@ def setup_for_ssp(include_header: bool,
 
     sections = 'ImplGuidance:Implementation Guidance,ExpectedEvidence:Expected Evidence,guidance:Guidance'
     args = argparse.Namespace(
-        trestle_root=tmp_trestle_dir, profile=prof_name, output=ssp_name, verbose=True, sections=sections
+        trestle_root=tmp_trestle_dir,
+        profile=prof_name,
+        output=ssp_name,
+        verbose=True,
+        sections=sections,
+        yaml_safe=False
     )
 
     yaml_path = test_utils.YAML_TEST_DATA_PATH / 'good_simple.yaml'
@@ -109,7 +114,8 @@ def test_ssp_generate(import_cat, tmp_trestle_dir: pathlib.Path) -> None:
         output=ssp_name,
         verbose=True,
         sections=sections,
-        yaml_header=str(yaml_path)
+        yaml_header=str(yaml_path),
+        yaml_safe=False
     )
     assert ssp_cmd._run(args) == 1
 

--- a/tests/trestle/core/control_io_test.py
+++ b/tests/trestle/core/control_io_test.py
@@ -147,7 +147,7 @@ end of text
         control.parts.extend([sec_1, sec_2])
 
     writer = ControlIOWriter()
-    writer.write_control(tmp_path, control, '', None, None, additional_content, False, None)
+    writer.write_control(tmp_path, control, '', None, None, additional_content, False, None, False)
 
     md_path = tmp_path / f'{control.id}.md'
     reader = ControlIOReader()
@@ -171,7 +171,7 @@ def test_control_objective(tmp_path: pathlib.Path) -> None:
     sub_dir.mkdir(exist_ok=True)
     # write it out as markdown in a separate directory to avoid name clash
     control_writer = ControlIOWriter()
-    control_writer.write_control(sub_dir, control, 'XY', None, None, False, False, None)
+    control_writer.write_control(sub_dir, control, 'XY', None, None, False, False, None, False)
     # confirm the newly written markdown text is identical to what was read originally
     assert test_utils.text_files_equal(md_path, sub_dir / 'xy-9.md')
 

--- a/tests/trestle/utils/md_writer_test.py
+++ b/tests/trestle/utils/md_writer_test.py
@@ -40,13 +40,11 @@ def test_md_writer(tmp_path: pathlib.Path) -> None:
     md_writer.write_out()
 
     desired_result = """---
-
 a: 1
 b:
   x: 2
   y: 3
 c: 4
-
 ---
 
 ## Control Statement

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -303,7 +303,8 @@ class CatalogInterface():
         sections: Optional[Dict[str, str]],
         responses: bool,
         additional_content: bool = False,
-        profile: Optional[prof.Profile] = None
+        profile: Optional[prof.Profile] = None,
+        yaml_safe: bool = False
     ) -> None:
         """Write out the catalog controls from dict as markdown to the given directory."""
         writer = ControlIOWriter()
@@ -318,7 +319,15 @@ class CatalogInterface():
             if not group_dir.exists():
                 group_dir.mkdir(parents=True, exist_ok=True)
             writer.write_control(
-                group_dir, control, group_title, yaml_header, sections, additional_content, responses, profile
+                group_dir,
+                control,
+                group_title,
+                yaml_header,
+                sections,
+                additional_content,
+                responses,
+                profile,
+                yaml_safe
             )
 
     @staticmethod

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -42,6 +42,9 @@ class CatalogGenerate(AuthorCommonCommand):
         self.add_argument('-n', '--name', help=name_help_str, required=True, type=str)
         self.add_argument('-o', '--output', help=const.HELP_MARKDOWN_NAME, required=True, type=str)
         self.add_argument('-y', '--yaml-header', help=const.HELP_YAML_PATH, required=False, type=str)
+        self.add_argument(
+            '-ys', '--yaml-safe', help=const.HELP_YAML_SAFE, required=False, action='store_true', default=False
+        )
 
     def _run(self, args: argparse.Namespace) -> int:
         log.set_log_level_from_args(args)
@@ -64,16 +67,21 @@ class CatalogGenerate(AuthorCommonCommand):
 
         markdown_path = trestle_root / args.output
 
-        return self.generate_markdown(trestle_root, catalog_path, markdown_path, yaml_header)
+        return self.generate_markdown(trestle_root, catalog_path, markdown_path, yaml_header, args.yaml_safe)
 
     def generate_markdown(
-        self, trestle_root: pathlib.Path, catalog_path: pathlib.Path, markdown_path: pathlib.Path, yaml_header: dict
+        self,
+        trestle_root: pathlib.Path,
+        catalog_path: pathlib.Path,
+        markdown_path: pathlib.Path,
+        yaml_header: dict,
+        yaml_safe: bool
     ) -> int:
         """Generate markdown for the controls in the catalog."""
         try:
             _, _, catalog = load_distributed(catalog_path, trestle_root)
             catalog_interface = CatalogInterface(catalog)
-            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, None, False)
+            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, None, False, yaml_safe=yaml_safe)
         except TrestleNotFoundError as e:
             logger.warning(f'Catalog {catalog_path} not found for load {e}')
             return 1

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -62,7 +62,7 @@ class ProfileGenerate(AuthorCommonCommand):
             if 'yaml_header' in args and args.yaml_header is not None:
                 try:
                     logging.debug(f'Loading yaml header file {args.yaml_header}')
-                    yaml = YAML(typ='safe')
+                    yaml = YAML()
                     yaml_header = yaml.load(pathlib.Path(args.yaml_header).open('r'))
                 except YAMLError as e:
                     logging.warning(f'YAML error loading yaml header for ssp generation: {e}')

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -46,6 +46,9 @@ class ProfileGenerate(AuthorCommonCommand):
         self.add_argument('-n', '--name', help=name_help_str, required=True, type=str)
         self.add_argument('-o', '--output', help=const.HELP_MARKDOWN_NAME, required=True, type=str)
         self.add_argument('-y', '--yaml-header', help=const.HELP_YAML_PATH, required=False, type=str)
+        self.add_argument(
+            '-ys', '--yaml-safe', help=const.HELP_YAML_SAFE, required=False, action='store_true', default=False
+        )
 
     def _run(self, args: argparse.Namespace) -> int:
         try:
@@ -69,14 +72,19 @@ class ProfileGenerate(AuthorCommonCommand):
 
             markdown_path = trestle_root / args.output
 
-            return self.generate_markdown(trestle_root, profile_path, markdown_path, yaml_header)
+            return self.generate_markdown(trestle_root, profile_path, markdown_path, yaml_header, args.yaml_safe)
         except Exception as e:
             logger.error(f'Generation of the profile markdown failed with error: {e}')
             logger.debug(traceback.format_exc())
             return 1
 
     def generate_markdown(
-        self, trestle_root: pathlib.Path, profile_path: pathlib.Path, markdown_path: pathlib.Path, yaml_header: dict
+        self,
+        trestle_root: pathlib.Path,
+        profile_path: pathlib.Path,
+        markdown_path: pathlib.Path,
+        yaml_header: dict,
+        yaml_safe: bool
     ) -> int:
         """Generate markdown for the controls in the profile.
 
@@ -92,7 +100,9 @@ class ProfileGenerate(AuthorCommonCommand):
             _, _, profile = load_distributed(profile_path, trestle_root)
             catalog = ProfileResolver().get_resolved_profile_catalog(trestle_root, profile_path, True)
             catalog_interface = CatalogInterface(catalog)
-            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, None, False, True, profile)
+            catalog_interface.write_catalog_as_markdown(
+                markdown_path, yaml_header, None, False, True, profile, yaml_safe
+            )
         except TrestleNotFoundError as e:
             logger.warning(f'Profile {profile_path} not found, error {e}')
             return 1

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -97,7 +97,9 @@ class SSPGenerate(AuthorCommonCommand):
             logger.debug(traceback.print_exc())
             return 1
         try:
-            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, sections, True, args.yaml_safe)
+            catalog_interface.write_catalog_as_markdown(
+                markdown_path, yaml_header, sections, True, yaml_safe=args.yaml_safe
+            )
         except Exception as e:
             logger.error(f'Error writing the catalog as markdown: {e}')
             logger.debug(traceback.print_exc())

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -63,7 +63,7 @@ class SSPGenerate(AuthorCommonCommand):
         if 'yaml_header' in args and args.yaml_header is not None:
             try:
                 logging.debug(f'Loading yaml header file {args.yaml_header}')
-                yaml = YAML(typ='safe')
+                yaml = YAML()
                 yaml_header = yaml.load(pathlib.Path(args.yaml_header).open('r'))
             except YAMLError as e:
                 logging.warning(f'YAML error loading yaml header for ssp generation: {e}')

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -44,6 +44,9 @@ class SSPGenerate(AuthorCommonCommand):
         self.add_argument('-p', '--profile', help=file_help_str, required=True, type=str)
         self.add_argument('-o', '--output', help=const.HELP_MARKDOWN_NAME, required=True, type=str)
         self.add_argument('-y', '--yaml-header', help=const.HELP_YAML_PATH, required=False, type=str)
+        self.add_argument(
+            '-ys', '--yaml-safe', help=const.HELP_YAML_SAFE, required=False, action='store_true', default=False
+        )
         sections_help_str = 'Comma separated list of section:alias pairs for sections to output'
         self.add_argument('-s', '--sections', help=sections_help_str, required=False, type=str)
 
@@ -94,7 +97,7 @@ class SSPGenerate(AuthorCommonCommand):
             logger.debug(traceback.print_exc())
             return 1
         try:
-            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, sections, True)
+            catalog_interface.write_catalog_as_markdown(markdown_path, yaml_header, sections, True, args.yaml_safe)
         except Exception as e:
             logger.error(f'Error writing the catalog as markdown: {e}')
             logger.debug(traceback.print_exc())

--- a/trestle/core/const.py
+++ b/trestle/core/const.py
@@ -243,4 +243,6 @@ DISPLAY_VERBOSE_OUTPUT = 'Display verbose output'
 
 HELP_YAML_PATH = 'Path to the optional yaml header file'
 
+HELP_YAML_SAFE = 'Only add the yaml header if no header exists.'
+
 HELP_MARKDOWN_NAME = 'Name of the output generated profile markdown folder'

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -350,7 +350,8 @@ class ControlIOWriter():
         sections: Optional[Dict[str, str]],
         additional_content: bool,
         prompt_responses: bool,
-        profile: Optional[prof.Profile]
+        profile: Optional[prof.Profile],
+        yaml_safe: bool
     ) -> None:
         """
         Write out the control in markdown format into the specified directory.
@@ -379,7 +380,7 @@ class ControlIOWriter():
         self._sections = sections
 
         # Need to merge any existing header info with the new one.  Either could be empty.
-        merged_header = yaml_header if yaml_header else {}
+        merged_header = yaml_header if yaml_header and not yaml_safe else {}
         if header:
             ControlIOWriter.merge_dicts_deep(merged_header, header)
         self._add_yaml_header(merged_header)

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -380,7 +380,10 @@ class ControlIOWriter():
         self._sections = sections
 
         # Need to merge any existing header info with the new one.  Either could be empty.
-        merged_header = copy.deepcopy(yaml_header) if yaml_header and not yaml_safe else {}
+        if yaml_safe and not header == {}:
+            merged_header = {}
+        else:
+            merged_header = copy.deepcopy(yaml_header) if yaml_header else {}
         if header:
             ControlIOWriter.merge_dicts_deep(merged_header, header)
         self._add_yaml_header(merged_header)

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Handle direct i/o reading and writing controls as markdown."""
-
+import copy
 import logging
 import pathlib
 import re
@@ -380,7 +380,7 @@ class ControlIOWriter():
         self._sections = sections
 
         # Need to merge any existing header info with the new one.  Either could be empty.
-        merged_header = yaml_header if yaml_header and not yaml_safe else {}
+        merged_header = copy.deepcopy(yaml_header) if yaml_header and not yaml_safe else {}
         if header:
             ControlIOWriter.merge_dicts_deep(merged_header, header)
         self._add_yaml_header(merged_header)

--- a/trestle/core/markdown/md_writer.py
+++ b/trestle/core/markdown/md_writer.py
@@ -128,12 +128,9 @@ class MDWriter():
                 # Make sure yaml header is written first
                 if self._yaml_header:
                     f.write('---\n')
-                    f.write('\n')
-                    yaml = YAML(typ='safe')
-                    yaml.default_flow_style = False
+                    yaml = YAML()
                     yaml.indent(mapping=2, sequence=4, offset=2)
                     yaml.dump(self._yaml_header, f)
-                    f.write('\n')
                     f.write('---\n\n')
 
                 f.write('\n'.join(self._lines))


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
- Adds an extra flag to ensure that the yaml header passed is non destructive
- This is required to cater to scenarios where a control is 'added' in a workflow.
- Also includes fixes to remove yaml reordering.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
