### PR TITLE
feat: Validate OSCAL directories

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ from trestle.oscal import common
 from trestle.oscal import profile as prof
 from trestle.utils import fs
 
-if os.name == 'nt':  # pragma: no cover
+if fs.is_windows():  # pragma: no cover
     import win32api
     import win32con
 
@@ -369,7 +369,7 @@ def make_file_hidden(file_path: pathlib.Path, if_dot=False) -> None:
 
     if_dot will make the change only if the filename is of the form .*
     """
-    if os.name == 'nt':
+    if fs.is_windows():
         if not if_dot or file_path.stem.startswith('.'):
             atts = win32api.GetFileAttributes(str(file_path))
             win32api.SetFileAttributes(str(file_path), win32con.FILE_ATTRIBUTE_HIDDEN | atts)

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -41,7 +41,10 @@ def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     for directory in const.MODEL_DIR_LIST:
         assert os.path.isdir(directory)
         assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
-        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+        if os.name == 'nt':
+            assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_WINDOWS))
+        else:
+            assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_LINUX))
     assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -17,7 +17,6 @@
 
 import os
 import pathlib
-import platform
 import stat
 import sys
 
@@ -27,6 +26,7 @@ import pytest
 
 import trestle.core.const as const
 from trestle import cli
+from trestle.utils import fs
 
 
 def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
@@ -41,7 +41,7 @@ def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     for directory in const.MODEL_DIR_LIST:
         assert os.path.isdir(directory)
         assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
-        if os.name == 'nt':
+        if fs.is_windows():
             assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_WINDOWS))
         else:
             assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_LINUX))
@@ -52,7 +52,7 @@ def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
 def test_directory_creation_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     """Test error during init when a directory cannot be created."""
     # Windows read-only on dir does not prevent file creation in dir
-    if platform.system() == const.WINDOWS_PLATFORM_STR:
+    if fs.is_windows():
         return
     os.chdir(tmp_path)
     config_dir = pathlib.Path(const.TRESTLE_CONFIG_DIR)

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -41,10 +41,7 @@ def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     for directory in const.MODEL_DIR_LIST:
         assert os.path.isdir(directory)
         assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
-        if fs.is_windows():
-            assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_WINDOWS))
-        else:
-            assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE_LINUX))
+        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
     assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 

--- a/tests/trestle/core/remote/cache_test.py
+++ b/tests/trestle/core/remote/cache_test.py
@@ -17,7 +17,6 @@
 
 import getpass
 import pathlib
-import platform
 import random
 import string
 import time
@@ -38,12 +37,13 @@ from trestle.core import generators
 from trestle.core.err import TrestleError
 from trestle.core.remote import cache
 from trestle.oscal.catalog import Catalog
+from trestle.utils import fs
 
 
 def as_file_uri(path: str) -> str:
     """Convert sample non-existent path to file:/// and add drive letter if windows."""
     # Correct usage would start with / and leaving off should cause errors with cache
-    if platform.system() == const.WINDOWS_PLATFORM_STR:
+    if fs.is_windows():
         drive = pathlib.Path.cwd().resolve().drive
         return f'file:///{drive}{path}'
     bare_path = path.lstrip('/')
@@ -328,7 +328,7 @@ def test_fetcher_factory(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
 
     # paths with drive letter
     for uri in ['C:\\Users\\user\\this.json', 'C:/Users/user/this.json', 'C:file.json']:
-        if platform.system() == const.WINDOWS_PLATFORM_STR:
+        if fs.is_windows():
             fetcher = cache.FetcherFactory.get_fetcher(tmp_trestle_dir, uri)
             assert type(fetcher) == cache.LocalFetcher
         else:
@@ -377,7 +377,7 @@ def test_fetcher_expiration(tmp_trestle_dir: pathlib.Path) -> None:
 @pytest.mark.parametrize('uri', ['C:mydir/myfile.json', 'C://mydir/myfile.json'])
 def test_fetcher_failures_windows(uri: str, tmp_trestle_dir: pathlib.Path) -> None:
     """Test failures specific to Windows."""
-    if platform.system() == const.WINDOWS_PLATFORM_STR:
+    if fs.is_windows():
         fetcher = cache.FetcherFactory.get_fetcher(tmp_trestle_dir, uri)
         with pytest.raises(TrestleError):
             _ = fetcher.get_oscal()
@@ -385,7 +385,7 @@ def test_fetcher_failures_windows(uri: str, tmp_trestle_dir: pathlib.Path) -> No
 
 def test_fetcher_failure_windows_wrong_drive(tmp_trestle_dir: pathlib.Path) -> None:
     """Test failures specific to Windows."""
-    if platform.system() == const.WINDOWS_PLATFORM_STR:
+    if fs.is_windows():
         rand_str = ''.join(random.choice(string.ascii_letters) for x in range(16))
         catalog_file = tmp_trestle_dir.parent / f'{rand_str}.json'
         catalog_data = generators.generate_sample_model(Catalog)

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -52,8 +52,12 @@ def test_oscal_dir_valid(tmp_path: pathlib.Path) -> None:
     hidden_file = tmp_path / 'catalogs' / '.hidden.txt'
     test_utils.make_hidden_file(hidden_file)
 
+    keep_file = tmp_path / 'catalogs' / '.keep'
+    test_utils.make_hidden_file(keep_file)
+
     assert fs.check_oscal_directories(tmp_path)
     assert not hidden_file.exists()
+    assert keep_file.exists()
 
     # add some markdown readme
     readme_file = tmp_path / 'catalogs' / 'README.md'
@@ -659,7 +663,7 @@ def test_relative_resolve(tmp_path, candidate: pathlib.Path, build: bool, expect
         _ = fs.relative_resolve(input_path, tmp_path)
 
 
-def test_iterdir_without_hidden_files(tmp_path) -> None:
+def test_iterdir_without_hidden_files(tmp_path: pathlib.Path) -> None:
     """Test that hidden files are filtered from the path."""
     pathlib.Path(tmp_path / 'visible.txt').touch()
     pathlib.Path(tmp_path / 'visibleDir/').mkdir()
@@ -683,6 +687,21 @@ def test_iterdir_without_hidden_files(tmp_path) -> None:
         pathlib.Path(tmp_path / '.hiddenDir/').mkdir()
 
         assert len(list(fs.iterdir_without_hidden_files(tmp_path))) == 3
+
+
+def test_make_hidden_file(tmp_path: pathlib.Path) -> None:
+    """Test make hidden files."""
+    file_path = tmp_path / '.keep'
+    fs.make_hidden_file(file_path)
+
+    file_path2 = tmp_path / 'hidden.txt'
+    fs.make_hidden_file(file_path2)
+
+    assert file_path.exists() and not fs.local_and_visible(file_path)
+    if fs.is_windows():
+        assert file_path2.exists() and not fs.local_and_visible(file_path2)
+    else:
+        assert (tmp_path / '.hidden.txt').exists() and not fs.local_and_visible(tmp_path / '.hidden.txt')
 
 
 def test_full_path_for_top_level_model(tmp_trestle_dir: pathlib.Path, sample_catalog_minimal: catalog.Catalog) -> None:

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for fs module."""
 
-import os
 import pathlib
 from typing import List
 
@@ -28,7 +27,7 @@ from trestle.core.models.file_content_type import FileContentType
 from trestle.oscal import catalog
 from trestle.utils import fs
 
-if os.name == 'nt':  # pragma: no cover
+if fs.is_windows():  # pragma: no cover
     import win32api
     import win32con
 
@@ -50,16 +49,8 @@ def test_oscal_dir_valid(tmp_path: pathlib.Path) -> None:
     assert fs.check_oscal_directories(tmp_path)
 
     # add some hidden files
-    if not os.name == 'nt':
-        hidden_file = tmp_path / 'catalogs' / '.hidden.txt'
-        hidden_file.touch()
-        assert fs.is_hidden(hidden_file)
-    elif os.name == 'nt':
-        hidden_file = tmp_path / 'catalogs' / 'hidden.txt'
-        hidden_file.touch()
-        atts = win32api.GetFileAttributes(str(hidden_file))
-        win32api.SetFileAttributes(str(hidden_file), win32con.FILE_ATTRIBUTE_HIDDEN | atts)
-        assert fs.is_hidden(hidden_file)
+    hidden_file = tmp_path / 'catalogs' / '.hidden.txt'
+    test_utils.make_hidden_file(hidden_file)
 
     assert fs.check_oscal_directories(tmp_path)
     assert not hidden_file.exists()
@@ -502,7 +493,7 @@ def test_get_contextual_file_type(tmp_path: pathlib.Path) -> None:
     assert fs.get_contextual_file_type(mycatalog_dir) == FileContentType.JSON
     (mycatalog_dir / 'file2.json').unlink()
 
-    if os.name == 'nt':
+    if fs.is_windows():
         hidden_file = mycatalog_dir / 'hidden.txt'
         hidden_file.touch()
         atts = win32api.GetFileAttributes(str(hidden_file))
@@ -513,7 +504,7 @@ def test_get_contextual_file_type(tmp_path: pathlib.Path) -> None:
     pathlib.Path(mycatalog_dir / 'file2.json').touch()
     assert fs.get_contextual_file_type(mycatalog_dir) == FileContentType.JSON
 
-    if os.name == 'nt':
+    if fs.is_windows():
         hidden_file.unlink()
     else:
         (mycatalog_dir / '.DS_Store').unlink()
@@ -559,7 +550,7 @@ def test_get_models_of_type_bad_cwd(tmp_path) -> None:
 
 def test_is_hidden_posix(tmp_path) -> None:
     """Test is_hidden on posix systems."""
-    if not os.name == 'nt':
+    if not fs.is_windows():
         hidden_file = tmp_path / '.hidden.md'
         hidden_dir = tmp_path / '.hidden/'
         visible_file = tmp_path / 'visible.md'
@@ -575,7 +566,7 @@ def test_is_hidden_posix(tmp_path) -> None:
 
 def test_is_hidden_windows(tmp_path) -> None:
     """Test is_hidden on windows systems."""
-    if os.name == 'nt':
+    if fs.is_windows():
         visible_file = tmp_path / 'visible.md'
         visible_dir = tmp_path / 'visible/'
         visible_file.touch()
@@ -622,7 +613,7 @@ def test_local_and_visible(tmp_path) -> None:
     """Test if file is local (not symlink) and visible (not hidden)."""
     local_file = tmp_path / 'local.md'
     local_file.touch()
-    if os.name == 'nt':
+    if fs.is_windows():
         link_file = tmp_path / 'not_local.lnk'
         link_file.touch()
     else:
@@ -673,7 +664,7 @@ def test_iterdir_without_hidden_files(tmp_path) -> None:
     pathlib.Path(tmp_path / 'visible.txt').touch()
     pathlib.Path(tmp_path / 'visibleDir/').mkdir()
 
-    if os.name == 'nt':
+    if fs.is_windows():
         """Windows"""
         hidden_file = tmp_path / 'hidden.txt'
         hidden_dir = tmp_path / 'hiddenDir/'

--- a/tests/trestle/utils/fs_test.py
+++ b/tests/trestle/utils/fs_test.py
@@ -17,12 +17,9 @@ import os
 import pathlib
 from typing import List
 
-from _pytest.monkeypatch import MonkeyPatch
-
 import pytest
 
 from tests import test_utils
-from tests.test_utils import execute_command_and_assert
 
 import trestle.core.const as const
 import trestle.oscal.common as common
@@ -44,11 +41,8 @@ def test_should_ignore() -> None:
     assert fs.should_ignore('test') is False
 
 
-def test_oscal_dir_valid(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_oscal_dir_valid(tmp_path: pathlib.Path) -> None:
     """Test if oscal dir is valid or not."""
-    command_init = 'trestle init'
-    execute_command_and_assert(command_init, 0, monkeypatch)
-
     assert fs.check_oscal_directories(tmp_path)
 
     create_sample_catalog_project(tmp_path)
@@ -76,10 +70,8 @@ def test_oscal_dir_valid(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> No
     assert fs.check_oscal_directories(tmp_path)
 
 
-def test_oscal_dir_notvalid(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+def test_oscal_dir_notvalid(tmp_path: pathlib.Path) -> None:
     """Test OSCAL directory not valid."""
-    command_init = 'trestle init'
-    execute_command_and_assert(command_init, 0, monkeypatch)
     assert fs.check_oscal_directories(tmp_path)
     create_sample_catalog_project(tmp_path)
     assert fs.check_oscal_directories(tmp_path)

--- a/trestle/core/commands/command_docs.py
+++ b/trestle/core/commands/command_docs.py
@@ -45,6 +45,7 @@ class CommandPlusDocs(CommandBase):
     """This class validates trestle-root argument.
 
     Trestle commands requiring trestle-root should extend from this class.
+    All commands that extend this class will validate the state of Trestle workspace.
     """
 
     def _validate_arguments(self, args):
@@ -52,6 +53,10 @@ class CommandPlusDocs(CommandBase):
         root = fs.get_trestle_project_root(args.trestle_root)
         if root is None:
             logger.error(f'Given directory {args.trestle_root} is not in a valid trestle root directory')
+            return CmdReturnCodes.TRESTLE_ROOT_ERROR.value
+        is_oscal_dir_valid = fs.check_oscal_directories(args.trestle_root)
+        if not is_oscal_dir_valid:
+            logger.error('OSCAL directories are not valid, please remove extra files specified above.')
             return CmdReturnCodes.TRESTLE_ROOT_ERROR.value
         args.trestle_root = root
         return CmdReturnCodes.SUCCESS.value

--- a/trestle/core/commands/init.py
+++ b/trestle/core/commands/init.py
@@ -16,6 +16,7 @@
 """Trestle Init Command."""
 import argparse
 import logging
+import os
 import pathlib
 import shutil
 from shutil import copyfile
@@ -27,6 +28,10 @@ import trestle.utils.log as log
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.err import TrestleError
+
+if os.name == 'nt':  # pragma: no cover
+    import win32api
+    import win32con
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +75,12 @@ class InitCmd(CommandBase):
             # Create directories
             for directory in directory_list:
                 directory.mkdir(parents=True, exist_ok=True)
-                file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE
+                if os.name == 'nt':
+                    file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_WINDOWS
+                    atts = win32api.GetFileAttributes(str(file_path))
+                    win32api.SetFileAttributes(str(file_path), win32con.FILE_ATTRIBUTE_HIDDEN | atts)
+                else:
+                    file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_LINUX
                 file_path.touch()
         except OSError as e:
             raise TrestleError(f'Error while creating directories: {e}')

--- a/trestle/core/commands/init.py
+++ b/trestle/core/commands/init.py
@@ -16,7 +16,6 @@
 """Trestle Init Command."""
 import argparse
 import logging
-import os
 import pathlib
 import shutil
 from shutil import copyfile
@@ -28,8 +27,9 @@ import trestle.utils.log as log
 from trestle.core.commands.command_docs import CommandBase
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.err import TrestleError
+from trestle.utils import fs
 
-if os.name == 'nt':  # pragma: no cover
+if fs.is_windows():  # pragma: no cover
     import win32api
     import win32con
 
@@ -75,7 +75,7 @@ class InitCmd(CommandBase):
             # Create directories
             for directory in directory_list:
                 directory.mkdir(parents=True, exist_ok=True)
-                if os.name == 'nt':
+                if fs.is_windows():
                     file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_WINDOWS
                     file_path.touch()
                     atts = win32api.GetFileAttributes(str(file_path))

--- a/trestle/core/commands/init.py
+++ b/trestle/core/commands/init.py
@@ -77,11 +77,12 @@ class InitCmd(CommandBase):
                 directory.mkdir(parents=True, exist_ok=True)
                 if os.name == 'nt':
                     file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_WINDOWS
+                    file_path.touch()
                     atts = win32api.GetFileAttributes(str(file_path))
                     win32api.SetFileAttributes(str(file_path), win32con.FILE_ATTRIBUTE_HIDDEN | atts)
                 else:
                     file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_LINUX
-                file_path.touch()
+                    file_path.touch()
         except OSError as e:
             raise TrestleError(f'Error while creating directories: {e}')
         except Exception as e:

--- a/trestle/core/commands/init.py
+++ b/trestle/core/commands/init.py
@@ -29,10 +29,6 @@ from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.err import TrestleError
 from trestle.utils import fs
 
-if fs.is_windows():  # pragma: no cover
-    import win32api
-    import win32con
-
 logger = logging.getLogger(__name__)
 
 
@@ -75,14 +71,8 @@ class InitCmd(CommandBase):
             # Create directories
             for directory in directory_list:
                 directory.mkdir(parents=True, exist_ok=True)
-                if fs.is_windows():
-                    file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_WINDOWS
-                    file_path.touch()
-                    atts = win32api.GetFileAttributes(str(file_path))
-                    win32api.SetFileAttributes(str(file_path), win32con.FILE_ATTRIBUTE_HIDDEN | atts)
-                else:
-                    file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE_LINUX
-                    file_path.touch()
+                file_path = pathlib.Path(directory) / const.TRESTLE_KEEP_FILE
+                fs.make_hidden_file(file_path)
         except OSError as e:
             raise TrestleError(f'Error while creating directories: {e}')
         except Exception as e:

--- a/trestle/core/const.py
+++ b/trestle/core/const.py
@@ -26,8 +26,7 @@ PACKAGE_OSCAL = 'trestle.oscal'
 TRESTLE_CONFIG_DIR = '.trestle'
 TRESTLE_DIST_DIR = 'dist'
 TRESTLE_CONFIG_FILE = 'config.ini'
-TRESTLE_KEEP_FILE_LINUX = '.keep'
-TRESTLE_KEEP_FILE_WINDOWS = 'keep'
+TRESTLE_KEEP_FILE = '.keep'
 
 # these are hyphenated - no underscore - and mixed singular and plural
 MODEL_TYPE_A_PLAN = 'assessment-plan'

--- a/trestle/core/const.py
+++ b/trestle/core/const.py
@@ -26,7 +26,8 @@ PACKAGE_OSCAL = 'trestle.oscal'
 TRESTLE_CONFIG_DIR = '.trestle'
 TRESTLE_DIST_DIR = 'dist'
 TRESTLE_CONFIG_FILE = 'config.ini'
-TRESTLE_KEEP_FILE = '.keep'
+TRESTLE_KEEP_FILE_LINUX = '.keep'
+TRESTLE_KEEP_FILE_WINDOWS = 'keep'
 
 # these are hyphenated - no underscore - and mixed singular and plural
 MODEL_TYPE_A_PLAN = 'assessment-plan'

--- a/trestle/utils/fs.py
+++ b/trestle/utils/fs.py
@@ -89,7 +89,7 @@ def verify_trestle_folder(path: pathlib.Path) -> bool:
                     f'Hidden files and symlinks are not allowed in OSCAL directories, deleting: {file_path}.'
                 )
                 os.remove(file_path)
-            if local_and_visible(file_path) and file_path.suffix not in {'.json', '.xml', '.yaml', '.yml', '.md'}:
+            elif local_and_visible(file_path) and file_path.suffix not in {'.json', '.xml', '.yaml', '.yml', '.md'}:
                 logger.warning(
                     f'Files of {file_path.suffix} are not allowed in the OSCAL directories '
                     f'and can cause the issues. Please remove the file {file_path}'

--- a/trestle/utils/fs.py
+++ b/trestle/utils/fs.py
@@ -69,7 +69,7 @@ def verify_trestle_folder(path: pathlib.Path) -> bool:
         if file_path.is_file() and not local_and_visible(file_path):
             logger.warning(f'Hidden files and symlinks are not allowed in OSCAL directories, deleting: {file_path}.')
             os.remove(file_path)
-        if file_path.is_file() and file_path.suffix not in {'.json', '.xml', '.yaml', '.md'}:
+        if file_path.is_file() and file_path.suffix not in {'.json', '.xml', '.yaml', '.yml', '.md'}:
             logger.warning(
                 f'Files of {file_path.suffix} are not allowed in the OSCAL directories '
                 f'and can cause the issues. Please remove the file {file_path}'

--- a/trestle/utils/fs.py
+++ b/trestle/utils/fs.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import pathlib
+import platform
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
 from pydantic import create_model
@@ -35,7 +36,7 @@ from trestle.core.err import TrestleError
 from trestle.core.models.file_content_type import FileContentType
 from trestle.utils.load_distributed import load_distributed
 
-if os.name == 'nt':  # pragma: no cover
+if platform.system() == const.WINDOWS_PLATFORM_STR:  # pragma: no cover
     import win32api
     import win32con
 
@@ -60,6 +61,11 @@ def get_trestle_project_root(path: pathlib.Path) -> Optional[pathlib.Path]:
             return path
         path = path.parent
     return None
+
+
+def is_windows() -> bool:
+    """Check if current operating system is Windows."""
+    return platform.system() == const.WINDOWS_PLATFORM_STR
 
 
 def verify_trestle_folder(path: pathlib.Path) -> bool:
@@ -456,7 +462,7 @@ def is_hidden(file_path: pathlib.Path) -> bool:
         Whether or not the file is file/directory is hidden.
     """
     # Handle windows
-    if os.name == 'nt':  # pragma: no cover
+    if is_windows():  # pragma: no cover
         attribute = win32api.GetFileAttributes(str(file_path))
         return attribute & (win32con.FILE_ATTRIBUTE_HIDDEN | win32con.FILE_ATTRIBUTE_SYSTEM)
     # Handle unix
@@ -465,7 +471,7 @@ def is_hidden(file_path: pathlib.Path) -> bool:
 
 def is_symlink(file_path: pathlib.Path) -> bool:
     """Is the file path a symlink."""
-    if os.name == 'nt':
+    if is_windows():
         return file_path.suffix == '.lnk'
     return file_path.is_symlink()
 


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Added a consistency check for OSCAL directories. No other files than `json | xml | yaml` or `md` are allowed to be in the directories. Hidden files are deleted automatically.

Also fixed a small bug related to `.keep` files on Windows

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

Closes #678 