### PR TITLE
feat: add optional numbering of figures and tables when generating md…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     rev: 0.7.11
     hooks:
     - id: mdformat
-      exclude: "CHANGELOG.md|docs/mkdocs_code_of_conduct.md|docs/api_reference|tests/data/author|docs/contributing/mkdocs_contributing.md|tests/data/jinja_markdown_include"
+      exclude: "CHANGELOG.md|docs/mkdocs_code_of_conduct.md|docs/api_reference|tests/data/author|docs/contributing/mkdocs_contributing.md|tests/data/jinja_markdown_include|tests/data/jinja_cmd/number_captions_data.md|tests/data/jinja_cmd/number_captions_expected_output.md"
       additional_dependencies:
       - mdformat-tables
       - mdformat-config

--- a/tests/data/jinja_cmd/number_captions_data.md
+++ b/tests/data/jinja_cmd/number_captions_data.md
@@ -1,0 +1,12 @@
+# Markdown document
+
+![Image One](img1.png)
+![Image Two](img2.png)
+[link](url)
+![malformed image][malformed.png]
+!(malformed image)[malformed.png]
+Table: informational table
+Table: another informational table
+table: lowercase table
+A sentence that ends with table:
+A sentence with Table: in it

--- a/tests/data/jinja_cmd/number_captions_expected_output.md
+++ b/tests/data/jinja_cmd/number_captions_expected_output.md
@@ -1,0 +1,12 @@
+# Markdown document
+
+![Figure 1 - Image One](img1.png)
+![Figure 2 - Image Two](img2.png)
+[link](url)
+![malformed image][malformed.png]
+!(malformed image)[malformed.png]
+Table: Table 1 - informational table
+Table: Table 2 - another informational table
+Table: Table 3 - lowercase table
+A sentence that ends with table:
+A sentence with Table: in it

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -20,6 +20,7 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from tests.test_utils import execute_command_and_assert, setup_for_ssp
 
+from trestle.core.commands.author.jinja import _number_captions
 from trestle.core.commands.author.ssp import SSPGenerate
 from trestle.core.markdown.markdown_node import MarkdownNode
 
@@ -82,3 +83,15 @@ def test_jinja_lookup_table(
         node2 = tree.get_node_for_key('# B')
         assert node1.content.text[1] == 'This word: compliance-trestle, was substituted.'
         assert node2.content.text
+
+
+def test_number_captions(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Test numbering of captions in markdown."""
+    with open(testdata_dir / 'jinja_cmd/number_captions_data.md', 'r') as fp:
+        test_data = fp.read()
+
+    with open(testdata_dir / 'jinja_cmd/number_captions_expected_output.md', 'r') as fp:
+        expected_output = fp.read().splitlines()
+
+    for idx, row in enumerate(_number_captions(test_data).splitlines()):
+        assert row == expected_output[idx]

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -18,6 +18,7 @@ import argparse
 import logging
 import operator
 import pathlib
+import re
 import traceback
 import uuid
 from typing import Any, Dict, Optional
@@ -62,6 +63,12 @@ class JinjaCmd(CommandPlusDocs):
             required=False
         )
         self.add_argument(
+            '-nc',
+            '--number-captions',
+            help='Add incremental numbering to table and image captions, in the form Table n - ... and Figure n - ...',
+            action='store_true'
+        )
+        self.add_argument(
             '-ssp', '--system-security-plan', help='An optional SSP to be passed', default=None, required=False
         )
         self.add_argument('-p', '--profile', help='An optional profile to be passed', default=None, required=False)
@@ -77,11 +84,11 @@ class JinjaCmd(CommandPlusDocs):
             lookup_table_path = pathlib.Path.cwd() / lut_table
             lut = JinjaCmd.load_LUT(lookup_table_path, args.external_lut_prefix)
             status = JinjaCmd.jinja_ify(
-                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile, lut
+                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile, lut, number_captions=args.number_captions
             )
         else:
             status = JinjaCmd.jinja_ify(
-                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile
+                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile, number_captions=args.number_captions
             )
         logger.debug(f'Done {self.name} command')
         return status
@@ -106,7 +113,8 @@ class JinjaCmd(CommandPlusDocs):
         r_output_file: pathlib.Path,
         ssp: Optional[str],
         profile: Optional[str],
-        lut: Optional[Dict[str, Any]] = None
+        lut: Optional[Dict[str, Any]] = None,
+        number_captions: Optional[bool] = False
     ) -> int:
         """Run jinja over an input file with additional booleans."""
         try:
@@ -158,10 +166,33 @@ class JinjaCmd(CommandPlusDocs):
                 new_output = template.render(**lut)
 
             output_file = trestle_root / r_output_file
-            output_file.open('w', encoding=const.FILE_ENCODING).write(output)
+            if number_captions:
+                output_file.open('w', encoding=const.FILE_ENCODING).write(_number_captions(output))
+            else:
+                output_file.open('w', encoding=const.FILE_ENCODING).write(output)
 
         except Exception as e:  # pragma: no cover
             logger.error(f'Unknown exception {str(e)} occured.')
             logger.debug(traceback.format_exc())
             return 1
         return 0
+    
+def _number_captions(md_body) -> str:
+    """Incrementally number tables and image captions"""
+    images = {}
+    tables = {}
+    output = md_body.splitlines()
+    
+    for n, line in enumerate(output):
+        if re.match('^!\[.+\]\(.+\)', line):
+            images[n] = line
+        if "table: " in output[n].lower():
+            tables[n] = line
+    
+    for n, row in enumerate(tables):
+        output[row] = f'Table: Table {n + 1} - {tables[row].split("Table: ")[1]}'
+
+    for n, row in enumerate(images):
+        output[row] = images[row].replace('![',f'![Figure {n + 1} - ')
+    
+    return "\n".join(output)

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -198,11 +198,11 @@ def _number_captions(md_body: str) -> str:
     for index, line in enumerate(output):
         if re.match('!\[.+\]\(.+\)', line):
             images[index] = line
-        if 'table: ' in output[index].lower():
+        if output[index].lower().startswith('table: '):
             tables[index] = line
 
     for index, row in enumerate(tables):
-        output[row] = f'Table: Table {index + 1} - {tables[row].split("Table: ")[1]}'
+        output[row] = f'Table: Table {index + 1} - {tables[row].split(": ")[1]}'
 
     for index, row in enumerate(images):
         output[row] = images[row].replace('![', f'![Figure {index + 1} - ')

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -84,11 +84,22 @@ class JinjaCmd(CommandPlusDocs):
             lookup_table_path = pathlib.Path.cwd() / lut_table
             lut = JinjaCmd.load_LUT(lookup_table_path, args.external_lut_prefix)
             status = JinjaCmd.jinja_ify(
-                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile, lut, number_captions=args.number_captions
+                pathlib.Path(args.trestle_root),
+                input_path,
+                output_path,
+                args.system_security_plan,
+                args.profile,
+                lut,
+                number_captions=args.number_captions
             )
         else:
             status = JinjaCmd.jinja_ify(
-                pathlib.Path(args.trestle_root), input_path, output_path, args.system_security_plan, args.profile, number_captions=args.number_captions
+                pathlib.Path(args.trestle_root),
+                input_path,
+                output_path,
+                args.system_security_plan,
+                args.profile,
+                number_captions=args.number_captions
             )
         logger.debug(f'Done {self.name} command')
         return status
@@ -176,23 +187,24 @@ class JinjaCmd(CommandPlusDocs):
             logger.debug(traceback.format_exc())
             return 1
         return 0
-    
-def _number_captions(md_body) -> str:
-    """Incrementally number tables and image captions"""
+
+
+def _number_captions(md_body: str) -> str:
+    """Incrementally number tables and image captions."""
     images = {}
     tables = {}
     output = md_body.splitlines()
-    
-    for n, line in enumerate(output):
-        if re.match('^!\[.+\]\(.+\)', line):
-            images[n] = line
-        if "table: " in output[n].lower():
-            tables[n] = line
-    
-    for n, row in enumerate(tables):
-        output[row] = f'Table: Table {n + 1} - {tables[row].split("Table: ")[1]}'
 
-    for n, row in enumerate(images):
-        output[row] = images[row].replace('![',f'![Figure {n + 1} - ')
-    
-    return "\n".join(output)
+    for index, line in enumerate(output):
+        if re.match('!\[.+\]\(.+\)', line):
+            images[index] = line
+        if 'table: ' in output[index].lower():
+            tables[index] = line
+
+    for index, row in enumerate(tables):
+        output[row] = f'Table: Table {index + 1} - {tables[row].split("Table: ")[1]}'
+
+    for index, row in enumerate(images):
+        output[row] = images[row].replace('![', f'![Figure {index + 1} - ')
+
+    return '\n'.join(output)


### PR DESCRIPTION
… ssp using jinja

Signed-off-by: Doug Chivers <doug.chivers@uk.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Add numbering of figures and tables to markdown output, number incrementally from the start of the document (not per the list template, where figures are numbered relative to the section, because section numbers are not known at this point). This uses the Pandoc method of identifying captions - image captions are sourced from the image alt text and table captions are sourced from a Table: line above or below the table. 

For example, 

`![alt text here](image name)`

becomes:

`![Figure n - alt text here](image name)`

which is rendered by Pandoc to 

_Figure n - alt text here_

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
