### PR TITLE
fix: added methods in catalog interface to sort controls by sort-id

### DIFF
--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -202,6 +202,16 @@ def test_catalog_interface_groups() -> None:
     assert len(groups) == 4
 
 
+def test_get_sorted_controls_in_group(simplified_nist_catalog: cat.Catalog) -> None:
+    """Test get sorted controls in group."""
+    catalog_interface = CatalogInterface(simplified_nist_catalog)
+    controls = catalog_interface.get_sorted_controls_in_group('ac')
+    ids = [control.id for control in controls]
+    # confirm that the list is not alphabetical but is numeric since it uses the control sort-ids for order
+    ref_ids = ['ac-1', 'ac-2', 'ac-2.1', 'ac-2.2', 'ac-2.3', 'ac-2.4', 'ac-2.5', 'ac-2.6', 'ac-2.7', 'ac-2.8', 'ac-2.9']
+    assert ids[:11] == ref_ids
+
+
 @pytest.mark.parametrize('replace_params', [True, False])
 def test_catalog_interface_merge_controls(replace_params: bool, sample_catalog_rich_controls: cat.Catalog) -> None:
     """Test merging of controls."""

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -207,7 +207,7 @@ def test_get_sorted_controls_in_group(simplified_nist_catalog: cat.Catalog) -> N
     catalog_interface = CatalogInterface(simplified_nist_catalog)
     controls = catalog_interface.get_sorted_controls_in_group('ac')
     ids = [control.id for control in controls]
-    # confirm that the list is not alphabetical but is numeric since it uses the control sort-ids for order
+    # Confirm the start of list is not alphabetical but is numeric since it uses the control sort-ids for order
     ref_ids = ['ac-1', 'ac-2', 'ac-2.1', 'ac-2.2', 'ac-2.3', 'ac-2.4', 'ac-2.5', 'ac-2.6', 'ac-2.7', 'ac-2.8', 'ac-2.9']
     assert ids[:11] == ref_ids
 

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -166,6 +166,15 @@ class CatalogInterface():
                 controls.extend(self._get_all_controls_in_group(sub_group, recurse))
         return controls
 
+    def get_sorted_controls_in_group(self, group_id: str) -> List[cat.Control]:
+        """Get the list of controls in a group sorted by the control sort-id."""
+        controls: List[cat.Control] = []
+        for control in self.get_all_controls_from_dict():
+            grp_id, _, _ = self.get_group_info_by_control(control.id)
+            if grp_id == group_id:
+                controls.append(control)
+        return sorted(controls, key=lambda control: ControlIOWriter.get_sort_id(control))
+
     def get_dependent_control_ids(self, control_id: str) -> List[str]:
         """Find all children of this control."""
         children: List[str] = []
@@ -220,6 +229,9 @@ class CatalogInterface():
 
         Returns:
             iterator of the controls in the catalog
+
+        Notes:
+            This follows the actual structure of the catalog and groups
         """
         if self._catalog.groups:
             for group in self._catalog.groups:
@@ -244,15 +256,17 @@ class CatalogInterface():
         return len(list(self.get_all_controls_from_catalog(recurse)))
 
     def get_group_ids(self) -> List[str]:
-        """Get all the group id's as strings in a list."""
-        return list(filter(lambda id: id, list({control.group_id for control in self._control_dict.values()})))
+        """Get all the group id's as a list of sorted strings."""
+        return sorted(filter(lambda id: id, list({control.group_id for control in self._control_dict.values()})))
 
-    def get_all_groups_from_catalog(self) -> Iterator[cat.Group]:
-        """Retrieve all groups in the catalog."""
+    def get_all_groups_from_catalog(self) -> List[cat.Group]:
+        """Retrieve all groups in the catalog sorted by group_id."""
+        groups: List[cat.Group] = []
         if self._catalog.groups:
             for my_group in self._catalog.groups:
                 for res in CatalogInterface._get_groups_from_group(my_group):
-                    yield res
+                    groups.append(res)
+        return sorted(groups, key=lambda group: group.id)
 
     def get_statement_label_if_exists(self, control_id: str,
                                       statement_id: str) -> Tuple[Optional[str], Optional[common.Part]]:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Fix allows jinja to query catalog_interface for controls in order sorted by sort-id
Needed by and hooked into the ssp-demo separately
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
