### PR TITLE
fix: Handle error when dealing with profiles with no modify object.

### DIFF
--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -374,6 +374,8 @@ class CatalogInterface():
     def get_full_profile_param_dict(profile: prof.Profile) -> Dict[str, str]:
         """Get the full mapping of param_id to modified value for this profile."""
         set_param_dict: Dict[str, str] = {}
+        if not profile.modify:
+            return set_param_dict
         for set_param in as_list(profile.modify.set_parameters):
             value_str = ControlIOReader.param_values_as_string(set_param)
             set_param_dict[set_param.param_id] = value_str


### PR DESCRIPTION
Signed-off-by: Chris Butler <chris@thebutlers.me>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
- Handles an error found when profile.modify was null
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
