### PR TITLE
refactor: use monkeypatch to replace more mock library patch blocks

### DIFF
--- a/tests/trestle/core/commands/author/command_test.py
+++ b/tests/trestle/core/commands/author/command_test.py
@@ -18,41 +18,43 @@ import pathlib
 import sys
 from unittest import mock
 
+from _pytest.monkeypatch import MonkeyPatch
+
 import pytest
 
 import trestle.cli
 
 
-def test_governed_docs_cli(tmp_trestle_dir: pathlib.Path) -> None:
+def test_governed_docs_cli(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test happy path of md governed-docs subcommand."""
     command = 'trestle author docs'
-    with mock.patch.object(sys, 'argv', command.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-            # FIXME: Needs to be changed once implemented.
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 2
+    monkeypatch.setattr(sys, 'argv', command.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+        # FIXME: Needs to be changed once implemented.
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 2
 
 
-def test_governed_folders_cli(tmp_trestle_dir: pathlib.Path) -> None:
+def test_governed_folders_cli(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test happy path of author governed-folders subcommand."""
     command = 'trestle author folders'
-    with mock.patch.object(sys, 'argv', command.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-            # FIXME: Needs to be changed once implemented.
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 2
+    monkeypatch.setattr(sys, 'argv', command.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+        # FIXME: Needs to be changed once implemented.
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 2
 
 
 @pytest.mark.parametrize(
     'command_string', [('trestle author docs setup -tn test'), ('trestle author folders setup -tn test')]
 )
-def test_failure_not_trestle(command_string, tmp_path: pathlib.Path) -> None:
+def test_failure_not_trestle(command_string, tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test for failure based on not in trestle directory."""
-    with mock.patch.object(sys, 'argv', command_string.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-            # FIXME: Needs to be changed once implemented.
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 1
+    monkeypatch.setattr(sys, 'argv', command_string.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+        # FIXME: Needs to be changed once implemented.
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 1

--- a/tests/trestle/core/commands/author/command_test.py
+++ b/tests/trestle/core/commands/author/command_test.py
@@ -16,7 +16,6 @@
 """Tests for trestle author command module."""
 import pathlib
 import sys
-from unittest import mock
 
 from _pytest.monkeypatch import MonkeyPatch
 

--- a/tests/trestle/core/commands/author/docs_test.py
+++ b/tests/trestle/core/commands/author/docs_test.py
@@ -17,7 +17,6 @@
 import pathlib
 import shutil
 import sys
-from unittest import mock
 from uuid import uuid4
 
 from _pytest.monkeypatch import MonkeyPatch
@@ -35,13 +34,15 @@ from trestle.core.commands.author.consts import START_TEMPLATE_VERSION
         ('trestle author docs setup --task-name catalogs', 1)
     ]
 )
-def test_governed_docs_high(tmp_trestle_dir: pathlib.Path, command_string: str, return_code: int) -> None:
+def test_governed_docs_high(
+    tmp_trestle_dir: pathlib.Path, command_string: str, return_code: int, monkeypatch: MonkeyPatch
+) -> None:
     """Simple execution tests of trestle author docs."""
-    with mock.patch.object(sys, 'argv', command_string.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == return_code
+    monkeypatch.setattr(sys, 'argv', command_string.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == return_code
 
 
 @pytest.mark.parametrize(
@@ -134,11 +135,11 @@ def test_e2e(
     template_target_loc = tmp_trestle_dir / '.trestle' / 'author' / task_name / START_TEMPLATE_VERSION / 'template.md'
     test_content_loc = tmp_trestle_dir / task_name / f'{uuid4()}.md'
     # Test setup
-    with mock.patch.object(sys, 'argv', command_string_setup.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == setup_code
+    monkeypatch.setattr(sys, 'argv', command_string_setup.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == setup_code
     if setup_code > 0:
         return
     # Copy in template:
@@ -169,36 +170,36 @@ def test_e2e(
     assert rc == validate_code
 
 
-def test_failure_bad_template_dir(tmp_trestle_dir: pathlib.Path) -> None:
+def test_failure_bad_template_dir(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Create and test a bad directory."""
     setup_ = 'trestle author docs setup --task-name foobaa'
 
     bad_template_sub_directory = tmp_trestle_dir / '.trestle' / 'author' / 'foobaa' / 'test'
     bad_template_sub_directory.mkdir(parents=True, exist_ok=True)
-    with mock.patch.object(sys, 'argv', setup_.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 1
+    monkeypatch.setattr(sys, 'argv', setup_.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 1
 
 
-def test_success_repeated_call(tmp_trestle_dir: pathlib.Path) -> None:
+def test_success_repeated_call(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test double setup."""
     setup_ = 'trestle author docs setup --task-name foobaa'
 
-    with mock.patch.object(sys, 'argv', setup_.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 0
-    with mock.patch.object(sys, 'argv', setup_.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 0
+    monkeypatch.setattr(sys, 'argv', setup_.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 0
+    monkeypatch.setattr(sys, 'argv', setup_.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 0
 
 
-def test_e2e_debugging(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path) -> None:
+def test_e2e_debugging(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Run an E2E workflow with two test criteria for success."""
     # hardcoded arguments for testing
     task_name = 'test_task'
@@ -218,29 +219,29 @@ def test_e2e_debugging(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path
     template_target_loc = tmp_trestle_dir / '.trestle' / 'author' / task_name / 'template.md'
     test_content_loc = tmp_trestle_dir / task_name / f'{uuid4()}.md'
     # Test setup
-    with mock.patch.object(sys, 'argv', command_string_setup.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == setup_code
+    monkeypatch.setattr(sys, 'argv', command_string_setup.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == setup_code
     if setup_code > 0:
         return
     # Copy in template:
     shutil.copyfile(str(testdata_dir / template_content), str(template_target_loc))
 
-    with mock.patch.object(sys, 'argv', command_string_validate_template.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == template_code
+    monkeypatch.setattr(sys, 'argv', command_string_validate_template.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == template_code
     if template_code > 0:
         return
     # Create sample - should always work if we are here.
-    with mock.patch.object(sys, 'argv', command_string_create_sample.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 0
+    monkeypatch.setattr(sys, 'argv', command_string_create_sample.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 0
 
     shutil.copyfile(str(testdata_dir / target_content), str(test_content_loc))
     if recurse:
@@ -251,11 +252,11 @@ def test_e2e_debugging(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path
         subdir.mkdir()
         sub_content = subdir / f'{uuid4()}.md'
         shutil.copyfile(str(sub_file_path), str(sub_content))
-    with mock.patch.object(sys, 'argv', command_string_validate_content.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == validate_code
+    monkeypatch.setattr(sys, 'argv', command_string_validate_content.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == validate_code
 
 
 @pytest.mark.parametrize(
@@ -319,7 +320,8 @@ def test_directory_content(
     template_code: int,
     validate_code: int,
     testdata_dir: pathlib.Path,
-    tmp_trestle_dir: pathlib.Path
+    tmp_trestle_dir: pathlib.Path,
+    monkeypatch: MonkeyPatch
 ):
     """Test setup where groups of files are tested to allow testing of readme flags."""
     readme_validate_flag = '-rv' if readme_validate else ''
@@ -333,25 +335,25 @@ def test_directory_content(
     # Test setup
     shutil.copytree(str(testdata_dir / template_source_directory), str(template_target_directory))
     shutil.copytree(str(testdata_dir / target_source_directory), str(task_directory))
-    with mock.patch.object(sys, 'argv', command_string_validate_template.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == template_code
+    monkeypatch.setattr(sys, 'argv', command_string_validate_template.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == template_code
     if template_code > 0:
         return
     # Create sample - should always work if we are here.
-    with mock.patch.object(sys, 'argv', command_string_create_sample.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == 0
+    monkeypatch.setattr(sys, 'argv', command_string_create_sample.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == 0
 
-    with mock.patch.object(sys, 'argv', command_string_validate_content.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == validate_code
+    monkeypatch.setattr(sys, 'argv', command_string_validate_content.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == validate_code
 
 
 @pytest.mark.parametrize(

--- a/tests/trestle/core/commands/author/folders_test.py
+++ b/tests/trestle/core/commands/author/folders_test.py
@@ -17,7 +17,6 @@
 import pathlib
 import shutil
 import sys
-from unittest import mock
 from uuid import uuid4
 
 from _pytest.monkeypatch import MonkeyPatch
@@ -38,14 +37,16 @@ from trestle.utils import fs
         ('trestle author folders setup --task-name catalogs', 1)
     ]
 )
-def test_governed_folders_high(tmp_trestle_dir: pathlib.Path, command_string: str, return_code: int) -> None:
+def test_governed_folders_high(
+    tmp_trestle_dir: pathlib.Path, command_string: str, return_code: int, monkeypatch: MonkeyPatch
+) -> None:
     """Simple execution tests of trestle author folders."""
-    with mock.patch.object(sys, 'argv', command_string.split()):
-        with pytest.raises(SystemExit) as wrapped_error:
-            trestle.cli.run()
-            # FIXME: Needs to be changed once implemented.
-        assert wrapped_error.type == SystemExit
-        assert wrapped_error.value.code == return_code
+    monkeypatch.setattr(sys, 'argv', command_string.split())
+    with pytest.raises(SystemExit) as wrapped_error:
+        trestle.cli.run()
+        # FIXME: Needs to be changed once implemented.
+    assert wrapped_error.type == SystemExit
+    assert wrapped_error.value.code == return_code
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

This improves more unittest *patch* blocks (from the mock library) with *monkeypatch* instead, to avoid the indentations and subsequent asserts. Actually this one takes care of blocks missed in [this previous PR](https://github.com/IBM/compliance-trestle/pull/739), which addressed issue #673 (which was resolved back then).