### PR TITLE
chore: Remove simulate from Plan

### DIFF
--- a/tests/trestle/core/commands/assemble_test.py
+++ b/tests/trestle/core/commands/assemble_test.py
@@ -89,8 +89,8 @@ def test_assemble_execution_failure(
 ) -> None:
     """Test execution of assemble plan fails."""
 
-    def simulate_mock(*args, **kwargs):
-        raise err.TrestleError('simulate_fail')
+    def execute_mock(*args, **kwargs):
+        raise err.TrestleError('execution failed')
 
     test_data_source = testdata_dir / 'split_merge/step4_split_groups_array/catalogs'
     catalogs_dir = pathlib.Path('catalogs/')
@@ -98,7 +98,7 @@ def test_assemble_execution_failure(
     shutil.rmtree(catalogs_dir)
     shutil.rmtree(pathlib.Path('dist'))
     shutil.copytree(test_data_source, catalogs_dir)
-    monkeypatch.setattr(Plan, 'simulate', simulate_mock)
+    monkeypatch.setattr(Plan, 'execute', execute_mock)
     rc = AssembleCmd().assemble_model(
         'catalog', argparse.Namespace(trestle_root=tmp_trestle_dir, name='mycatalog', extension='json', verbose=1)
     )

--- a/tests/trestle/core/commands/create_test.py
+++ b/tests/trestle/core/commands/create_test.py
@@ -116,6 +116,6 @@ def test_execute_failure(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir, extension='json', output='my_catalog', verbose=0, include_optional_fields=False
     )
-    monkeypatch.setattr('trestle.core.models.plans.Plan.simulate', test_utils.patch_raise_exception)
+    monkeypatch.setattr('trestle.core.models.plans.Plan.execute', test_utils.patch_raise_exception)
     rc = create.CreateCmd.create_object('catalog', Catalog, args)
     assert rc == 1

--- a/tests/trestle/core/commands/import__test.py
+++ b/tests/trestle/core/commands/import__test.py
@@ -348,30 +348,8 @@ def test_import_root_key_found(tmp_trestle_dir: pathlib.Path) -> None:
     assert rc == 0
 
 
-def test_import_failure_simulate_plan(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Test model failures throw errors and exit badly."""
-
-    def simulate_plan_mock(*args, **kwargs):
-        raise err.TrestleError('stuff')
-
-    rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
-    catalog_file = f'{tmp_trestle_dir.parent}/{rand_str}.json'
-    catalog_data = generators.generate_sample_model(Catalog)
-    catalog_data.oscal_write(pathlib.Path(catalog_file))
-    monkeypatch.setattr(Plan, 'simulate', simulate_plan_mock)
-    args = argparse.Namespace(
-        trestle_root=tmp_trestle_dir, file=catalog_file, output='imported', verbose=True, regenerate=False
-    )
-    i = importcmd.ImportCmd()
-    rc = i._run(args)
-    assert rc == 1
-
-
 def test_import_failure_execute_plan(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test model failures throw errors and exit badly."""
-
-    def simulate_mock(*args, **kwargs):
-        return
 
     def execute_plan_mock(*args, **kwargs):
         raise err.TrestleError('stuff')
@@ -380,7 +358,6 @@ def test_import_failure_execute_plan(tmp_trestle_dir: pathlib.Path, monkeypatch:
     catalog_file = f'{tmp_trestle_dir.parent}/{rand_str}.json'
     catalog_data = generators.generate_sample_model(Catalog)
     catalog_data.oscal_write(pathlib.Path(catalog_file))
-    monkeypatch.setattr(Plan, 'simulate', simulate_mock)
     monkeypatch.setattr(Plan, 'execute', execute_plan_mock)
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir, file=catalog_file, output='imported', verbose=True, regenerate=False

--- a/tests/trestle/core/commands/merge_test.py
+++ b/tests/trestle/core/commands/merge_test.py
@@ -497,7 +497,6 @@ def test_split_merge_out_of_context(
     else:
         os.chdir(full_path_to_model_dir)
         plan = MergeCmd.merge(pathlib.Path.cwd(), ElementPath(merge_elem), trestle_root=tmp_trestle_dir)
-    plan.simulate()
     plan.execute()
 
     # Check both the catalogs are the same.

--- a/tests/trestle/core/commands/remove_test.py
+++ b/tests/trestle/core/commands/remove_test.py
@@ -60,7 +60,6 @@ def test_remove(tmp_path: pathlib.Path):
 
     add_plan = Plan()
     add_plan.add_action(actual_remove_action)
-    add_plan.simulate()
     add_plan.execute()
 
     # 1.2 Assertion about resulting element after removal
@@ -87,7 +86,6 @@ def test_remove(tmp_path: pathlib.Path):
 
     add_plan = Plan()
     add_plan.add_action(actual_remove_action)
-    add_plan.simulate()
     add_plan.execute()
 
     # 2.2 Assertion about resulting element after removal
@@ -254,10 +252,6 @@ def test_run_failure_plan_execute(
     # Plant this specific logged error for failing execution in mock_execute:
     logged_error = 'fail_execute'
 
-    # Mock a successful simulate(), to avoid the actual simulate() call invoking an execute() call:
-    def mock_simulate(*args, **kwargs):
-        return
-
     def mock_execute(*args, **kwargs):
         raise err.TrestleError(logged_error)
 
@@ -276,7 +270,6 @@ def test_run_failure_plan_execute(
     Trestle().run()
     # .. then attempt to remove it here, but mocking a failed execute:
     testargs = ['trestle', 'remove', '-f', str(catalog_def_file), '-e', 'catalog.metadata.remarks']
-    monkeypatch.setattr(Plan, 'simulate', mock_simulate)
     monkeypatch.setattr(Plan, 'execute', mock_execute)
     monkeypatch.setattr(sys, 'argv', testargs)
     caplog.clear()

--- a/tests/trestle/core/commands/replicate_test.py
+++ b/tests/trestle/core/commands/replicate_test.py
@@ -111,9 +111,6 @@ def test_replicate_cmd_failures(testdata_dir, tmp_trestle_dir, regen, monkeypatc
     def execute_trestle_error(*args, **kwargs):
         raise err.TrestleError('execute_trestle_error')
 
-    def simulate_trestle_error(*args, **kwargs):
-        raise err.TrestleError('simulate_trestle_error')
-
     # prepare trestle project dir with the file
     test_utils.ensure_trestle_config_dir(tmp_trestle_dir)
     source_name = 'minimal_catalog'
@@ -152,7 +149,6 @@ def test_replicate_cmd_failures(testdata_dir, tmp_trestle_dir, regen, monkeypatc
     assert rc == 1
 
     monkeypatch.setattr('trestle.core.commands.replicate.load_distributed', load_distributed_return)
-    monkeypatch.setattr('trestle.core.commands.replicate.Plan.simulate', mock_return)
     monkeypatch.setattr('trestle.core.commands.replicate.Plan.rollback', mock_return)
     monkeypatch.setattr('trestle.core.commands.replicate.Plan.execute', execute_trestle_error)
     rc = ReplicateCmd.replicate_object('catalog', args)
@@ -160,7 +156,7 @@ def test_replicate_cmd_failures(testdata_dir, tmp_trestle_dir, regen, monkeypatc
 
     # Force TrestleError in simulate:
     monkeypatch.setattr('trestle.core.commands.replicate.load_distributed', load_distributed_return)
-    monkeypatch.setattr('trestle.core.commands.replicate.Plan.simulate', simulate_trestle_error)
+    monkeypatch.setattr('trestle.core.commands.replicate.Plan.execute', execute_trestle_error)
     rc = ReplicateCmd.replicate_object('catalog', args)
     assert rc == 1
 

--- a/trestle/core/commands/add.py
+++ b/trestle/core/commands/add.py
@@ -102,7 +102,6 @@ class AddCmd(CommandPlusDocs):
             add_plan.add_action(create_action)
             add_plan.add_action(write_action)
 
-            add_plan.simulate()
             add_plan.execute()
             return CmdReturnCodes.SUCCESS.value
         except err.TrestleError as e:

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -110,7 +110,6 @@ class AssembleCmd(CommandPlusDocs):
                 )
 
                 try:
-                    plan.simulate()
                     plan.execute()
                 except Exception as e:
                     logger.error('Unknown error executing trestle create operations. Rolling back.')

--- a/trestle/core/commands/create.py
+++ b/trestle/core/commands/create.py
@@ -104,7 +104,6 @@ class CreateCmd(CommandPlusDocs):
             create_plan = Plan()
             create_plan.add_action(create_action)
             create_plan.add_action(write_action)
-            create_plan.simulate()
             create_plan.execute()
             return CmdReturnCodes.SUCCESS.value
         except Exception as e:

--- a/trestle/core/commands/import_.py
+++ b/trestle/core/commands/import_.py
@@ -110,13 +110,6 @@ class ImportCmd(CommandPlusDocs):
         import_plan.add_action(write_action)
 
         try:
-            import_plan.simulate()
-        except TrestleError as err:
-            logger.debug(f'import_plan.simulate() failed: {err}')
-            logger.error(f'Import failed, error in simulating import operation: {err}')
-            return CmdReturnCodes.COMMAND_ERROR.value
-
-        try:
             import_plan.execute()
         except TrestleError as err:
             logger.debug(f'import_plan.execute() failed: {err}')

--- a/trestle/core/commands/merge.py
+++ b/trestle/core/commands/merge.py
@@ -77,7 +77,6 @@ class MergeCmd(CommandPlusDocs):
             for element_path in element_paths:
                 logger.debug(f'merge {element_path}')
                 plan = cls.merge(effective_cwd, ElementPath(element_path), trestle_root)
-                plan.simulate()
                 plan.execute()
         except TrestleError as err:
             logger.error(f'Merge failed: {err}')

--- a/trestle/core/commands/remove.py
+++ b/trestle/core/commands/remove.py
@@ -107,13 +107,6 @@ class RemoveCmd(CommandPlusDocs):
             add_plan.add_action(write_action)
 
             try:
-                add_plan.simulate()
-            except TrestleError as err:
-                logger.debug(f'Remove failed at simulate(): {err}')
-                logger.error(f'Remove failed (simulate()): {err}')
-                return CmdReturnCodes.COMMAND_ERROR.value
-
-            try:
                 add_plan.execute()
             except TrestleError as err:
                 logger.debug(f'Remove failed at execute(): {err}')

--- a/trestle/core/commands/replicate.py
+++ b/trestle/core/commands/replicate.py
@@ -132,13 +132,6 @@ class ReplicateCmd(CommandPlusDocs):
         replicate_plan.add_action(write_action)
 
         try:
-            replicate_plan.simulate()
-        except TrestleError as err:
-            logger.debug(f'replicate_plan.simulate() failed: {err}')
-            logger.error(f'Replicate failed, error in simulating replicate operation: {err}')
-            return CmdReturnCodes.COMMAND_ERROR.value
-
-        try:
             replicate_plan.execute()
         except TrestleError as err:
             logger.debug(f'replicate_plan.execute() failed: {err}')

--- a/trestle/core/commands/split.py
+++ b/trestle/core/commands/split.py
@@ -196,10 +196,6 @@ class SplitCmd(CommandPlusDocs):
                 model, element_paths, base_dir, content_type, file_name_no_path, aliases_to_strip
             )
 
-            # Simulate the plan
-            # if it fails, it would throw errors and get out of this command
-            split_plan.simulate()
-
             # If we are here then simulation passed
             # so move the original file to the trash
             trash.store(file_path, True)

--- a/trestle/core/commands/split.py
+++ b/trestle/core/commands/split.py
@@ -195,13 +195,15 @@ class SplitCmd(CommandPlusDocs):
             split_plan = cls.split_model(
                 model, element_paths, base_dir, content_type, file_name_no_path, aliases_to_strip
             )
-
-            # If we are here then simulation passed
-            # so move the original file to the trash
             trash.store(file_path, True)
 
-            # execute the plan
-            split_plan.execute()
+            try:
+                split_plan.execute()
+            except Exception as e:
+                logger.error(f'Split has failed with error: {e}.')
+                trash.recover(file_path, True)
+                return CmdReturnCodes.COMMAND_ERROR.value
+
         return CmdReturnCodes.SUCCESS.value
 
     @classmethod

--- a/trestle/core/models/plans.py
+++ b/trestle/core/models/plans.py
@@ -64,10 +64,9 @@ class Plan:
             try:
                 action.execute()
             except Exception as e:
-                logger.error(f'Failed to execute action {action} for the plan: {e}.')
-                if action.has_rollback():
-                    logger.error('Rolling back the action...')
-                    self.rollback()
+                logger.error(f'Failed to execute action {action} for the plan: {e}. Rolling back.')
+                self.rollback()
+                raise e
 
     def rollback(self) -> None:
         """Rollback the actions in the plan."""

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -104,7 +104,6 @@ class ManagedOSCAL:
         import_plan.add_action(create_action)
         import_plan.add_action(write_action)
 
-        import_plan.simulate()
         import_plan.execute()
 
         logger.debug(f'Model {self.model_name} written to repository')
@@ -162,7 +161,6 @@ class ManagedOSCAL:
         try:
             for elem in elements:
                 plan = mergecmd.MergeCmd.merge(effective_cwd, ElementPath(elem), self.root_dir)
-                plan.simulate()
                 plan.execute()
 
         except Exception as e:
@@ -224,8 +222,6 @@ class Repository:
         import_plan = Plan()
         import_plan.add_action(create_action)
         import_plan.add_action(write_action)
-
-        import_plan.simulate()
         import_plan.execute()
 
         # Validate the imported file, rollback if unsuccessful


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Remove `simulate()` from the commands.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar

Closes #906 