### PR TITLE
feat: Add custom parameter wrapping to jinja

### DIFF
--- a/docs/trestle_author_jinja.md
+++ b/docs/trestle_author_jinja.md
@@ -27,6 +27,7 @@ Note the examples here use markdown, however, jinja can quite easily target xml 
 - `-p` (optional) profile name (in the trestle project). When used the jinja template will have `resolved_catalog` and `catalog_interface` variables to use.
 - `-lut` (optional) loads yaml into a dictionary in python for which each (top level) variable is available in jinja.
 - `-elp` (optional) a period separated prefix for the variables in the lookup table. E.g. if the lut contained `banana: yellow` and the prefix was `fruit.tropical` using `{{ fruit.tropical.banana }}` would print out `yellow` in the jinja template.
+- `-pf` (optional) use to provide a custom formatting of the substituted parameters in the text. Use dot (.) to indicate where the parameter value will be written. E.g. `-pf *.*` to wrap all the substituted parameters in *bold*, `-pf Prefix:.` to add `Prefix:` to all parameters.
 
 ## Sample jinja templates
 

--- a/docs/trestle_author_jinja.md
+++ b/docs/trestle_author_jinja.md
@@ -27,7 +27,7 @@ Note the examples here use markdown, however, jinja can quite easily target xml 
 - `-p` (optional) profile name (in the trestle project). When used the jinja template will have `resolved_catalog` and `catalog_interface` variables to use.
 - `-lut` (optional) loads yaml into a dictionary in python for which each (top level) variable is available in jinja.
 - `-elp` (optional) a period separated prefix for the variables in the lookup table. E.g. if the lut contained `banana: yellow` and the prefix was `fruit.tropical` using `{{ fruit.tropical.banana }}` would print out `yellow` in the jinja template.
-- `-pf` (optional) use to provide a custom formatting of the substituted parameters in the text. Use dot (.) to indicate where the parameter value will be written. E.g. `-pf *.*` to wrap all the substituted parameters in *bold*, `-pf Prefix:.` to add `Prefix:` to all parameters.
+- `-pf` (optional) use to provide a custom formatting of the substituted parameters in the text. Use dot (.) to indicate where the parameter value will be written. E.g. `-pf *.*` to italicize all substituted parameters, `-pf Prefix:.` to add `Prefix:` to all parameters.
 
 ## Sample jinja templates
 

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -95,3 +95,66 @@ def test_number_captions(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Pa
 
     for idx, row in enumerate(_number_captions(test_data).splitlines()):
         assert row == expected_output[idx]
+
+
+def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Test that parameters are substituted with the given formatting."""
+    input_template = 'ssp_template.md.jinja'
+
+    args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
+    ssp_cmd = SSPGenerate()
+    assert ssp_cmd._run(args) == 0
+
+    command_ssp_gen = 'trestle author ssp-assemble -m my_ssp -o ssp_json'
+    execute_command_and_assert(command_ssp_gen, 0, monkeypatch)
+
+    for file_name in os.listdir(testdata_dir / 'jinja'):
+        full_file_name = os.path.join(testdata_dir / 'jinja', file_name)
+        if os.path.isfile(full_file_name):
+            shutil.copy(full_file_name, tmp_trestle_dir)
+
+    command_md_gen = f'trestle author jinja -pf *.* -i {input_template} -o output.md -ssp ssp_json -p main_profile'
+    execute_command_and_assert(command_md_gen, 0, monkeypatch)
+
+    with open('output.md') as test_output:
+        output = test_output.read()
+        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        assert tree
+        parent = tree.get_node_for_key('### AC-1 - Policy and Procedures')
+        child1 = parent.get_node_for_key('#### AC-1 Summary information')
+        child2 = parent.get_node_for_key('#### Control Statement')
+        for i in range(0, len(child1.content.tables)):
+            if i >= 2:
+                cells = child1.content.tables[i].split('|')
+                if len(cells) < 2:
+                    continue
+                value = cells[2].strip()
+                is_found = False
+                for line in child2.content.text:
+                    if '*' + value + '*' in line:
+                        is_found = True
+                        break
+                assert is_found
+
+    command_md_gen = f'trestle author jinja -pf Prefix:. -i {input_template} -o output.md -ssp ssp_json -p main_profile'
+    execute_command_and_assert(command_md_gen, 0, monkeypatch)
+
+    with open('output.md') as test_output:
+        output = test_output.read()
+        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        assert tree
+        parent = tree.get_node_for_key('### AC-1 - Policy and Procedures')
+        child1 = parent.get_node_for_key('#### AC-1 Summary information')
+        child2 = parent.get_node_for_key('#### Control Statement')
+        for i in range(0, len(child1.content.tables)):
+            if i >= 2:
+                cells = child1.content.tables[i].split('|')
+                if len(cells) < 2:
+                    continue
+                value = cells[2].strip()
+                is_found = False
+                for line in child2.content.text:
+                    if 'Prefix:' + value in line:
+                        is_found = True
+                        break
+                assert is_found

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -146,15 +146,14 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
         parent = tree.get_node_for_key('### AC-1 - Policy and Procedures')
         child1 = parent.get_node_for_key('#### AC-1 Summary information')
         child2 = parent.get_node_for_key('#### Control Statement')
-        for i in range(0, len(child1.content.tables)):
-            if i >= 2:
-                cells = child1.content.tables[i].split('|')
-                if len(cells) < 2:
-                    continue
-                value = cells[2].strip()
-                is_found = False
-                for line in child2.content.text:
-                    if 'Prefix:' + value in line:
-                        is_found = True
-                        break
-                assert is_found
+        for i in range(2, len(child1.content.tables)):
+            cells = child1.content.tables[i].split('|')
+            if len(cells) < 2:
+                continue
+            value = cells[2].strip()
+            is_found = False
+            for line in child2.content.text:
+                if 'Prefix:' + value in line:
+                    is_found = True
+                    break
+            assert is_found

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -69,6 +69,12 @@ class JinjaCmd(CommandPlusDocs):
             action='store_true'
         )
         self.add_argument(
+            '-pf',
+            '--param-formatting',
+            help='Add given text to each parameter, use dot to specify location of param relative to text. i.e. [ . ].',
+            required=False
+        )
+        self.add_argument(
             '-ssp', '--system-security-plan', help='An optional SSP to be passed', default=None, required=False
         )
         self.add_argument('-p', '--profile', help='An optional profile to be passed', default=None, required=False)
@@ -90,7 +96,8 @@ class JinjaCmd(CommandPlusDocs):
                 args.system_security_plan,
                 args.profile,
                 lut,
-                number_captions=args.number_captions
+                number_captions=args.number_captions,
+                parameters_formatting=args.param_formatting
             )
         else:
             status = JinjaCmd.jinja_ify(
@@ -99,7 +106,8 @@ class JinjaCmd(CommandPlusDocs):
                 output_path,
                 args.system_security_plan,
                 args.profile,
-                number_captions=args.number_captions
+                number_captions=args.number_captions,
+                parameters_formatting=args.param_formatting
             )
         logger.debug(f'Done {self.name} command')
         return status
@@ -125,7 +133,8 @@ class JinjaCmd(CommandPlusDocs):
         ssp: Optional[str],
         profile: Optional[str],
         lut: Optional[Dict[str, Any]] = None,
-        number_captions: Optional[bool] = False
+        number_captions: Optional[bool] = False,
+        parameters_formatting: Optional[str] = None
     ) -> int:
         """Run jinja over an input file with additional booleans."""
         try:
@@ -149,7 +158,9 @@ class JinjaCmd(CommandPlusDocs):
                 lut['ssp'] = ssp_data
                 _, profile_path = fs.load_top_level_model(trestle_root, profile, Profile)
                 profile_resolver = ProfileResolver()
-                resolved_catalog = profile_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
+                resolved_catalog = profile_resolver.get_resolved_profile_catalog(
+                    trestle_root, profile_path, False, parameters_formatting
+                )
 
                 ssp_writer = SSPMarkdownWriter(trestle_root)
                 ssp_writer.set_ssp(ssp_data)

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -71,7 +71,8 @@ class JinjaCmd(CommandPlusDocs):
         self.add_argument(
             '-pf',
             '--param-formatting',
-            help='Add given text to each parameter, use dot to specify location of param relative to text. i.e. [ . ].',
+            help='Add given text to each parameter, '
+            'use dot to specify location of parameter (i.e. foo.bar will wrap param with foo and bar)',
             required=False
         )
         self.add_argument(

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -1121,6 +1121,11 @@ class ControlIOReader():
             elif values_only:
                 continue
             if params_format:
+                if params_format.count('.') > 1:
+                    raise TrestleError(
+                        f'Additional text {params_format} '
+                        f'for the parameters cannot contain multiple dots (.)'
+                    )
                 value_str = params_format.replace('.', value_str)
             param_dict[param.id] = value_str
         return param_dict

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -1101,7 +1101,9 @@ class ControlIOReader():
         return new_alters, param_dict
 
     @staticmethod
-    def get_control_param_dict(control: cat.Control, values_only: bool) -> Dict[str, str]:
+    def get_control_param_dict(control: cat.Control,
+                               values_only: bool,
+                               params_format: Optional[str] = None) -> Dict[str, str]:
         """Get a dict of the parameters in a control and their values."""
         param_dict: Dict[str, str] = {}
         params: List[common.Parameter] = as_list(control.params)
@@ -1118,6 +1120,8 @@ class ControlIOReader():
             # if there isn't an actual value then ignore this param
             elif values_only:
                 continue
+            if params_format:
+                value_str = params_format.replace('.', value_str)
             param_dict[param.id] = value_str
         return param_dict
 


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Added additional flag to `trestle author jinja -pf`. This flag allows users to add some text to the parameters or even wrap parameters with specified symbols. To cover all possible scenarios like adding text at the beginning or the end or wrapping the parameters, the decision was to reserve dot `.` to indicate the position of the parameter.

E.g. `trestle author ninja -pf *.*` will italicize all substituted parameters. Or `trestle author jinja -pf Prefix:.` will add `Prefix:` to the beginning of each parameter.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

Closes #965 
