### PR TITLE
fix: fix blind link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Compliance trestle is currently beta. The expectation is that in ongoing work th
 
 ## Contributing to Trestle
 
-Our project welcomes external contributions. Please consult [contributing](contributing/overview) to get started.
+Our project welcomes external contributions. Please consult [contributing](https://ibm.github.io/compliance-trestle/contributing/mkdocs_contributing/) to get started.
 
 ## License & Authors
 


### PR DESCRIPTION
Signed-off-by: Doug Chivers <doug.chivers@uk.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Contributing link in readme.md lead to 404


## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
