### PR TITLE
chore: [To Discuss] Remove error duplicates and standarize exceptions

### DIFF
--- a/trestle/common/err.py
+++ b/trestle/common/err.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Trestle core errors module."""
+from logging import Logger
+
+from trestle.common.log import get_current_verbosity_level
+from trestle.core.commands.common.return_codes import CmdReturnCodes
 
 
 class TrestleError(RuntimeError):
@@ -40,7 +44,7 @@ class TrestleError(RuntimeError):
 
 class TrestleNotFoundError(TrestleError):
     """
-    General framwork related not found error.
+    General framework related not found error.
 
     Attributes:
         msg (str): Human readable string describing the exception.
@@ -48,9 +52,57 @@ class TrestleNotFoundError(TrestleError):
 
     def __init__(self, msg: str):
         """
-        Intialization for TresleNotFoundError.
+        Intialize TresleNotFoundError.
 
         Args:
             msg: The error message
         """
         super().__init__(msg)
+
+
+class TrestleRootError(TrestleError):
+    """General error for Trestle project root/setup errors."""
+
+    def __init__(self, msg: str):
+        """
+        Initialize TrestleRootError.
+
+        Args:
+            msg (str): The error message
+        """
+        super().__init__(msg)
+
+
+class TrestleIncorrectArgsError(TrestleError):
+    """General error for incorrect args passed to Trestle command."""
+
+    def __init__(self, msg: str):
+        """
+        Initialize TrestleIncorrectArgsError.
+
+        Args:
+            msg (str): The error message
+        """
+        super().__init__(msg)
+
+
+def handle_generic_command_exception(
+    exception: Exception, logger: Logger, msg: str = 'Exception occured during execution'
+) -> int:
+    """Print out error message based on the verbosity and return appropriate status code."""
+    if get_current_verbosity_level(logger) == 0:
+        logger.error(msg + f': {exception}')
+    else:
+        logger.exception(msg + f': {exception}')
+
+    return _exception_to_error_code(exception)
+
+
+def _exception_to_error_code(exception: Exception) -> int:
+    """Convert exception to the status code."""
+    if isinstance(exception, TrestleRootError):
+        return CmdReturnCodes.TRESTLE_ROOT_ERROR.value
+    elif isinstance(exception, TrestleIncorrectArgsError):
+        return CmdReturnCodes.INCORRECT_ARGS.value
+
+    return CmdReturnCodes.COMMAND_ERROR.value

--- a/trestle/common/file_utils.py
+++ b/trestle/common/file_utils.py
@@ -104,17 +104,17 @@ def is_directory_name_allowed(name: str) -> bool:
 
     root_path = pathed_name.parts[0]
     if root_path in const.MODEL_TYPE_TO_MODEL_DIR.values():
-        logger.error('Task name is the same as an OSCAL schema name.')
+        logger.warning('Task name is the same as an OSCAL schema name.')
         return False
     if root_path[0] == '.':
-        logger.error('Task name must not start with "."')
+        logger.warning('Task name must not start with "."')
         return False
     if pathed_name.suffix != '':
         # Does it look like a file
-        logger.error('tasks name must not look like a file path (e.g. contain a suffix')
+        logger.warning('Task name must not look like a file path (e.g. contain a suffix')
         return False
     if '__global__' in pathed_name.parts:
-        logger.error('Task name cannot contain __global__')
+        logger.warning('Task name cannot contain __global__')
         return False
     return True
 

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -17,10 +17,9 @@
 
 import argparse
 import logging
-import traceback
 
 from trestle.common import const, file_utils, log
-from trestle.common.err import TrestleError
+from trestle.common.err import TrestleError, TrestleRootError, handle_generic_command_exception
 from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.common.return_codes import CmdReturnCodes
@@ -57,8 +56,7 @@ class AssembleCmd(CommandPlusDocs):
 
             trestle_root = args.trestle_root  # trestle root is set via command line in args. Default is cwd.
             if not trestle_root or not file_utils.is_valid_project_root(args.trestle_root):
-                logger.error(f'Given directory {trestle_root} is not a trestle project.')
-                return CmdReturnCodes.TRESTLE_ROOT_ERROR.value
+                raise TrestleRootError(f'Given directory {trestle_root} is not a trestle project.')
 
             model_names = []
             if args.name:
@@ -75,19 +73,14 @@ class AssembleCmd(CommandPlusDocs):
             for model_name in model_names:
                 # contruct path to the model file name
                 root_model_dir = trestle_root / ModelUtils.model_type_to_model_dir(model_alias)
-                try:
-                    model_file_type = file_utils.get_contextual_file_type(root_model_dir / model_name)
-                except Exception as e:
-                    logger.error('No files found in the specified model directory.')
-                    logger.debug(e)
-                    return CmdReturnCodes.COMMAND_ERROR.value
+
+                model_file_type = file_utils.get_contextual_file_type(root_model_dir / model_name)
 
                 model_file_name = f'{model_alias}{FileContentType.to_file_extension(model_file_type)}'
                 root_model_filepath = root_model_dir / model_name / model_file_name
 
                 if not root_model_filepath.exists():
-                    logger.error(f'No top level model file at {root_model_dir}')
-                    return CmdReturnCodes.COMMAND_ERROR.value
+                    raise TrestleError(f'No top level model file at {root_model_dir}')
 
                 # distributed load
                 _, _, assembled_model = ModelUtils.load_distributed(root_model_filepath, args.trestle_root)
@@ -107,18 +100,9 @@ class AssembleCmd(CommandPlusDocs):
                     )
                 )
 
-                try:
-                    plan.execute()
-                except Exception as e:
-                    logger.error('Unknown error executing trestle create operations. Rolling back.')
-                    logger.debug(e)
-                    return CmdReturnCodes.COMMAND_ERROR.value
+                plan.execute()
+
             return CmdReturnCodes.SUCCESS.value
-        except TrestleError as e:
-            logger.debug(traceback.format_exc())
-            logger.error(f'Error while assembling OSCAL model: {e}')
-            return CmdReturnCodes.COMMAND_ERROR.value
+
         except Exception as e:  # pragma: no cover
-            logger.debug(traceback.format_exc())
-            logger.error(f'Unexpected error while assembling OSCAL model: {e}')
-            return CmdReturnCodes.UNKNOWN_ERROR.value
+            return handle_generic_command_exception(e, logger, 'Error while assembling OSCAL model')

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -26,7 +26,7 @@ import trestle.common.const as const
 import trestle.common.log as log
 import trestle.oscal.common as com
 from trestle.common import file_utils
-from trestle.common.err import TrestleError, TrestleNotFoundError
+from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -57,29 +57,30 @@ class CatalogGenerate(AuthorCommonCommand):
         )
 
     def _run(self, args: argparse.Namespace) -> int:
-        log.set_log_level_from_args(args)
-        trestle_root = args.trestle_root
-        if not file_utils.is_directory_name_allowed(args.output):
-            logger.warning(f'{args.output} is not an allowed directory name')
-            return CmdReturnCodes.COMMAND_ERROR.value
+        try:
+            log.set_log_level_from_args(args)
+            trestle_root = args.trestle_root
+            if not file_utils.is_directory_name_allowed(args.output):
+                raise TrestleError(f'{args.output} is not an allowed directory name')
 
-        yaml_header: dict = {}
-        if args.yaml_header:
-            try:
-                logging.debug(f'Loading yaml header file {args.yaml_header}')
-                yaml = YAML(typ='safe')
-                yaml_header = yaml.load(pathlib.Path(args.yaml_header).open('r'))
-            except YAMLError as e:
-                logging.warning(f'YAML error loading yaml header {args.yaml_header} for ssp generation: {e}')
-                return CmdReturnCodes.COMMAND_ERROR.value
+            yaml_header: dict = {}
+            if args.yaml_header:
+                try:
+                    logging.debug(f'Loading yaml header file {args.yaml_header}')
+                    yaml = YAML(typ='safe')
+                    yaml_header = yaml.load(pathlib.Path(args.yaml_header).open('r'))
+                except YAMLError as e:
+                    raise TrestleError(f'YAML error loading yaml header {args.yaml_header} for ssp generation: {e}')
 
-        catalog_path = trestle_root / f'catalogs/{args.name}/catalog.json'
+            catalog_path = trestle_root / f'catalogs/{args.name}/catalog.json'
 
-        markdown_path = trestle_root / args.output
+            markdown_path = trestle_root / args.output
 
-        return self.generate_markdown(
-            trestle_root, catalog_path, markdown_path, yaml_header, args.overwrite_header_values
-        )
+            return self.generate_markdown(
+                trestle_root, catalog_path, markdown_path, yaml_header, args.overwrite_header_values
+            )
+        except Exception as e:
+            return handle_generic_command_exception(e, logger, 'Error occurred when generating markdown for catalog')
 
     def generate_markdown(
         self,
@@ -105,10 +106,10 @@ class CatalogGenerate(AuthorCommonCommand):
                 required_sections=None
             )
         except TrestleNotFoundError as e:
-            logger.warning(f'Catalog {catalog_path} not found for load {e}')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'Catalog {catalog_path} not found for load: {e}')
         except Exception as e:
             raise TrestleError(f'Error generating markdown for controls in {catalog_path}: {e}')
+
         return CmdReturnCodes.SUCCESS.value
 
 
@@ -132,17 +133,20 @@ class CatalogAssemble(AuthorCommonCommand):
         self.add_argument('-vn', '--version', help=const.HELP_VERSION, required=False, type=str)
 
     def _run(self, args: argparse.Namespace) -> int:
-        log.set_log_level_from_args(args)
-        trestle_root = pathlib.Path(args.trestle_root)
-        return CatalogAssemble.assemble_catalog(
-            trestle_root=trestle_root,
-            md_name=args.markdown,
-            catalog_name=args.output,
-            orig_cat_name=args.name,
-            set_parameters=args.set_parameters,
-            regenerate=args.regenerate,
-            version=args.version
-        )
+        try:
+            log.set_log_level_from_args(args)
+            trestle_root = pathlib.Path(args.trestle_root)
+            return CatalogAssemble.assemble_catalog(
+                trestle_root=trestle_root,
+                md_name=args.markdown,
+                catalog_name=args.output,
+                orig_cat_name=args.name,
+                set_parameters=args.set_parameters,
+                regenerate=args.regenerate,
+                version=args.version
+            )
+        except Exception as e:
+            return handle_generic_command_exception(e, logger, 'Error occurred while assembling catalog')
 
     @staticmethod
     def assemble_catalog(
@@ -175,16 +179,15 @@ class CatalogAssemble(AuthorCommonCommand):
         """
         md_dir = trestle_root / md_name
         if not md_dir.exists():
-            logger.warning(f'Markdown directory {md_name} does not exist.')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'Markdown directory {md_name} does not exist.')
+
         md_catalog_interface = CatalogInterface()
         try:
             md_catalog = md_catalog_interface.read_catalog_from_markdown(md_dir, set_parameters)
         except Exception as e:
             raise TrestleError(f'Error reading catalog from markdown {md_dir}: {e}')
         if md_catalog_interface.get_count_of_controls_in_catalog(True) == 0:
-            logger.warning(f'No controls were loaded from markdown {md_dir}.  No catalog.json created.')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'No controls were loaded from markdown {md_dir}.  No catalog.json created.')
 
         # if original catalog given then merge the markdown controls into it
         if orig_cat_name:

--- a/trestle/core/commands/author/docs.py
+++ b/trestle/core/commands/author/docs.py
@@ -19,12 +19,11 @@ import logging
 import pathlib
 import re
 import shutil
-import traceback
 from typing import Optional
 
 import trestle.core.commands.author.consts as author_const
 from trestle.common import file_utils
-from trestle.common.err import TrestleError
+from trestle.common.err import TrestleError, handle_generic_command_exception
 from trestle.core.commands.author.common import AuthorCommonCommand
 from trestle.core.commands.author.versioning.template_versioning import TemplateVersioning
 from trestle.core.commands.common.return_codes import CmdReturnCodes
@@ -115,16 +114,9 @@ class Docs(AuthorCommonCommand):
                 )
 
             return status
-        except TrestleError as e:
-            logger.debug(traceback.format_exc())
-            logger.error(f'Error occurred when running trestle author docs: {e}')
-            logger.error('Exiting')
-            return CmdReturnCodes.COMMAND_ERROR.value
+
         except Exception as e:  # pragma: no cover
-            logger.debug(traceback.format_exc())
-            logger.error(f'Unexpected error occurred when running trestle author docs: {e}')
-            logger.error('Exiting')
-            return CmdReturnCodes.UNKNOWN_ERROR.value
+            return handle_generic_command_exception(e, logger, 'Error occurred when running trestle author docs')
 
     def setup_template_governed_docs(self, template_version: str) -> int:
         """Create structure to allow markdown template enforcement.
@@ -188,8 +180,8 @@ class Docs(AuthorCommonCommand):
             md_api = MarkdownAPI()
             md_api.load_validator_with_template(template_file, validate_header, validate_only_header, heading)
         except Exception as ex:
-            logger.error(f'Template for task {self.task_name} failed to validate due to {ex}')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'Template for task {self.task_name} failed to validate due to {ex}')
+
         logger.info(f'TEMPLATES VALID: {self.task_name}')
         return CmdReturnCodes.SUCCESS.value
 

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -17,7 +17,6 @@ import argparse
 import logging
 import pathlib
 import shutil
-import traceback
 from typing import Dict, List, Optional
 
 from ruamel.yaml import YAML
@@ -28,7 +27,7 @@ import trestle.common.log as log
 import trestle.oscal.common as com
 import trestle.oscal.profile as prof
 from trestle.common import file_utils
-from trestle.common.err import TrestleError, TrestleNotFoundError
+from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -93,8 +92,7 @@ class ProfileGenerate(AuthorCommonCommand):
             log.set_log_level_from_args(args)
             trestle_root: pathlib.Path = args.trestle_root
             if not file_utils.is_directory_name_allowed(args.output):
-                logger.warning(f'{args.output} is not an allowed directory name')
-                return CmdReturnCodes.COMMAND_ERROR.value
+                raise TrestleError(f'{args.output} is not an allowed directory name')
 
             yaml_header: dict = {}
             if args.yaml_header:
@@ -103,8 +101,7 @@ class ProfileGenerate(AuthorCommonCommand):
                     yaml = YAML()
                     yaml_header = yaml.load(pathlib.Path(args.yaml_header).open('r'))
                 except YAMLError as e:
-                    logging.warning(f'YAML error loading yaml header for ssp generation: {e}')
-                    return CmdReturnCodes.COMMAND_ERROR.value
+                    raise TrestleError(f'YAML error loading yaml header for ssp generation: {e}')
 
             # combine command line sections with any in the yaml header, with priority to command line
             sections_dict: Optional[Dict[str, str]] = None
@@ -125,9 +122,7 @@ class ProfileGenerate(AuthorCommonCommand):
                 args.required_sections
             )
         except Exception as e:
-            logger.error(f'Generation of the profile markdown failed with error: {e}')
-            logger.debug(traceback.format_exc())
-            return CmdReturnCodes.COMMAND_ERROR.value
+            return handle_generic_command_exception(e, logger, 'Generation of the profile markdown failed')
 
     def generate_markdown(
         self,
@@ -174,11 +169,9 @@ class ProfileGenerate(AuthorCommonCommand):
                 required_sections=required_sections
             )
         except TrestleNotFoundError as e:
-            logger.warning(f'Profile {profile_path} not found, error {e}')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'Profile {profile_path} not found, error {e}')
         except TrestleError as e:
-            logger.warning(f'Error generating the catalog as markdown: {e}')
-            return CmdReturnCodes.COMMAND_ERROR.value
+            raise TrestleError(f'Error generating the catalog as markdown: {e}')
         return CmdReturnCodes.SUCCESS.value
 
 
@@ -221,9 +214,7 @@ class ProfileAssemble(AuthorCommonCommand):
                 allowed_sections=args.allowed_sections
             )
         except Exception as e:
-            logger.error(f'Assembly of markdown to profile failed with error: {e}')
-            logger.debug(traceback.format_exc())
-            return CmdReturnCodes.COMMAND_ERROR.value
+            return handle_generic_command_exception(e, logger, 'Assembly of markdown to profile failed')
 
     @staticmethod
     def _replace_alter_adds(profile: prof.Profile, alters: List[prof.Alter]) -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
This is a sample of the proposed structure to follow in the project when it comes to the exception handling and logging. The aim of the change is to remove the error duplicates and use appropriate logger level for logger messages.

The proposal consists of several parts:

### Logger level standardisation:
When to use which exception level:
- Info (logger.info): Provide information on successful execution. Confirm that things are working as expected.
- Warning (logger.warning): Issue a warning to the user that there is a problem that can lead to some issues or bugs. However, the problem does not halt the execution and operation proceeds.
- Error (logger.error): Indicates to a user that there is critical problem and execution cannot proceed. Such problem must end the execution and exit with appropriate code.


### Exception handling and logging
- `Logger.error` is no longer allowed anywhere but in the most outer level.
- `Logger.warning` and `Logger.info` allowed anywhere but the execution after `logger.warning` **must** proceed.
- Traceback will only be printed if command is executed in the verbose mode.
- Exit codes are entirely handled by outer most level.
- Handling of inner exceptions - do not catch the exception and replace them with status codes. Only catch exceptions if there is need to provide more information to the user of what went wrong. In this case, raise an appropriate instance of `TrestleError` with your new message and add extra message if needed. You can also include the original exception message.
  Example: 
```
except SomeException as e:
    raise TrestleError(f'Something went wrong during SSP generation: {e}')
```

- Wrap each `_run()` function in `try-except` block - in except block simply pass the exception to `handle_generic_command_exception` with your message and return output.
- Keep number of `returns` to the minimum, if execution should end, raise an exception and let outer exception handler handle it.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
