### PR TITLE
docs: move trestle references from beta to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A collection of demos utilizing trestle can be found in the related project [com
 
 ## Development status
 
-Compliance trestle is currently beta. The expectation is that in ongoing work there may be un-announced changes that are breaking within the trestle codebase. With the release of NIST's version 1.0.0 of OSCAL we expect that these changes will be decreasing in size as trestle approaches a 1.0.0 release for itself.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0.
 
 ## Contributing to Trestle
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A collection of demos utilizing trestle can be found in the related project [com
 
 ## Development status
 
-Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0, with active development continuing.
 
 ## Contributing to Trestle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Trestle runs on most all python platforms (e.g. Linux, Mac, Windows) and is avai
 
 ## Development status
 
-Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0, with active development continuing.
 
 ## Contributing to Trestle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Trestle runs on most all python platforms (e.g. Linux, Mac, Windows) and is avai
 
 ## Development status
 
-Compliance trestle is currently beta. The expectation is that in ongoing work there may be un-announced changes that are breaking within the trestle codebase. With the release of NIST's version 1.0.0 of OSCAL we expect that these changes will be decreasing in size as trestle approaches a 1.0.0 release for itself.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0.
 
 ## Contributing to Trestle
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author_email = avikas@in.ibm.com
 license = Apache Software License v2
 url = https://ibm.github.io/compliance-trestle
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Updated readme and index to change from beta to stable
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
