### PR TITLE
fix: Improve cloud-docs generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0  # Use the ref you want to point at
+    rev: v4.2.0  # Use the ref you want to point at
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/tests/data/jinja/profile_to_docs.md.jinja
+++ b/tests/data/jinja/profile_to_docs.md.jinja
@@ -1,3 +1,3 @@
 # Control Page
 
-{{ control_writer.write_control_with_sections(control, group_title, ['statement', 'objective', 'expected_evidence', 'implementation_guidance', 'table_of_parameters'], {'statement':'Control Statement Header', 'objective':'Control Objective Header', 'expected_evidence':'Expected Evidence Header', 'implementation_guidance':'Implementation Guidance', 'table_of_parameters':'Table of Control Parameters'}) }}
+{{ control_writer.write_control_with_sections(control, group_title, ['statement', 'objective', 'ExpectedEvidence', 'ImplGuidance', 'table_of_parameters'], {'statement':'Control Statement Header', 'objective':'Control Objective Header', 'ExpectedEvidence':'Expected Evidence Header', 'ImplGuidance':'Implementation Guidance', 'table_of_parameters':'Table of Control Parameters'}) }}

--- a/tests/data/jinja/profile_to_docs_invalid.md.jinja
+++ b/tests/data/jinja/profile_to_docs_invalid.md.jinja
@@ -1,0 +1,3 @@
+# Control Page
+
+{{ control_writer.write_control_with_sections(control, ['statement', 'objective', 'expected_evidence', 'implementation_guidance', 'table_of_parameters'], {'statement':'Control Statement Header', 'objective':'Control Objective Header', 'expected_evidence':'Expected Evidence Header', 'implementation_guidance':'Implementation Guidance', 'table_of_parameters':'Table of Control Parameters'}) }}

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -177,7 +177,7 @@ def test_jinja_profile_docs(
         if os.path.isfile(full_file_name):
             shutil.copy(full_file_name, tmp_trestle_dir)
 
-    command_import = f'trestle author jinja -i {input_template} -o controls -p main_profile --docs-profile'
+    command_import = f'trestle author jinja -i {input_template} -o controls -p test_profile_a --docs-profile'
     execute_command_and_assert(command_import, 0, monkeypatch)
 
     for md_control in (tmp_trestle_dir / 'controls' / 'ac').iterdir():
@@ -189,6 +189,8 @@ def test_jinja_profile_docs(
             assert node1
             node2 = tree.get_node_for_key('## Control Statement Header')
             assert node2
+            node3 = tree.get_node_for_key('## Control Expected Evidence Header')
+            assert node3
 
 
 def test_jinja_profile_docs_fails(

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -214,3 +214,7 @@ def test_jinja_profile_docs_fails(
 
     command_jinja = f'trestle author jinja -i {input_template} -o controls -ssp ssp_json -p main_profile --docs-profile'
     execute_command_and_assert(command_jinja, 2, monkeypatch)
+
+    input_template = 'profile_to_docs_invalid.md.jinja'
+    command_jinja = f'trestle author jinja -i {input_template} -o controls -p main_profile --docs-profile'
+    execute_command_and_assert(command_jinja, 1, monkeypatch)


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Addressed the feedback for cloud-docs generation:
1. Title is now capitalized
2. Sections can be printed in the arbitrary order.
3. `group_title` now is mandatory

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
