### PR TITLE
fix: allow trace logging with verbose level 2

### DIFF
--- a/tests/trestle/core/commands/merge_test.py
+++ b/tests/trestle/core/commands/merge_test.py
@@ -413,7 +413,7 @@ def test_split_merge(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path) 
 
     # Merge everything back into the catalog
     # Equivalent to trestle merge -e catalog.*
-    args = argparse.Namespace(name='merge', element='catalog.*', verbose=1, trestle_root=tmp_trestle_dir)
+    args = argparse.Namespace(name='merge', element='catalog.*', verbose=2, trestle_root=tmp_trestle_dir)
     rc = MergeCmd()._run(args)
     assert rc == 0
 

--- a/trestle/core/commands/merge.py
+++ b/trestle/core/commands/merge.py
@@ -33,6 +33,7 @@ from trestle.utils import fs, load_distributed
 from trestle.utils import log
 
 logger = logging.getLogger(__name__)
+trace = log.Trace(logger)
 
 
 class MergeCmd(CommandPlusDocs):
@@ -55,9 +56,8 @@ class MergeCmd(CommandPlusDocs):
 
             # remove any quotes passed in as on windows platforms
             elements_clean = args.element.strip("'")
-
             element_paths = elements_clean.split(',')
-            logger.debug(f'merge _run element paths {element_paths}')
+            trace.log(f'merge _run element paths {element_paths}')
             cwd = Path.cwd()
             rc = self.perform_all_merges(element_paths, cwd, args.trestle_root)
             return rc

--- a/trestle/core/commands/split.py
+++ b/trestle/core/commands/split.py
@@ -36,6 +36,7 @@ from trestle.core.trestle_base_model import TrestleBaseModel
 from trestle.utils import fs, trash
 
 logger = logging.getLogger(__name__)
+trace = log.Trace(logger)
 
 
 class AliasTracker(TrestleBaseModel):
@@ -85,7 +86,7 @@ class SplitCmd(CommandPlusDocs):
         """Split an OSCAL file into elements."""
         try:
             log.set_log_level_from_args(args)
-            logger.debug('Entering trestle split.')
+            trace.log('Entering trestle split.')
             # get the Model
             args_raw: Dict[str, str] = args.__dict__
 

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -322,9 +322,9 @@ class Repository:
             raise TrestleError(f'Given model {model_alias} is not a top level model.')
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            verbose = True
+            verbose = 1
         else:
-            verbose = False
+            verbose = 0
         args = argparse.Namespace(
             type=model_alias, name=name, extension=extension, trestle_root=self.root_dir, verbose=verbose
         )
@@ -349,9 +349,9 @@ class Repository:
             raise TrestleError(f'Given model {model_alias} is not a top level model.')
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            verbose = True
+            verbose = 1
         else:
-            verbose = False
+            verbose = 0
         args = argparse.Namespace(type=model_alias, name=name, trestle_root=self.root_dir, verbose=verbose)
 
         try:

--- a/trestle/utils/log.py
+++ b/trestle/utils/log.py
@@ -82,8 +82,25 @@ def exception_handler(exception_type, exception, traceback) -> None:  # pylint: 
 
 def set_log_level_from_args(args: argparse.Namespace) -> None:
     """Vanity function to automatically set log levels based on verbosity flags."""
-    if args.verbose > 0:
+    if args.verbose > 1:
+        # these msgs only output by trace calls
+        set_global_logging_levels(logging.DEBUG - 5)
+    elif args.verbose == 1:
         set_global_logging_levels(logging.DEBUG)
     else:
         set_global_logging_levels(logging.INFO)
         sys.excepthook = exception_handler
+
+
+class Trace():
+    """Class allowing low priority trace message when verbose > 1 and log level below DEBUG."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        """Store the main logger with its module name."""
+        self._logger = logger
+
+    def log(self, msg: str) -> None:
+        """Output the trace msg if log level is below DEBUG."""
+        level = self._logger.getEffectiveLevel()
+        if level < logging.DEBUG:
+            self._logger.debug(msg)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Simple way to add the ability to output trace messages when verbose > 1 - without messing with the logging itself.
If acceptable we can expand its usage.
If it needs to be changed, it should be easy to change all usages.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
