### PR TITLE
fix: fix json blocks in md so mdformat doesnt raise cannot format warn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1  # Use the ref you want to point at
+    rev: v4.1.0  # Use the ref you want to point at
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -8,7 +8,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, develop, --branch, main]
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.31.0
+    rev: v0.32.0
     hooks:
       - id: yapf
         args: [--in-place, --parallel, --recursive, --style, .yapf-config]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -433,11 +433,14 @@ This command allows users to add an OSCAL model to a subcomponent in source dire
 will add the following property under the `metadata` property for a catalog that will be written to the appropriate file under `catalogs/nist800-53` directory:
 
 ```json
-"roles": [
-  {
-    "id": "REPLACE_ME",
-    "title": "REPLACE_ME"
-  }
+{
+  "roles": [
+    {
+      "id": "REPLACE_ME",
+      "title": "REPLACE_ME"
+    }
+  ]
+}
 ```
 
 Default values for mandatory datatypes will be like below. All UUID's will be populated by default whether or not they are mandatory.
@@ -802,8 +805,9 @@ Example output OSCAL Observations file contents (snippet):
           ]
         }
       ]
-    },
-    ...
+    }
+  ]
+}
 ```
 
 </details>
@@ -855,12 +859,83 @@ Example input directory contents listing:
 <summary>display sample</summary>
 
 ```json
-{"IP Address":"fe80::3cd5:564b:940e:49ab","Computer Name":"cmp-wn-2106.demo.tanium.local","Comply - JovalCM Results[c2dc8749]":[{"Benchmark":"CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark","Benchmark Version":"1.5.0.1","Profile":"Windows 10 - NIST 800-53","ID":"xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords","Result":"pass","Custom ID":"800-53: IA-5","Version":"version: 1"}],"Count":"1","Age":"600"}
-{"IP Address":"10.8.69.11","Computer Name":"","Comply - JovalCM Results[c2dc8749]":[{"Benchmark":"CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark","Benchmark Version":"1.5.0.1","Profile":"Windows 10 - NIST 800-53","ID":"xccdf_org.cisecurity.benchmarks_rule_1.1.2_L1_Ensure_Maximum_password_age_is_set_to_60_or_fewer_days_but_not_0","Result":"pass","Custom ID":"800-53: IA-5","Version":"version: 1"}],"Count":"1","Age":"600"}
-{"IP Address":"10.8.69.11","Computer Name":"cmp-wn-2106.demo.tanium.local","Comply - JovalCM Results[c2dc8749]":[{"Benchmark":"CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark","Benchmark Version":"1.5.0.1","Profile":"Windows 10 - NIST 800-53","ID":"xccdf_org.cisecurity.benchmarks_rule_1.1.3_L1_Ensure_Minimum_password_age_is_set_to_1_or_more_days","Result":"fail","Custom ID":"800-53: IA-5","Version":"version: 1"}],"Count":"1","Age":"600"}
-{"IP Address":"10.8.69.11","Computer Name":"cmp-wn-2106.demo.tanium.local","Comply - JovalCM Results[c2dc8749]":[{"Benchmark":"CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark","Benchmark Version":"1.5.0.1","Profile":"Windows 10 - NIST 800-53","ID":"xccdf_org.cisecurity.benchmarks_rule_1.1.4_L1_Ensure_Minimum_password_length_is_set_to_14_or_more_characters","Result":"pass","Custom ID":"800-53: IA-5","Version":"version: 1"}],"Count":"1","Age":"600"}
+{
+  "IP Address": "fe80::3cd5:564b:940e:49ab",
+  "Computer Name": "cmp-wn-2106.demo.tanium.local",
+  "Comply - JovalCM Results[c2dc8749]": [
+    {
+      "Benchmark": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark",
+      "Benchmark Version": "1.5.0.1",
+      "Profile": "Windows 10 - NIST 800-53",
+      "ID": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords",
+      "Result": "pass",
+      "Custom ID": "800-53: IA-5",
+      "Version": "version: 1"
+    }
+  ],
+  "Count": "1",
+  "Age": "600"
+}
+```
 
+```json
+{
+  "IP Address": "10.8.69.11",
+  "Computer Name": "",
+  "Comply - JovalCM Results[c2dc8749]": [
+    {
+      "Benchmark": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark",
+      "Benchmark Version": "1.5.0.1",
+      "Profile": "Windows 10 - NIST 800-53",
+      "ID": "xccdf_org.cisecurity.benchmarks_rule_1.1.2_L1_Ensure_Maximum_password_age_is_set_to_60_or_fewer_days_but_not_0",
+      "Result": "pass",
+      "Custom ID": "800-53: IA-5",
+      "Version": "version: 1"
+    }
+  ],
+  "Count": "1",
+  "Age": "600"
+}
+```
 
+```json
+{
+  "IP Address": "10.8.69.11",
+  "Computer Name": "cmp-wn-2106.demo.tanium.local",
+  "Comply - JovalCM Results[c2dc8749]": [
+    {
+      "Benchmark": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark",
+      "Benchmark Version": "1.5.0.1",
+      "Profile": "Windows 10 - NIST 800-53",
+      "ID": "xccdf_org.cisecurity.benchmarks_rule_1.1.3_L1_Ensure_Minimum_password_age_is_set_to_1_or_more_days",
+      "Result": "fail",
+      "Custom ID": "800-53: IA-5",
+      "Version": "version: 1"
+    }
+  ],
+  "Count": "1",
+  "Age": "600"
+}
+```
+
+```json
+{
+  "IP Address": "10.8.69.11",
+  "Computer Name": "cmp-wn-2106.demo.tanium.local",
+  "Comply - JovalCM Results[c2dc8749]": [
+    {
+      "Benchmark": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark",
+      "Benchmark Version": "1.5.0.1",
+      "Profile": "Windows 10 - NIST 800-53",
+      "ID": "xccdf_org.cisecurity.benchmarks_rule_1.1.4_L1_Ensure_Minimum_password_length_is_set_to_14_or_more_characters",
+      "Result": "pass",
+      "Custom ID": "800-53: IA-5",
+      "Version": "version: 1"
+    }
+  ],
+  "Count": "1",
+  "Age": "600"
+}
 ```
 
 </details>

--- a/docs/reference/third-party-result-schema-SCC.md
+++ b/docs/reference/third-party-result-schema-SCC.md
@@ -58,52 +58,53 @@ The inventory should be included in *local-definitions* if observations are bein
 1. Inventory is captured under *local-definitions* in result object. local-definitions can be used to represent inventory items, components, users, etc. For our purposes only components and inventory-items will be used. Components should be used to represent software, services, etc. whereas inventory-items represent specific machines, VMs, network devices, etc. The inventory items should be associated to a component through *implemented-components* as shown below.
 
    ```json
-   "local-definitions": {
+   {
+     "local-definitions": {
        "components": {
-           "b3e243a1-4660-4f5a-aa85-159b4b2d69ce": {
-               "type": "Operating System",
-               "title": "Windows 10",
-               "description": "Windows 10",
-               "status": {
-                   "state": "operational"
-               }
+         "b3e243a1-4660-4f5a-aa85-159b4b2d69ce": {
+           "type": "Operating System",
+           "title": "Windows 10",
+           "description": "Windows 10",
+           "status": {
+             "state": "operational"
            }
+         }
        },
        "inventory-items": [
-           {
-               "uuid": "c9fb63cf-d21e-4584-88f8-44d67ea33ba0",
-               "description": "inventory",
-               "props": [
-                   {
-                       "name": "Computer Name",
-                       "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                       "value": "cmp-wn-2106.demo.tanium.local"
-                   },
-                   {
-                       "name": "Tanium Client IP Address",
-                       "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                       "value": "192.168.0.120",
-                       "class": "scc_inventory_item_id"
-                   },
-                   {
-                       "name": "IP Address",
-                       "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                       "value": "['fe80::cd44:4154:61e8:53ae', '192.168.0.120']"
-                   },
-                   {
-                       "name": "Count",
-                       "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                       "value": "1"
-                   }
-               ],
-               "implemented-components": [
-                   {
-                       "component-uuid": "b3e243a1-4660-4f5a-aa85-159b4b2d69ce"
-                   }
-               ]
-           },
-           ...
+         {
+           "uuid": "c9fb63cf-d21e-4584-88f8-44d67ea33ba0",
+           "description": "inventory",
+           "props": [
+             {
+               "name": "Computer Name",
+               "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+               "value": "cmp-wn-2106.demo.tanium.local"
+             },
+             {
+               "name": "Tanium Client IP Address",
+               "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+               "value": "192.168.0.120",
+               "class": "scc_inventory_item_id"
+             },
+             {
+               "name": "IP Address",
+               "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+               "value": "['fe80::cd44:4154:61e8:53ae', '192.168.0.120']"
+             },
+             {
+               "name": "Count",
+               "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+               "value": "1"
+             }
+           ],
+           "implemented-components": [
+             {
+               "component-uuid": "b3e243a1-4660-4f5a-aa85-159b4b2d69ce"
+             }
+           ]
+         }
        ]
+     }
    }
    ```
 
@@ -117,9 +118,8 @@ The inventory should be included in *local-definitions* if observations are bein
 
    ```json
    {
-       "uuid" : "00000000-0000-4000-9999-000000000016",
-       "description" : "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords",
-       ...
+     "uuid": "00000000-0000-4000-9999-000000000016",
+     "description": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords"
    }
    ```
 
@@ -212,41 +212,41 @@ The inventory should be included in *local-definitions* if observations are bein
 
    ```json
    {
-       "uuid": "cde35fad-3922-4046-8ef8-830e77ffd75a",
-       "title": "800-53: IA-5",
-       "description": "800-53: IA-5",
-       "target": {
-           "type": "statement-id",
-           "id-ref": "800-53: IA-5",
-           "props": [
-               {
-                   "name": "Profile",
-                   "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                   "value": "Windows 10 - NIST 800-53",
-                   "class": "scc_predefined_profile"
-               },
-               {
-                   "name": "Version",
-                   "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                   "value": "version: 1",
-                   "class": "scc_predefined_profile_version"
-               },
-               {
-                   "name": "Custom ID",
-                   "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
-                   "value": "800-53: IA-5",
-               }
-           ],
-           "status": "not-satisfied"
+     "uuid": "cde35fad-3922-4046-8ef8-830e77ffd75a",
+     "title": "800-53: IA-5",
+     "description": "800-53: IA-5",
+     "target": {
+       "type": "statement-id",
+       "id-ref": "800-53: IA-5",
+       "props": [
+         {
+           "name": "Profile",
+           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+           "value": "Windows 10 - NIST 800-53",
+           "class": "scc_predefined_profile"
+         },
+         {
+           "name": "Version",
+           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+           "value": "version: 1",
+           "class": "scc_predefined_profile_version"
+         },
+         {
+           "name": "Custom ID",
+           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
+           "value": "800-53: IA-5"
+         }
+       ],
+       "status": "not-satisfied"
+     },
+     "related-observations": [
+       {
+         "observation-uuid": "d8bd1785-b95f-45c9-9fa8-32a362845102"
        },
-       "related-observations": [
-           {
-               "observation-uuid": "d8bd1785-b95f-45c9-9fa8-32a362845102"
-           },
-           {
-               "observation-uuid": "d06c6f13-5006-4e2d-b3f3-5cdb577473b1"
-           }
-       ]
+       {
+         "observation-uuid": "d06c6f13-5006-4e2d-b3f3-5cdb577473b1"
+       }
+     ]
    }
    ```
 

--- a/docs/tutorials/task.transformer-construction/transformer-construction.md
+++ b/docs/tutorials/task.transformer-construction/transformer-construction.md
@@ -91,76 +91,76 @@ metadata:
 <summary>example snippet: instance OSCAL Observation</summary>
 
 ```json
+{
+  "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+  "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+  "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
+  "methods": [
+    "TEST-AUTOMATED"
+  ],
+  "subjects": [
     {
-      "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-      "title": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
-      "description": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument",
-      "methods": [
-        "TEST-AUTOMATED"
-      ],
-      "subjects": [
+      "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+      "type": "component",
+      "title": "Red Hat OpenShift Kubernetes"
+    },
+    {
+      "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
+      "type": "inventory-item",
+      "title": "Pod",
+      "props": [
         {
-          "uuid-ref": "56666738-0f9a-4e38-9aac-c0fad00a5821",
-          "type": "component",
-          "title": "Red Hat OpenShift Kubernetes"
+          "name": "target",
+          "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
         },
         {
-          "uuid-ref": "46aADFAC-A1fd-4Cf0-a6aA-d1AfAb3e0d3e",
-          "type": "inventory-item",
-          "title": "Pod",
-          "props": [
-            {
-              "name": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-            },
-            {
-              "name": "cluster-name",
-              "value": "ROKS-OpenSCAP-1"
-            },
-            {
-              "name": "cluster-type",
-              "value": "openshift"
-            },
-            {
-              "name": "cluster-region",
-              "value": "us-south"
-            }
-          ]
-        }
-      ],
-      "relevant-evidence": [
+          "name": "cluster-name",
+          "value": "ROKS-OpenSCAP-1"
+        },
         {
-          "href": "https://github.mycorp.com/degenaro/evidence-locker",
-          "description": "Evidence location.",
-          "props": [
-            {
-              "name": "rule",
-              "ns": "dns://xccdf",
-              "class": "id",
-              "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
-            },
-            {
-              "name": "time",
-              "ns": "dns://xccdf",
-              "class": "timestamp",
-              "value": "2020-08-03T02:26:26+00:00"
-            },
-            {
-              "name": "result",
-              "ns": "dns://xccdf",
-              "class": "result",
-              "value": "fail"
-            },
-            {
-              "name": "target",
-              "ns": "dns://xccdf",
-              "class": "target",
-              "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
-            }
-          ]
+          "name": "cluster-type",
+          "value": "openshift"
+        },
+        {
+          "name": "cluster-region",
+          "value": "us-south"
         }
       ]
-    },
+    }
+  ],
+  "relevant-evidence": [
+    {
+      "href": "https://github.mycorp.com/degenaro/evidence-locker",
+      "description": "Evidence location.",
+      "props": [
+        {
+          "name": "rule",
+          "ns": "dns://xccdf",
+          "class": "id",
+          "value": "xccdf_org.ssgproject.content_rule_scheduler_profiling_argument"
+        },
+        {
+          "name": "time",
+          "ns": "dns://xccdf",
+          "class": "timestamp",
+          "value": "2020-08-03T02:26:26+00:00"
+        },
+        {
+          "name": "result",
+          "ns": "dns://xccdf",
+          "class": "result",
+          "value": "fail"
+        },
+        {
+          "name": "target",
+          "ns": "dns://xccdf",
+          "class": "target",
+          "value": "kube-br7qsa3d0vceu2so1a90-roksopensca-default-0000026b.iks.mycorp"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 </details>
@@ -208,42 +208,47 @@ then the best mapping wound be to Findings with Observations.
 <summary>example snippet: instance OSCAL Finding</summary>
 
 ```json
-      "findings": [
-        {
-          "uuid": "99c0a0de-e34e-4e22-95a1-1d4f24826565",
-          "title": "800-53: IA-5",
-          "description": "800-53: IA-5",
-          "collected": "2021-03-16T13:29:14.000+00:00",
-          "objective-status": {
-            "props": [
-              {
-                "name": "profile",
-                "ns": "dns://tanium",
-                "class": "source",
-                "value": "NIST 800-53"
-              },
-              {
-                "name": "id-ref",
-                "ns": "dns://tanium",
-                "class": "source",
-                "value": "IA-5"
-              },
-              {
-                "name": "result",
-                "ns": "dns://xccdf",
-                "class": "STRVALUE",
-                "value": "FAIL"
-              }
-            ],
-            "status": "not-satisfied"
+{
+  "findings": [
+    {
+      "uuid": "99c0a0de-e34e-4e22-95a1-1d4f24826565",
+      "title": "800-53: IA-5",
+      "description": "800-53: IA-5",
+      "collected": "2021-03-16T13:29:14.000+00:00",
+      "objective-status": {
+        "props": [
+          {
+            "name": "profile",
+            "ns": "dns://tanium",
+            "class": "source",
+            "value": "NIST 800-53"
           },
-          "related-observations": [
-            {
-              "observation-uuid": "61092735-e365-4638-bc2c-ecd0ed407e73"
-            },
-            {
-              "observation-uuid": "95a20b8e-ed0a-4b6c-bf87-8789265c7158"
-            },
+          {
+            "name": "id-ref",
+            "ns": "dns://tanium",
+            "class": "source",
+            "value": "IA-5"
+          },
+          {
+            "name": "result",
+            "ns": "dns://xccdf",
+            "class": "STRVALUE",
+            "value": "FAIL"
+          }
+        ],
+        "status": "not-satisfied"
+      },
+      "related-observations": [
+        {
+          "observation-uuid": "61092735-e365-4638-bc2c-ecd0ed407e73"
+        },
+        {
+          "observation-uuid": "95a20b8e-ed0a-4b6c-bf87-8789265c7158"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 </details>
@@ -252,45 +257,49 @@ then the best mapping wound be to Findings with Observations.
 <summary>example snippet: instance OSCAL Observation</summary>
 
 ```json
-      "observations": [
+{
+  "observations": [
+    {
+      "uuid": "61092735-e365-4638-bc2c-ecd0ed407e73",
+      "description": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords",
+      "props": [
         {
-          "uuid": "61092735-e365-4638-bc2c-ecd0ed407e73",
-          "description": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords",
-          "props": [
-            {
-              "name": "benchmark",
-              "ns": "dns://tanium",
-              "class": "source",
-              "value": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark"
-            },
-            {
-              "name": "rule",
-              "ns": "dns://xccdf",
-              "class": "id",
-              "value": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords"
-            },
-            {
-              "name": "result",
-              "ns": "dns://xccdf",
-              "class": "result",
-              "value": "pass"
-            },
-            {
-              "name": "time",
-              "ns": "dns://xccdf",
-              "class": "timestamp",
-              "value": "2021-03-16T13:29:14+00:00"
-            }
-          ],
-          "methods": [
-            "TEST-AUTOMATED"
-          ],
-          "subjects": [
-            {
-              "uuid-ref": "2650b9ba-e767-4381-9a3f-127d1552d7d2",
-              "type": "inventory-item"
-            }
-          ]
+          "name": "benchmark",
+          "ns": "dns://tanium",
+          "class": "source",
+          "value": "CIS Microsoft Windows 10 Enterprise Release 1803 Benchmark"
+        },
+        {
+          "name": "rule",
+          "ns": "dns://xccdf",
+          "class": "id",
+          "value": "xccdf_org.cisecurity.benchmarks_rule_1.1.1_L1_Ensure_Enforce_password_history_is_set_to_24_or_more_passwords"
+        },
+        {
+          "name": "result",
+          "ns": "dns://xccdf",
+          "class": "result",
+          "value": "pass"
+        },
+        {
+          "name": "time",
+          "ns": "dns://xccdf",
+          "class": "timestamp",
+          "value": "2021-03-16T13:29:14+00:00"
+        }
+      ],
+      "methods": [
+        "TEST-AUTOMATED"
+      ],
+      "subjects": [
+        {
+          "uuid-ref": "2650b9ba-e767-4381-9a3f-127d1552d7d2",
+          "type": "inventory-item"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 </details>
@@ -299,7 +308,8 @@ then the best mapping wound be to Findings with Observations.
 <summary>example snippet: local definitions</summary>
 
 ```json
-"results": [
+{
+  "results": [
     {
       "uuid": "98028241-8705-4211-bf36-71e1f7aa6192",
       "title": "Tanium",
@@ -330,7 +340,12 @@ then the best mapping wound be to Findings with Observations.
                 "value": "Windows 10"
               }
             ]
-          },
+          }
+        ]
+      }
+    }
+  ]
+}
 ```
 
 </details>


### PR DESCRIPTION
Signed-off-by: Doug Chivers <doug.chivers@uk.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [] My PR meets testing requirements.
- [] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

`make mdformat` would raise errors due to inability to format json, which could be misleading to users creating documentation (it appears there is a json formatting error, rather than the standard reformat due to a documentation change), and prevents mdformat reformatting the block. For example:

```
pre-commit run mdformat --all-files
mdformat.................................................................Failed
- hook id: mdformat
- files were modified by this hook

Warning: Failed formatting content of a json code block (line 429 before formatting)
Warning: Failed formatting content of a json code block (line 518 before formatting)
Warning: Failed formatting content of a json code block (line 60 before formatting)
Warning: Failed formatting content of a json code block (line 118 before formatting)
Warning: Failed formatting content of a json code block (line 213 before formatting)
Warning: Failed formatting content of a json code block (line 7 before formatting)
Warning: Failed formatting content of a json code block (line 60 before formatting)
Warning: Failed formatting content of a json code block (line 118 before formatting)
Warning: Failed formatting content of a json code block (line 213 before formatting)
Warning: Failed formatting content of a json code block (line 435 before formatting)
Warning: Failed formatting content of a json code block (line 717 before formatting)
Warning: Failed formatting content of a json code block (line 857 before formatting)
Warning: Failed formatting content of a json code block (line 93 before formatting)
Warning: Failed formatting content of a json code block (line 210 before formatting)
Warning: Failed formatting content of a json code block (line 254 before formatting)
Warning: Failed formatting content of a json code block (line 301 before formatting)
```

This changes any code blocks in the documentation labelled json to be valid json. It is questionable if this is desirable in all cases, for example in CLI line 435 there is an example of a property that is added to a catalog, so by converting this to a valid json dict it doesn't exactly represent what is added to the catalog.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
