### PR TITLE
fix: several issues in profile assemble and catalog generate

### DIFF
--- a/tests/data/author/controls/control_no_labels.md
+++ b/tests/data/author/controls/control_no_labels.md
@@ -1,4 +1,4 @@
-# xy-1 - \[zz\]  Fancy Control
+# xy-1 - \[My Group Title\]  Fancy Control
 
 ## Control statement
 The organisation:

--- a/tests/data/author/controls/control_some_labels.md
+++ b/tests/data/author/controls/control_some_labels.md
@@ -1,4 +1,4 @@
-# xy-1 - \[zz\]  Fancy Control
+# xy-1 - \[My Group Title\]  Fancy Control
 
 ## Control statement
 The organisation:

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -158,4 +158,4 @@ def test_get_profile_param_dict(tmp_trestle_dir: pathlib.Path) -> None:
     full_param_dict = CatalogInterface.get_full_profile_param_dict(profile)
     control_param_dict = CatalogInterface.get_profile_param_dict(control, full_param_dict)
     assert control_param_dict['ac-1_prm_1'] == 'all alert personell'
-    assert 'ac-1_prm_7' not in control_param_dict
+    assert control_param_dict['ac-1_prm_7'] == 'organization-defined events'

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -384,7 +384,7 @@ class CatalogInterface():
     @staticmethod
     def get_profile_param_dict(control: cat.Control, profile_param_dict: Dict[str, str]) -> Dict[str, str]:
         """Get the list of params for this control and any set by the profile."""
-        param_dict = ControlIOReader.get_control_param_dict(control, True)
+        param_dict = ControlIOReader.get_control_param_dict(control, False)
         for key in param_dict.keys():
             if key in profile_param_dict:
                 param_dict[key] = profile_param_dict[key]
@@ -499,11 +499,26 @@ class CatalogInterface():
         for group_id in group_ids:
             group_dir = md_path / group_id
             control_list = []
+            group_title = ''
+            # Need to get group title from one control
+            # All controls in dir should have same group title
+            # Set group title to the first one found and warn if different title appears
             for control_path in CatalogInterface._get_control_paths(group_dir):
-                control = ControlIOReader.read_control(control_path)
+                control, control_group_title = ControlIOReader.read_control(control_path)
+                if control_group_title:
+                    if group_title:
+                        if control_group_title != group_title:
+                            logger.warning(
+                                f'Control {control.id} group title {control_group_title} differs from {group_title}'
+                            )
+                    else:
+                        group_title = control_group_title
+
                 control_list.append(control)
             if group_id:
-                new_group = cat.Group(id=group_id, title='')
+                if not group_title:
+                    logger.warning(f'No group title found in controls for group {group_id}')
+                new_group = cat.Group(id=group_id, title=group_title)
                 new_group.controls = control_list
                 groups.append(new_group)
             else:

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -500,9 +500,11 @@ class CatalogInterface():
             group_dir = md_path / group_id
             control_list = []
             group_title = ''
-            # Need to get group title from one control
+            # Need to get group title from at least one control in this directory
             # All controls in dir should have same group title
-            # Set group title to the first one found and warn if different title appears
+            # Set group title to the first one found and warn if different non-empty title appears
+            # Controls with empty group titles are tolerated but at least one title must be present or warning given
+            # The special group with no name that has the catalog as parent is just a list and has no title
             for control_path in CatalogInterface._get_control_paths(group_dir):
                 control, control_group_title = ControlIOReader.read_control(control_path)
                 if control_group_title:
@@ -522,6 +524,7 @@ class CatalogInterface():
                 new_group.controls = control_list
                 groups.append(new_group)
             else:
+                # if the list of controls has no group id it also has no title and is just the controls of the catalog
                 self._catalog.controls = control_list
         self._catalog.groups = groups if groups else None
         return self._catalog

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -94,7 +94,7 @@ class CatalogGenerate(AuthorCommonCommand):
                 yaml_header,
                 sections=None,
                 responses=False,
-                additional_content=True,
+                additional_content=False,
                 profile=None,
                 preserve_header_values=preserve_header_values
             )

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -139,7 +139,7 @@ class ProfileAssemble(AuthorCommonCommand):
     def _init_arguments(self) -> None:
         name_help_str = (
             'Optional name of the profile model in the trestle workspace that is being modified.  '
-            'If not provided the output name is used. '
+            'If not provided the output name is used.'
         )
         self.add_argument('-n', '--name', help=name_help_str, required=False, type=str)
         file_help_str = 'Name of the source markdown file directory'

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -137,8 +137,11 @@ class ProfileAssemble(AuthorCommonCommand):
     name = 'profile-assemble'
 
     def _init_arguments(self) -> None:
-        name_help_str = 'Name of the profile model in the trestle workspace that is being modified'
-        self.add_argument('-n', '--name', help=name_help_str, required=True, type=str)
+        name_help_str = (
+            'Optional name of the profile model in the trestle workspace that is being modified.  '
+            'If not provided the output name is used. '
+        )
+        self.add_argument('-n', '--name', help=name_help_str, required=False, type=str)
         file_help_str = 'Name of the source markdown file directory'
         self.add_argument('-m', '--markdown', help=file_help_str, required=True, type=str)
         output_help_str = 'Name of the output generated json Profile (ok to overwrite original)'
@@ -149,7 +152,8 @@ class ProfileAssemble(AuthorCommonCommand):
         try:
             log.set_log_level_from_args(args)
             trestle_root = pathlib.Path(args.trestle_root)
-            return self.assemble_profile(trestle_root, args.name, args.markdown, args.output, args.set_parameters)
+            prof_name = args.output if not args.name else args.name
+            return self.assemble_profile(trestle_root, prof_name, args.markdown, args.output, args.set_parameters)
         except Exception as e:
             logger.error(f'Assembly of markdown to profile failed with error: {e}')
             logger.debug(traceback.format_exc())
@@ -210,8 +214,8 @@ class ProfileAssemble(AuthorCommonCommand):
 
         Args:
             trestle_root: The trestle root directory
-            orig_profile_name: The output name of the profile json file to be created from the assembly
-            md_name: The name of the directory containing the markdown control files for the ssp
+            orig_profile_name: The name of the original profile json file used to generate the markdown
+            md_name: The name of the directory containing the markdown control files for the profile
             new_profile_name: The name of the new json profile.  It can be the same as original to overwrite
             set_parameters: Use the parameters in the yaml header to specify values for parameters in the profile
 

--- a/trestle/core/const.py
+++ b/trestle/core/const.py
@@ -296,3 +296,5 @@ COMPLETION_DATE = 'completion-date'
 HELP_SET_PARAMS = 'set profile parameter values based on the yaml header in control markdown'
 
 SET_PARAMS_TAG = 'x-trestle-set-params'
+
+EDITABLE_CONTENT = 'Editable Content'

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -289,7 +289,7 @@ class ControlIOWriter():
         adds = ControlIOWriter._get_adds(control.id, profile)
         has_content = len(adds) > 0
 
-        self._md_file.new_header(level=1, title='Editable Content')
+        self._md_file.new_header(level=1, title=const.EDITABLE_CONTENT)
         self._md_file.new_line('<!-- Make additions and edits below -->')
         self._md_file.new_line(
             '<!-- The above represents the contents of the control as received by the profile, prior to additions. -->'  # noqa E501
@@ -491,20 +491,20 @@ class ControlIOReader():
         return clean_lines, header
 
     @staticmethod
-    def _read_id_group_id_title(line: str) -> Tuple[int, str, str]:
-        """Process the line and find the control id, group id and control title."""
+    def _read_id_group_title_title(line: str) -> Tuple[int, str, str]:
+        """Process the line and find the control id, group title (in brackets) and control title."""
         if line.count('-') < 2:
             raise TrestleError(f'Markdown control title format error: {line}')
         control_id = line.split()[1]
         first_dash = line.find('-')
         title_line = line[first_dash + 1:]
-        group_start = title_line.find('\[')
-        group_end = title_line.find('\]')
-        if group_start < 0 or group_end < 0 or group_start > group_end:
-            raise TrestleError(f'unable to read group and title for control {control_id}')
-        group_id = title_line[group_start + 2:group_end].strip()
-        control_title = title_line[group_end + 2:].strip()
-        return control_id, group_id, control_title
+        group_title_start = title_line.find('\[')
+        group_title_end = title_line.find('\]')
+        if group_title_start < 0 or group_title_end < 0 or group_title_start > group_title_end:
+            raise TrestleError(f'unable to read group title for control {control_id}')
+        group_title = title_line[group_title_start + 2:group_title_end].strip()
+        control_title = title_line[group_title_end + 2:].strip()
+        return control_id, group_title, control_title
 
     @staticmethod
     def _indent(line: str) -> int:
@@ -738,7 +738,7 @@ class ControlIOReader():
         prefix = '## Control '
         while 0 <= ii < len(lines):
             line = lines[ii]
-            if line.startswith('## What is the solution') or line.startswith('# Editable Content'):
+            if line.startswith('## What is the solution') or line.startswith(f'# {const.EDITABLE_CONTENT}'):
                 ii += 1
                 continue
             if not line:
@@ -751,7 +751,7 @@ class ControlIOReader():
             prose = ''
             ii += 1
             while 0 <= ii < len(lines) and not lines[ii].startswith(prefix) and not lines[ii].startswith(
-                    '# Editable Content'):
+                    f'# {const.EDITABLE_CONTENT}'):
                 prose = '\n'.join([prose, lines[ii]])
                 ii += 1
             if prose:
@@ -1047,7 +1047,7 @@ class ControlIOReader():
             prefix = '## Control '
             if line:
                 if not line.startswith(prefix):
-                    raise TrestleError(f'Unexpected line in Editable Content for control {control_id}: {line}')
+                    raise TrestleError(f'Unexpected line in {const.EDITABLE_CONTENT} for control {control_id}: {line}')
                 part_name_raw = line[len(prefix):]
                 part_name = spaces_and_caps_to_snake(part_name_raw)
                 prose_lines = []
@@ -1082,7 +1082,7 @@ class ControlIOReader():
         ii = 0
         while 0 <= ii < len(lines):
             line = lines[ii]
-            if line.startswith('# Editable Content'):
+            if line.startswith(f'# {const.EDITABLE_CONTENT}'):
                 ii += 1
                 while 0 <= ii < len(lines):
                     ii, part = ControlIOReader._read_added_part(ii, lines, control_id)
@@ -1122,7 +1122,7 @@ class ControlIOReader():
         return param_dict
 
     @staticmethod
-    def read_control(control_path: pathlib.Path) -> cat.Control:
+    def read_control(control_path: pathlib.Path) -> Tuple[cat.Control, str]:
         """Read the control markdown file."""
         control = gens.generate_sample_model(cat.Control)
         md_api = MarkdownAPI()
@@ -1131,7 +1131,7 @@ class ControlIOReader():
         if len(control_titles) == 0:
             raise TrestleError(f'Control markdown: {control_path} contains no control title.')
 
-        control.id, _, control.title = ControlIOReader._read_id_group_id_title(control_titles[0])
+        control.id, group_title, control.title = ControlIOReader._read_id_group_title_title(control_titles[0])
 
         control_headers = list(control_tree.get_all_headers_for_level(2))
         if len(control_headers) == 0:
@@ -1142,7 +1142,7 @@ class ControlIOReader():
             0, control_statement.content.raw_text.split('\n'), control.id
         )
         if rc < 0:
-            return control
+            return control, group_title
         control.parts = [statement_part] if statement_part else None
         control_objective = control_tree.get_node_for_key('## Control Objective')
         if control_objective is not None:
@@ -1160,4 +1160,4 @@ class ControlIOReader():
                 _, control.parts = ControlIOReader._read_sections(
                     0, section_node.content.raw_text.split('\n'), control.id, control.parts
                 )
-        return control
+        return control, group_title

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -491,8 +491,8 @@ class ControlIOReader():
         return clean_lines, header
 
     @staticmethod
-    def _read_id_group_title_title(line: str) -> Tuple[int, str, str]:
-        """Process the line and find the control id, group title (in brackets) and control title."""
+    def _parse_control_title_line(line: str) -> Tuple[int, str, str]:
+        """Process the title line and extract the control id, group title (in brackets) and control title."""
         if line.count('-') < 2:
             raise TrestleError(f'Markdown control title format error: {line}')
         control_id = line.split()[1]
@@ -1123,7 +1123,7 @@ class ControlIOReader():
 
     @staticmethod
     def read_control(control_path: pathlib.Path) -> Tuple[cat.Control, str]:
-        """Read the control markdown file."""
+        """Read the control and group title from the markdown file."""
         control = gens.generate_sample_model(cat.Control)
         md_api = MarkdownAPI()
         _, control_tree = md_api.processor.process_markdown(control_path)
@@ -1131,7 +1131,7 @@ class ControlIOReader():
         if len(control_titles) == 0:
             raise TrestleError(f'Control markdown: {control_path} contains no control title.')
 
-        control.id, group_title, control.title = ControlIOReader._read_id_group_title_title(control_titles[0])
+        control.id, group_title, control.title = ControlIOReader._parse_control_title_line(control_titles[0])
 
         control_headers = list(control_tree.get_all_headers_for_level(2))
         if len(control_headers) == 0:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Group titles weren't handled properly in several places and were lost when reading from markdown.  Now fixed.
Extra editable field was being created improperly with catalog generate
Profile generate wasn't creating parameter headers properly based on set-parameters flag
Profile assemble now has name as optional and otherwise defaults to the output profile name
Test files now use group titles better

closes #962 
closes #966 
closes #967 
closes #968

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
