### PR TITLE
fix: add toml as yapf pre-commit dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         args: [--in-place, --parallel, --recursive, --style, .yapf-config]
         files: "^(trestle|tests|scripts)"
         stages: [commit]
+        additional_dependencies: [toml]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:


### PR DESCRIPTION
Signed-off-by: Doug Chivers <doug.chivers@uk.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Fixes https://github.com/IBM/compliance-trestle/issues/971 where `make code-format` fails due to missing toml dependency. This is caused by yapf not including toml in its dependencies, so it is not installed in the venv created by pre-commit.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
