### PR TITLE
docs: clear edit_uri to remove edit pencil

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+edit_uri: ""
 extra:
   analytics:
     property: G-XT3KGMHSY8

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,8 @@
-edit_uri: ""
+edit_uri: ''
 extra:
   analytics:
     property: G-XT3KGMHSY8
     provider: google
-extra_css:
-- css/extra.css
 markdown_extensions:
 - admonition
 - markdown_include.include


### PR DESCRIPTION
Closes: https://github.com/IBM/compliance-trestle/issues/529

Signed-off-by: Ryan Moats <rmoats@us.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Set edit_url field in mkdocs.yml to empty string to see if that removes the pencil icon (edit function) from rendered pages.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
