### PR TITLE
 fix: update control title format for ssp output

### DIFF
--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -122,7 +122,8 @@ class ControlIOWriter():
     def _add_control_statement(self, control: cat.Control, group_title: str) -> None:
         """Add the control statement and items to the md file."""
         self._md_file.new_paragraph()
-        title = f'{control.id} - \[{group_title}\] {control.title}'
+        label = self._get_label(control) if self._get_label(control) != '' else control.id.upper()
+        title = f'{label} - {control.title}'
         self._md_file.new_header(level=1, title=title)
         self._md_file.new_header(level=2, title='Control Statement')
         self._md_file.set_indent_level(-1)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Updates the output for control headings to use the label, e.g. AC-2(1), rather than the control ID, e.g. ac-2.1, because the labels are commonly used to refer to controls in documents. 

The else clause allows for the case where controls do not have a label set (for example the IBM control catalog) - or does this highlight an issue elsewhere if controls do not have a label set?

Removed the group title from the titles, not necessary here.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
