### PR TITLE
feat: Altering ssp-generate to add all sections by default

### DIFF
--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -82,9 +82,12 @@ def confirm_control_contains(trestle_dir: pathlib.Path, control_id: str, part_la
 
 
 @pytest.mark.parametrize('import_cat', [False, True])
-def test_ssp_generate(import_cat, tmp_trestle_dir: pathlib.Path) -> None:
+@pytest.mark.parametrize('sections', [False, True])
+def test_ssp_generate(import_cat, sections, tmp_trestle_dir: pathlib.Path) -> None:
     """Test the ssp generator."""
-    args, sections, yaml_path = setup_for_ssp(True, False, tmp_trestle_dir, import_cat)
+    args, _, yaml_path = setup_for_ssp(True, False, tmp_trestle_dir, import_cat)
+    if not sections:
+        args.sections = None
     ssp_cmd = SSPGenerate()
     # run the command for happy path
     assert ssp_cmd._run(args) == 0

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -460,3 +460,15 @@ class CatalogInterface():
                 logging.error(f'controls differ: {a.id}')
                 return False
         return True
+
+    def get_sections(self) -> List[str]:
+        """Get the available sections by a full index of all controls."""
+        sections: List[str] = []
+
+        for control in self._control_dict.values():
+            if not control.control.parts:
+                continue
+            for part in control.control.parts:
+                if part.name not in sections:
+                    sections.append(part.name)
+        return sections

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -18,7 +18,7 @@ import copy
 import logging
 import pathlib
 import traceback
-from typing import List, Set
+from typing import Dict, List, Set
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
@@ -26,7 +26,7 @@ from ruamel.yaml.error import YAMLError
 import trestle.core.generators as gens
 import trestle.oscal.profile as prof
 import trestle.oscal.ssp as ossp
-from trestle.core import const
+from trestle.core import const, err
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
 from trestle.core.profile_resolver import ProfileResolver
@@ -54,8 +54,26 @@ class SSPGenerate(AuthorCommonCommand):
             action='store_true',
             default=False
         )
-        sections_help_str = 'Comma separated list of section:alias pairs for sections to output'
+        sections_help_str = (
+            'Comma separated list of section:alias pairs for sections to output.' + ' Otherwises defaults to all.'
+        )
         self.add_argument('-s', '--sections', help=sections_help_str, required=False, type=str)
+
+    @staticmethod
+    def _sections_from_args(args: argparse.Namespace) -> Dict[str, str]:
+        sections = {}
+        if args.sections is not None:
+            section_tuples = args.sections.strip("'").split(',')
+            for section in section_tuples:
+                if ':' in section:
+                    s = section.split(':')
+                    sections[s[0].strip()] = s[1].strip()
+                else:
+
+                    sections[section] = section
+            if 'statement' in sections.keys():
+                raise err.TrestleError('"statement" sections are not allowed ')
+        return sections
 
     def _run(self, args: argparse.Namespace) -> int:
         log.set_log_level_from_args(args)
@@ -78,23 +96,6 @@ class SSPGenerate(AuthorCommonCommand):
 
         markdown_path = trestle_root / args.output
 
-        sections = None
-        if args.sections is not None:
-            section_tuples = args.sections.strip("'").split(',')
-            sections = {}
-            for section in section_tuples:
-                if ':' in section:
-                    s = section.split(':')
-                    sections[s[0].strip()] = s[1].strip()
-                else:
-
-                    sections[section] = section
-            if 'statement' in sections.keys():
-                logger.warning('Section label "statement" is not allowed.')
-                return 1
-
-        logger.debug(f'ssp sections: {sections}')
-
         profile_resolver = ProfileResolver()
         try:
             resolved_catalog = profile_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
@@ -103,6 +104,18 @@ class SSPGenerate(AuthorCommonCommand):
             logger.error(f'Error creating the resolved profile catalog: {e}')
             logger.debug(traceback.format_exc())
             return 1
+
+        try:
+            sections = SSPGenerate._sections_from_args(args)
+            if sections == {}:
+                s_list = catalog_interface.get_sections()
+                for item in s_list:
+                    sections[item] = item
+            logger.debug(f'ssp sections: {sections}')
+        except err.TrestleError:
+            logger.warning('"statement" section is not allowed.')
+            return 1
+
         try:
             catalog_interface.write_catalog_as_markdown(
                 markdown_path, yaml_header, sections, True, False, None, header_dont_merge=args.header_dont_merge


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
 - Changes the behaviour of spp-generate to default to using all sections.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar
