### PR TITLE
fix: bad control causes uncaught exception in ssp-generate

### DIFF
--- a/tests/data/json/profile_bad_control.json
+++ b/tests/data/json/profile_bad_control.json
@@ -1,0 +1,24 @@
+{
+  "profile": {
+    "uuid": "b7ac2bb6-75ec-411e-a162-378f50ac4ea3",
+    "metadata": {
+      "title": "Sample profile.",
+      "last-modified": "2021-11-17T15:46:14.402466-08:00",
+      "version": "0.0.0",
+      "oscal-version": "1.0.0"
+    },
+    "imports": [
+      {
+        "href": "https://github.com/usnistgov/oscal-content/raw/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_MODERATE-baseline-resolved-profile_catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "ac-2-1"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -23,6 +23,7 @@ from ruamel.yaml import YAML
 
 from tests import test_utils
 
+import trestle.oscal.profile as prof
 import trestle.oscal.ssp as ossp
 from trestle.core import const
 from trestle.core.commands.author.ssp import SSPAssemble, SSPFilter, SSPGenerate
@@ -288,3 +289,14 @@ def test_ssp_filter(tmp_trestle_dir: pathlib.Path) -> None:
     )
     ssp_filter = SSPFilter()
     assert ssp_filter._run(args) == 1
+
+
+def test_ssp_bad_control_id(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test ssp gen when profile has bad control id."""
+    profile = prof.Profile.oscal_read(test_utils.JSON_TEST_DATA_PATH / 'profile_bad_control.json')
+    fs.save_top_level_model(profile, tmp_trestle_dir, 'bad_prof', fs.FileContentType.JSON)
+    args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir, profile='bad_prof', output='my_ssp', verbose=False, sections=None
+    )
+    ssp_cmd = SSPGenerate()
+    assert ssp_cmd._run(args) == 1

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -179,8 +179,10 @@ class ProfileResolver():
                 if control_id not in loaded_ids:
                     control = self._catalog_interface.get_control(control_id)
                     if control is None:
-                        msg = f'Profile {self._profile.metadata.title} references control {control_id} '
-                        + f'but it is not in catalog {self._catalog.metadata.title}'
+                        msg = (
+                            f'Profile titled "{self._profile.metadata.title}" references control {control_id} '
+                            f'but it is not in catalog titled "{self._catalog.metadata.title}"'
+                        )
                         raise TrestleError(msg)
                     control = self._prune_control(needed_ids, control, loaded_ids)
                     self._catalog_interface.replace_control(control)

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -68,6 +68,8 @@ class ProfileResolver():
             Inject the import.
 
             This needs to be created prior to knowing the catalog.
+            The profile itself is only needed for debug messages.
+            The import is one possibly several imports in that profile.
             """
             self._import = import_
             self._profile = profile


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Profile referencing control not in catalog caused exception with no error info.
Now catch the exception and provide details on the control and profile involved.

closes #892 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar
