### PR TITLE
feat: updated to OSCAL 1.0.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 
 ## Important Note:
 
-The current version of trestle supports NIST OSCAL 1.0.2 and beyond.  There as a breaking change in OSCAL moving from
+The current version of trestle supports NIST OSCAL 1.0.2.  There as a breaking change in OSCAL moving from
 version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development
 path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version
 is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and trestle 1.0.0.
 
-OSCAL version 1.0.0 files are still handled but any AssessmentResults must conform to the OSCAL 1.0.2 version with
-props instead of prop.
+OSCAL version 1.0.0 files are still handled on import but any AssessmentResults must conform to the OSCAL 1.0.2 schema, with
+props instead of prop.  And all files created by trestle will be output as OSCAL version 1.0.2.
 
 ## Why Trestle
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Trestle provides tooling to help orchestrate the compliance process across a num
 - Support within trestle to streamline management within a managed git environment.
 - An underlying object model that supports developers interacting with OSCAL artefacts.
 
+## Important Note:
+
+The current version of trestle supports NIST OSCAL 1.0.2 and beyond.  There as a breaking change in OSCAL moving from
+version 1.0.0 to 1.0.2 mainly due to `prop` becoming `props` in AssessmentResults.  As a result, the current development
+path of trestle requires OSCAL 1.0.2, but for those who require OSCAL 1.0.0 please use trestle version 0.37.x.  That version
+is stable but will not have any features added, and we encourage users to move to OSCAL 1.0.2 and trestle 1.0.0.
+
+OSCAL version 1.0.0 files are still handled but any AssessmentResults must conform to the OSCAL 1.0.2 version with
+props instead of prop.
+
 ## Why Trestle
 
 Compliance suffers from being a complex topic that is hard to articulate simply. It involves complete and accurate execution of multiple procedures across many disciplines (e.g. IT, HR, management) with periodic verification and audit of those procedures against controls.
@@ -77,7 +87,7 @@ A collection of demos utilizing trestle can be found in the related project [com
 
 ## Development status
 
-Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0, with active development continuing.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.2, with active development continuing.
 
 ## Contributing to Trestle
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Trestle runs on most all python platforms (e.g. Linux, Mac, Windows) and is avai
 
 ## Development status
 
-Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.0, with active development continuing.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.2, with active development continuing.
 
 ## Contributing to Trestle
 

--- a/docs/tutorials/trestle_sample_workflow.md
+++ b/docs/tutorials/trestle_sample_workflow.md
@@ -64,7 +64,7 @@ As a reminder, you could also have imported the file from a local directory on y
 
 The `import` command will also check the
 validity of the file including the presence of any duplicate uuid's.  If the file is manually created
-please be sure it conforms with the current OSCAL schema (OSCAL version 1.0.0) and has no defined uuid's that are duplicates.
+please be sure it conforms with the current OSCAL schema (OSCAL version 1.0.2) and has no defined uuid's that are duplicates.
 If there are any errors the Import will fail and the file must be corrected.
 
 <br>

--- a/scripts/simplify_retain_ac.py
+++ b/scripts/simplify_retain_ac.py
@@ -78,6 +78,11 @@ class SimplifyCatalog(ilcli.Command):
     Changes made here should be coordinated with the corresponding manually created simplified_nist_profile.json
     Currently this creates one group of controls and ideally it should be made a bit more complex than that.
     The Makefile invokes this script as rule simplified-catalog and creates the test file simplified_nist_catalog.json
+
+    This should only be run with the NIST catalog based on OSCAL 1.0.0 and not OSCAL 1.0.2 because the controls used
+    by the tests were changed in terms of contents and parameter names.  Normally there is no need to regenerate this
+    catalog as long as it exercises the code paths as expected.  Regenerating based on the newer version of the NIST
+    catalog would require significant changes to the tests and expected results after operations.
     """
 
     def _init_arguments(self) -> None:

--- a/tests/data/tasks/ocp4-cis-profile-to-oscal-cd/output/component-definition.json
+++ b/tests/data/tasks/ocp4-cis-profile-to-oscal-cd/output/component-definition.json
@@ -5,7 +5,7 @@
       "title": "Component definition for OCP4 profiles",
       "last-modified": "2021-07-19T14:03:03+00:00",
       "version": "0.21.0",
-      "oscal-version": "1.0.0",
+      "oscal-version": "1.0.2",
       "roles": [
         {
           "id": "prepared-by",

--- a/tests/data/tasks/osco/output-1.3.5/ssg-ocp4-ds-cis-111.222.333.444-pod.oscal.json
+++ b/tests/data/tasks/osco/output-1.3.5/ssg-ocp4-ds-cis-111.222.333.444-pod.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output-compressed/ssg-rhel7-ds-cis-111.222.333.444-pod.oscal.json
+++ b/tests/data/tasks/osco/output-compressed/ssg-rhel7-ds-cis-111.222.333.444-pod.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output-configmaps/configmaps.oscal.json
+++ b/tests/data/tasks/osco/output-configmaps/configmaps.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output-fetcher/cluster_resource.oscal.json
+++ b/tests/data/tasks/osco/output-fetcher/cluster_resource.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output-xml-ocp4/ocp4-check-result.oscal.json
+++ b/tests/data/tasks/osco/output-xml-ocp4/ocp4-check-result.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output-xml-rhel7/rhel7-check-result.oscal.json
+++ b/tests/data/tasks/osco/output-xml-rhel7/rhel7-check-result.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-111.222.333.444-pod.oscal.json
+++ b/tests/data/tasks/osco/output/ssg-ocp4-ds-cis-111.222.333.444-pod.oscal.json
@@ -6,7 +6,7 @@
       "description": "OpenShift Compliance Operator Scan Results",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "scanner_name",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/osco",

--- a/tests/data/tasks/tanium/output/Tanium.oscal.2020.json
+++ b/tests/data/tasks/tanium/output/Tanium.oscal.2020.json
@@ -6,7 +6,7 @@
       "description": "Tanium",
       "start": "2020-02-24T19:31:13+00:00",
       "end": "2020-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
@@ -600,7 +600,7 @@
       "description": "Tanium",
       "start": "2020-02-24T19:31:13+00:00",
       "end": "2020-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID_Benchmark",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
@@ -17780,7 +17780,7 @@
       "description": "Tanium",
       "start": "2020-02-24T19:31:13+00:00",
       "end": "2020-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID_Benchmark",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",

--- a/tests/data/tasks/tanium/output/Tanium.oscal.json
+++ b/tests/data/tasks/tanium/output/Tanium.oscal.json
@@ -6,7 +6,7 @@
       "description": "Tanium",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
@@ -600,7 +600,7 @@
       "description": "Tanium",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID_Benchmark",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",
@@ -17780,7 +17780,7 @@
       "description": "Tanium",
       "start": "2021-02-24T19:31:13+00:00",
       "end": "2021-02-24T19:31:13+00:00",
-      "prop": [
+      "props": [
         {
           "name": "Check_ID_Benchmark",
           "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/tanium",

--- a/tests/data/tasks/xlsx/output-filtered/profile.json
+++ b/tests/data/tasks/xlsx/output-filtered/profile.json
@@ -5,7 +5,7 @@
       "title": "Profile for IBM Best Practices SCC GOALS",
       "last-modified": "2021-07-19T14:03:03+00:00",
       "version": "0.21.0",
-      "oscal-version": "1.0.0"
+      "oscal-version": "1.0.2"
     },
     "imports": [
       {

--- a/tests/data/tasks/xlsx/output/component-definition.json
+++ b/tests/data/tasks/xlsx/output/component-definition.json
@@ -5,7 +5,7 @@
       "title": "Component definition for NIST Special Publication 800-53 Revision 4 profiles",
       "last-modified": "2021-07-19T14:03:03+00:00",
       "version": "0.21.0",
-      "oscal-version": "1.0.0",
+      "oscal-version": "1.0.2",
       "roles": [
         {
           "id": "prepared-by",

--- a/tests/data/tasks/xlsx/output/profile.json
+++ b/tests/data/tasks/xlsx/output/profile.json
@@ -5,7 +5,7 @@
       "title": "Profile for IBM Best Practices SCC GOALS",
       "last-modified": "2021-07-19T14:03:03+00:00",
       "version": "0.21.0",
-      "oscal-version": "1.0.0"
+      "oscal-version": "1.0.2"
     },
     "imports": [
       {

--- a/trestle/core/generators.py
+++ b/trestle/core/generators.py
@@ -96,7 +96,7 @@ def generate_sample_value_by_type(
     if type_ is pydantic.networks.AnyUrl:
         # TODO: Cleanup: this should be usable from a url.. but it's not inuitive.
         return pydantic.networks.AnyUrl('https://sample.com/replaceme.html', scheme='http', host='sample.com')
-    if type_ == Any:
+    if type_ is Any or type_ is Dict[str, Any]:
         # Return empty dict - aka users can put whatever they want here.
         return {}
     raise err.TrestleError(f'Fatal: Bad type in model {type_}')

--- a/trestle/oscal/__init__.py
+++ b/trestle/oscal/__init__.py
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 #TODO: Ensure this is automatically updated successfully.
-OSCAL_VERSION = '1.0.0'
-OSCAL_VERSION_REGEX = r'^1\.0\.0$'
+OSCAL_VERSION = '1.0.2'
+OSCAL_VERSION_REGEX = r'^1\.0\.[02]$'

--- a/trestle/oscal/assessment_plan.py
+++ b/trestle/oscal/assessment_plan.py
@@ -82,7 +82,7 @@ class SetParameter(OscalBaseModel):
         ...,
         alias='param-id',
         description=
-        "A reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
+        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
         title='Parameter ID',
     )
     values: List[common.Value] = Field(...)
@@ -103,7 +103,8 @@ class SelectControlById(OscalBaseModel):
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     statement_ids: Optional[List[common.StatementId]] = Field(None, alias='statement-ids')
@@ -122,7 +123,7 @@ class RelatedObservation(OscalBaseModel):
     ) = Field(
         ...,
         alias='observation-uuid',
-        description='References an observation defined in the list of observations.',
+        description='A machine-oriented identifier reference to an observation defined in the list of observations.',
         title='Observation Universally Unique Identifier Reference',
     )
 
@@ -160,7 +161,7 @@ class Observation(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this observation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given observation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this observation elsewhere in this or other OSCAL instances. The locally defined UUID of the observation can be used to reference the data item locally or globally (e.g., in an imorted OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Observation Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this observation.', title='Observation Title')
@@ -203,7 +204,7 @@ class Entry(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a risk log entry. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk log entry elsewhere in this or other OSCAL instances. The locally defined UUID of the risk log entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Log Entry Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this risk log entry.', title='Title')
@@ -246,12 +247,7 @@ class ControlSelection(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    include_all: Optional[Dict[str, Any]] = Field(
-        None,
-        alias='include-all',
-        description='A key word to indicate all.',
-        title='All',
-    )
+    include_all: Optional[common.IncludeAll] = Field(None, alias='include-all')
     include_controls: Optional[List[SelectControlById]] = Field(None, alias='include-controls')
     exclude_controls: Optional[List[SelectControlById]] = Field(None, alias='exclude-controls')
     remarks: Optional[common.Remarks] = None
@@ -291,12 +287,14 @@ class SystemComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -372,7 +370,7 @@ class FindingTarget(OscalBaseModel):
     ) = Field(
         ...,
         alias='target-id',
-        description='Identifies the specific target qualified by the type.',
+        description='A machine-oriented identifier reference for a specific target qualified by the type.',
         title='Finding Target Identifier Reference',
     )
     title: Optional[str] = Field(
@@ -443,7 +441,7 @@ class Response(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this remediation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given remediation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this remediation elsewhere in this or other OSCAL instances. The locally defined UUID of the risk response can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Remediation Universally Unique Identifier',
     )
     lifecycle: constr(
@@ -482,7 +480,7 @@ class Risk(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this risk. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given risk across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk elsewhere in this or other OSCAL instances. The locally defined UUID of the risk can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Universally Unique Identifier',
     )
     title: str = Field(..., description='The title for this risk.', title='Risk Title')
@@ -499,10 +497,7 @@ class Risk(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    status: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(..., description='Describes the status of the associated risk.', title='Status')
+    status: common.RiskStatus
     origins: Optional[List[Origin]] = Field(None)
     threat_ids: Optional[List[common.ThreatId]] = Field(None, alias='threat-ids')
     characterizations: Optional[List[Characterization]] = Field(None)
@@ -547,7 +542,7 @@ class Step(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a step. This UUID may be referenced elsewhere in an OSCAL document when referring to this step. A UUID should be consistently used for a given test step across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this step elsewhere in this or other OSCAL instances. The locally defined UUID of the step (in a series of steps) can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Step Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this step.', title='Step Title')
@@ -576,7 +571,7 @@ class Activity(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this assessment activity. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for a given included activity across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment activity elsewhere in this or other OSCAL instances. The locally defined UUID of the activity can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Activity Universally Unique Identifier',
     )
     title: Optional[str] = Field(
@@ -626,7 +621,7 @@ class AssessmentPlan(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this assessment plan. This UUID must be changed each time the content of the plan changes.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment plan in this or other OSCAL instances. The locally defined UUID of the assessment plan can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Plan Universally Unique Identifier',
     )
     metadata: common.Metadata

--- a/trestle/oscal/assessment_results.py
+++ b/trestle/oscal/assessment_results.py
@@ -71,7 +71,7 @@ class SetParameter(OscalBaseModel):
         ...,
         alias='param-id',
         description=
-        "A reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
+        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
         title='Parameter ID',
     )
     values: List[common.Value] = Field(...)
@@ -92,7 +92,8 @@ class SelectControlById(OscalBaseModel):
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     statement_ids: Optional[List[common.StatementId]] = Field(None, alias='statement-ids')
@@ -111,7 +112,7 @@ class RelatedObservation(OscalBaseModel):
     ) = Field(
         ...,
         alias='observation-uuid',
-        description='References an observation defined in the list of observations.',
+        description='A machine-oriented identifier reference to an observation defined in the list of observations.',
         title='Observation Universally Unique Identifier Reference',
     )
 
@@ -146,7 +147,7 @@ class ImportAp(OscalBaseModel):
 
     href: str = Field(
         ...,
-        description='>A resolvable URL reference to the assessment plan governing the assessment activities.',
+        description='A resolvable URL reference to the assessment plan governing the assessment activities.',
         title='Assessment Plan Reference',
     )
     remarks: Optional[common.Remarks] = None
@@ -165,7 +166,7 @@ class Entry1(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a risk log entry. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk log entry elsewhere in this or other OSCAL instances. The locally defined UUID of the risk log entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Log Entry Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this risk log entry.', title='Title')
@@ -206,7 +207,7 @@ class Entry(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies an assessment event. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference an assessment event in this or other OSCAL instances. The locally defined UUID of the assessment log entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Log Entry Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this event.', title='Action Title')
@@ -248,12 +249,7 @@ class ControlSelection(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    include_all: Optional[Dict[str, Any]] = Field(
-        None,
-        alias='include-all',
-        description='A key word to indicate all.',
-        title='All',
-    )
+    include_all: Optional[common.IncludeAll] = Field(None, alias='include-all')
     include_controls: Optional[List[SelectControlById]] = Field(None, alias='include-controls')
     exclude_controls: Optional[List[SelectControlById]] = Field(None, alias='exclude-controls')
     remarks: Optional[common.Remarks] = None
@@ -316,12 +312,14 @@ class SystemComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -397,7 +395,7 @@ class FindingTarget(OscalBaseModel):
     ) = Field(
         ...,
         alias='target-id',
-        description='Identifies the specific target qualified by the type.',
+        description='A machine-oriented identifier reference for a specific target qualified by the type.',
         title='Finding Target Identifier Reference',
     )
     title: Optional[str] = Field(
@@ -435,7 +433,7 @@ class Finding(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this finding. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given finding across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this finding in this or other OSCAL instances. The locally defined UUID of the finding can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Finding Universally Unique Identifier',
     )
     title: str = Field(..., description='The title for this finding.', title='Finding Title')
@@ -453,7 +451,8 @@ class Finding(OscalBaseModel):
     )] = Field(
         None,
         alias='implementation-statement-uuid',
-        description='Identifies the implementation statement in the SSP to which this finding is related.',
+        description=
+        'A machine-oriented identifier reference to the implementation statement in the SSP to which this finding is related.',
         title='Implementation Statement UUID',
     )
     related_observations: Optional[List[RelatedObservation]] = Field(None, alias='related-observations')
@@ -507,7 +506,7 @@ class Response(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this remediation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given remediation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this remediation elsewhere in this or other OSCAL instances. The locally defined UUID of the risk response can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Remediation Universally Unique Identifier',
     )
     lifecycle: constr(
@@ -546,7 +545,7 @@ class Risk(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this risk. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given risk across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk elsewhere in this or other OSCAL instances. The locally defined UUID of the risk can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Universally Unique Identifier',
     )
     title: str = Field(..., description='The title for this risk.', title='Risk Title')
@@ -563,10 +562,7 @@ class Risk(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    status: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(..., description='Describes the status of the associated risk.', title='Status')
+    status: common.RiskStatus
     origins: Optional[List[Origin]] = Field(None)
     threat_ids: Optional[List[common.ThreatId]] = Field(None, alias='threat-ids')
     characterizations: Optional[List[Characterization]] = Field(None)
@@ -599,7 +595,7 @@ class Observation(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this observation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given observation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this observation elsewhere in this or other OSCAL instances. The locally defined UUID of the observation can be used to reference the data item locally or globally (e.g., in an imorted OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Observation Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this observation.', title='Observation Title')
@@ -669,7 +665,7 @@ class Result(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this set of results. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given set of results across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this set of results in this or other OSCAL instances. The locally defined UUID of the assessment result can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Results Universally Unique Identifier',
     )
     title: str = Field(..., description='The title for this set of results.', title='Results Title')
@@ -689,7 +685,7 @@ class Result(OscalBaseModel):
         'Date/time stamp identifying the end of the evidence collection reflected in these results. In a continuous motoring scenario, this may contain the same value as start if appropriate.',
         title='end field',
     )
-    prop: Optional[List[common.Property]] = Field(None)
+    props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
     local_definitions: Optional[LocalDefinitions1] = Field(
         None,
@@ -725,7 +721,7 @@ class Step(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a step. This UUID may be referenced elsewhere in an OSCAL document when referring to this step. A UUID should be consistently used for a given test step across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this step elsewhere in this or other OSCAL instances. The locally defined UUID of the step (in a series of steps) can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Step Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this step.', title='Step Title')
@@ -754,7 +750,7 @@ class Activity(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this assessment activity. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for a given included activity across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment activity elsewhere in this or other OSCAL instances. The locally defined UUID of the activity can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Activity Universally Unique Identifier',
     )
     title: Optional[str] = Field(
@@ -801,7 +797,7 @@ class AssessmentResults(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this assessment results file. This UUID must be changed each time the content of the results changes.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment results instance in this or other OSCAL instances. The locally defined UUID of the assessment result can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Results Universally Unique Identifier',
     )
     metadata: common.Metadata

--- a/trestle/oscal/catalog.py
+++ b/trestle/oscal/catalog.py
@@ -50,7 +50,7 @@ class Control(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        "A unique identifier for a specific control instance that can be used to reference the control in other OSCAL documents. This identifier's uniqueness is document scoped and is intended to be consistent for the same control across minor revisions of the document.",
+        'A human-oriented, locally unique identifier with instance scope that can be used to reference this control elsewhere in this and other OSCAL instances (e.g., profiles). This id should be assigned per-subject, which means it should be consistently used to identify the same control across revisions of the document.',
         title='Control Identifier',
     )
     class_: Optional[constr(
@@ -88,7 +88,7 @@ class Group(OscalBaseModel):
     )] = Field(
         None,
         description=
-        "A unique identifier for a specific group instance that can be used to reference the group within this and in other OSCAL documents. This identifier's uniqueness is document scoped and is intended to be consistent for the same group across minor revisions of the document.",
+        'A human-oriented, locally unique identifier with cross-instance scope that can be used to reference this defined group elsewhere in in this and other OSCAL instances (e.g., profiles). This id should be assigned per-subject, which means it should be consistently used to identify the same group across revisions of the document.',
         title='Group Identifier',
     )
     class_: Optional[constr(
@@ -126,7 +126,7 @@ class Catalog(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier for this catalog instance. This UUID should be changed when this document is revised.',
+        'A globally unique identifier with cross-instance scope for this catalog instance. This UUID should be changed when this document is revised.',
         title='Catalog Universally Unique Identifier',
     )
     metadata: common.Metadata

--- a/trestle/oscal/common.py
+++ b/trestle/oscal/common.py
@@ -211,7 +211,7 @@ class TelephoneNumber(OscalBaseModel):
 
 class SystemId(OscalBaseModel):
     """
-    A unique identifier for the system described by this system security plan.
+    A human-oriented, globally unique identifier with cross-instance scope that can be used to reference this system identification property elsewhere in this or other OSCAL instances. When referencing an externally defined system identification, the system identification must be used in the context of the external / imported OSCAL instance (e.g., uri-reference). This string should be assigned per-subject, which means it should be consistently used to identify the same system across revisions of the document.
     """
 
     class Config:
@@ -251,7 +251,7 @@ class Source(OscalBaseModel):
         ...,
         alias='task-uuid',
         description=
-        'Uniquely identifies an assessment activity to be performed as part of the event. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference (in this or other OSCAL instances) an assessment activity to be performed as part of the event. The locally defined UUID of the task can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Task Universally Unique Identifier',
     )
 
@@ -281,7 +281,7 @@ class RoleId(OscalBaseModel):
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
     ) = Field(
         ...,
-        description='A reference to the roles served by the user.',
+        description='A human-oriented identifier reference to roles served by the user.',
         title='Role Identifier Reference',
     )
 
@@ -317,7 +317,7 @@ class RelatedRisk(OscalBaseModel):
                       ) = Field(
                           ...,
                           alias='risk-uuid',
-                          description='References an risk defined in the list of risks.',
+                          description='A machine-oriented identifier reference to a risk defined in the list of risks.',
                           title='Risk Universally Unique Identifier Reference',
                       )
 
@@ -335,7 +335,7 @@ class RelatedObservation1(OscalBaseModel):
     ) = Field(
         ...,
         alias='observation-uuid',
-        description='References an observation defined in the list of observations.',
+        description='A machine-oriented identifier reference to an observation defined in the list of observations.',
         title='Observation Universally Unique Identifier Reference',
     )
 
@@ -371,7 +371,7 @@ class Property(OscalBaseModel):
     )] = Field(
         None,
         description=
-        'A unique identifier that can be used to reference this property elsewhere in an OSCAL document. A UUID should be consistently used for a given location across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this defined property elsewhere in this or other OSCAL instances. This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Property Universally Unique Identifier',
     )
     ns: Optional[AnyUrl] = Field(
@@ -432,7 +432,7 @@ class Protocol(OscalBaseModel):
     )] = Field(
         None,
         description=
-        'A globally unique identifier that can be used to reference this service protocol entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this service protocol information elsewhere in this or other OSCAL instances. The locally defined UUID of the service protocol can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Service Protocol Information Universally Unique Identifier',
     )
     name: constr(regex=r'^\S(.*\S)?$') = Field(
@@ -450,12 +450,14 @@ class Protocol(OscalBaseModel):
 
 
 class PartyUuid(OscalBaseModel):
-    __root__: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                     ) = Field(
-                         ...,
-                         description='References a party defined in metadata.',
-                         title='Party Reference',
-                     )
+    __root__: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented identifier reference to another party defined in metadata. The UUID of the party in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).',
+        title='Party Reference',
+    )
 
 
 class ParameterValue(OscalBaseModel):
@@ -515,7 +517,7 @@ class MemberOfOrganization(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Identifies that the party object is a member of the organization associated with the provided UUID.',
+        'A machine-oriented identifier reference to another party (person or organization) that this subject is associated with. The UUID of the party in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).',
         title='Organizational Affiliation',
     )
 
@@ -528,13 +530,14 @@ class LoggedBy(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    party_uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                       ) = Field(
-                           ...,
-                           alias='party-uuid',
-                           description='A pointer to the party who is making the log entry.',
-                           title='Party UUID Reference',
-                       )
+    party_uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        alias='party-uuid',
+        description='A machine-oriented identifier reference to the party who is making the log entry.',
+        title='Party UUID Reference',
+    )
     role_id: Optional[constr(
         regex=
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
@@ -547,12 +550,14 @@ class LoggedBy(OscalBaseModel):
 
 
 class LocationUuid(OscalBaseModel):
-    __root__: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                     ) = Field(
-                         ...,
-                         description='References a location defined in metadata.',
-                         title='Location Reference',
-                     )
+    __root__: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented identifier reference to a location defined in the metadata section of this or another OSCAL instance. The UUID of the location in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).',
+        title='Location Reference',
+    )
 
 
 class Link(OscalBaseModel):
@@ -600,6 +605,17 @@ class LastModified(OscalBaseModel):
     )
 
 
+class IncludeAll(OscalBaseModel):
+    """
+    Include all controls from the imported catalog or profile resources.
+    """
+
+    pass
+
+    class Config:
+        extra = Extra.forbid
+
+
 class ImportSsp(OscalBaseModel):
     """
     Used by the assessment plan and POA&M to import information about the system.
@@ -610,7 +626,7 @@ class ImportSsp(OscalBaseModel):
 
     href: str = Field(
         ...,
-        description='>A resolvable URL reference to the system security plan for the system being assessed.',
+        description='A resolvable URL reference to the system security plan for the system being assessed.',
         title='System Security Plan Reference',
     )
     remarks: Optional[Remarks] = None
@@ -720,7 +736,7 @@ class EmailAddress(OscalBaseModel):
 
 class DocumentId(OscalBaseModel):
     """
-    A document identifier qualified by an identifier scheme. A document identifier provides a globally unique identifier for a group of documents that are to be treated as different versions of the same document. If this element does not appear, or if the value of this element is empty, the value of "document-id" is equal to the value of the "uuid" flag of the top-level root element.
+    A document identifier qualified by an identifier scheme. A document identifier provides a globally unique identifier with a cross-instance scope that is used for a group of documents that are to be treated as different versions of the same document. If this element does not appear, or if the value of this element is empty, the value of "document-id" is equal to the value of the "uuid" flag of the top-level root element.
     """
 
     class Config:
@@ -747,7 +763,7 @@ class Dependency(OscalBaseModel):
                       ) = Field(
                           ...,
                           alias='task-uuid',
-                          description='References a unique task by UUID.',
+                          description='A machine-oriented identifier reference to a unique task.',
                           title='Task Universally Unique Identifier Reference',
                       )
     remarks: Optional[Remarks] = None
@@ -768,12 +784,7 @@ class ControlObjectiveSelection(OscalBaseModel):
     )
     props: Optional[List[Property]] = Field(None)
     links: Optional[List[Link]] = Field(None)
-    include_all: Optional[Dict[str, Any]] = Field(
-        None,
-        alias='include-all',
-        description='A key word to indicate all.',
-        title='All',
-    )
+    include_all: Optional[IncludeAll] = Field(None, alias='include-all')
     include_objectives: Optional[List[SelectObjectiveById]] = Field(None, alias='include-objectives')
     exclude_objectives: Optional[List[SelectObjectiveById]] = Field(None, alias='exclude-objectives')
     remarks: Optional[Remarks] = None
@@ -868,7 +879,7 @@ class AssessmentSubjectPlaceholder(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a set of assessment subjects that will be identified by a task or an activity that is part of a task.',
+        'A machine-oriented, globally unique identifier for a set of assessment subjects that will be identified by a task or an activity that is part of a task. The locally defined UUID of the assessment subject placeholder can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Subject Placeholder Universally Unique Identifier',
     )
     description: Optional[str] = Field(
@@ -895,7 +906,7 @@ class AssessmentPart(OscalBaseModel):
     )] = Field(
         None,
         description=
-        "A unique identifier for a specific part instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same part across minor revisions of the document.",
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this part elsewhere in this or other OSCAL instances. The locally defined UUID of the part can be used to reference the data item locally or globally (e.g., in an ported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Part Identifier',
     )
     name: constr(
@@ -950,7 +961,7 @@ class AssessmentMethod(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this defined assessment method. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for a given assessment method across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment method elsewhere in this or other OSCAL instances. The locally defined UUID of the assessment method can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Method Universally Unique Identifier',
     )
     description: Optional[str] = Field(
@@ -1032,12 +1043,14 @@ class SystemUser(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the user class.',
-                     title='User Universally Unique Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this user class elsewhere in this or other OSCAL instances. The locally defined UUID of the system user can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='User Universally Unique Identifier',
+    )
     title: Optional[str] = Field(
         None,
         description='A name given to the user, which may be used by a tool for display and navigation.',
@@ -1063,7 +1076,7 @@ class SystemUser(OscalBaseModel):
 
 class SubjectReference(OscalBaseModel):
     """
-    A pointer to a resource based on its universally unique identifier (UUID). Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.
+    A human-oriented identifier reference to a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else.
     """
 
     class Config:
@@ -1074,7 +1087,8 @@ class SubjectReference(OscalBaseModel):
     ) = Field(
         ...,
         alias='subject-uuid',
-        description="A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.",
+        description=
+        "A machine-oriented identifier reference to a component, inventory-item, location, party, user, or resource using it's UUID.",
         title='Subject Universally Unique Identifier Reference',
     )
     type: constr(
@@ -1108,7 +1122,7 @@ class MitigatingFactor(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this mitigating factor. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given mitigating factor across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this mitigating factor elsewhere in this or other OSCAL instances. The locally defined UUID of the mitigating factor can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Mitigating Factor Universally Unique Identifier',
     )
     implementation_uuid: Optional[constr(
@@ -1116,7 +1130,8 @@ class MitigatingFactor(OscalBaseModel):
     )] = Field(
         None,
         alias='implementation-uuid',
-        description='Points to an implementation statement in the SSP.',
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this implementation statement elsewhere in this or other OSCAL instancess. The locally defined UUID of the implementation statement can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Implementation UUID',
     )
     description: str = Field(
@@ -1142,7 +1157,8 @@ class SelectSubjectById(OscalBaseModel):
     ) = Field(
         ...,
         alias='subject-uuid',
-        description="A pointer to a component, inventory-item, location, party, user, or resource using it's UUID.",
+        description=
+        "A machine-oriented identifier reference to a component, inventory-item, location, party, user, or resource using it's UUID.",
         title='Subject Universally Unique Identifier Reference',
     )
     type: constr(
@@ -1182,12 +1198,7 @@ class AssessmentSubject(OscalBaseModel):
     )
     props: Optional[List[Property]] = Field(None)
     links: Optional[List[Link]] = Field(None)
-    include_all: Optional[Dict[str, Any]] = Field(
-        None,
-        alias='include-all',
-        description='A key word to indicate all.',
-        title='All',
-    )
+    include_all: Optional[IncludeAll] = Field(None, alias='include-all')
     include_subjects: Optional[List[SelectSubjectById]] = Field(None, alias='include-subjects')
     exclude_subjects: Optional[List[SelectSubjectById]] = Field(None, alias='exclude-subjects')
     remarks: Optional[Remarks] = None
@@ -1207,7 +1218,7 @@ class Role(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        "A unique identifier for a specific role instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same role across minor revisions of the document.",
+        'A human-oriented, locally unique identifier with cross-instance scope that can be used to reference this defined role elsewhere in this or other OSCAL instances. When referenced from another OSCAL instance, the locally defined ID of the Role from the imported OSCAL instance must be referenced in the context of the containing resource (e.g., import, import-component-definition, import-profile, import-ssp or import-ap). This ID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Role Identifier',
     )
     title: str = Field(
@@ -1267,7 +1278,7 @@ class Resource(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this defined resource elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this defined resource elsewhere in this or other OSCAL instances. This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Resource Universally Unique Identifier',
     )
     title: Optional[str] = Field(
@@ -1322,7 +1333,7 @@ class Revision(OscalBaseModel):
     )
     published: Optional[Published] = None
     last_modified: Optional[LastModified] = Field(None, alias='last-modified')
-    version: Optional[Version] = None
+    version: Version
     oscal_version: Optional[OscalVersion] = Field(None, alias='oscal-version')
     props: Optional[List[Property]] = Field(None)
     links: Optional[List[Link]] = Field(None)
@@ -1343,7 +1354,7 @@ class ResponsibleRole(OscalBaseModel):
     ) = Field(
         ...,
         alias='role-id',
-        description='The role that is responsible for the business function.',
+        description='A human-oriented identifier reference to roles responsible for the business function.',
         title='Responsible Role ID',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1366,7 +1377,7 @@ class ResponsibleParty(OscalBaseModel):
     ) = Field(
         ...,
         alias='role-id',
-        description='The role that the party is responsible for.',
+        description='A human-oriented identifier reference to roles served by the user.',
         title='Responsible Role',
     )
     party_uuids: List[PartyUuid] = Field(..., alias='party-uuids')
@@ -1388,7 +1399,7 @@ class RequiredAsset(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this required asset. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given required asset across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this required asset elsewhere in this or other OSCAL instances. The locally defined UUID of the asset can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Required Universally Unique Identifier',
     )
     subjects: Optional[List[SubjectReference]] = Field(None)
@@ -1417,7 +1428,7 @@ class RelevantEvidence(OscalBaseModel):
 
     href: Optional[str] = Field(
         None,
-        description='>A resolvable URL reference to relevant evidence.',
+        description='A resolvable URL reference to relevant evidence.',
         title='Relevant Evidence Reference',
     )
     description: str = Field(
@@ -1443,7 +1454,7 @@ class Party(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A unique identifier that can be used to reference this defined location elsewhere in an OSCAL document. A UUID should be consistently used for a given party across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this defined party elsewhere in this or other OSCAL instances. The locally defined UUID of the party can be used to reference the data item locally or globally (e.g., from an importing OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Party Universally Unique Identifier',
     )
     type: Type = Field(
@@ -1487,7 +1498,7 @@ class Part(OscalBaseModel):
     )] = Field(
         None,
         description=
-        "A unique identifier for a specific part instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same part across minor revisions of the document.",
+        'A human-oriented, locally unique identifier with cross-instance scope that can be used to reference this defined part elsewhere in this or other OSCAL instances. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Part Identifier',
     )
     name: constr(
@@ -1543,7 +1554,8 @@ class LocalObjective(OscalBaseModel):
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     description: Optional[str] = Field(
@@ -1589,7 +1601,7 @@ class Parameter(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        "A unique identifier for a specific parameter instance. This identifier's uniqueness is document scoped and is intended to be consistent for the same parameter across minor revisions of the document.",
+        'A human-oriented, locally unique identifier with cross-instance scope that can be used to reference this defined parameter elsewhere in this or other OSCAL instances. When referenced from another OSCAL instance, this identifier must be referenced in the context of the containing resource (e.g., import-profile). This id should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Parameter Identifier',
     )
     class_: Optional[constr(
@@ -1607,7 +1619,8 @@ class Parameter(OscalBaseModel):
     )] = Field(
         None,
         alias='depends-on',
-        description='Another parameter invoking this one',
+        description=
+        '**(deprecated)** Another parameter invoking this one. This construct has been deprecated and should not be used.',
         title='Depends on',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1639,13 +1652,14 @@ class OriginActor(OscalBaseModel):
         extra = Extra.forbid
 
     type: Type3 = Field(..., description='The kind of actor.', title='Actor Type')
-    actor_uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                       ) = Field(
-                           ...,
-                           alias='actor-uuid',
-                           description='A pointer to the tool or person based on the associated type.',
-                           title='Actor Universally Unique Identifier Reference',
-                       )
+    actor_uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        alias='actor-uuid',
+        description='A machine-oriented identifier reference to the tool or person based on the associated type.',
+        title='Actor Universally Unique Identifier Reference',
+    )
     role_id: Optional[constr(
         regex=
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
@@ -1672,7 +1686,7 @@ class Location(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A unique identifier that can be used to reference this defined location elsewhere in an OSCAL document. A UUID should be consistently used for a given location across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this defined location elsewhere in this or other OSCAL instances. The locally defined UUID of the location can be used to reference the data item locally or globally (e.g., from an importing OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Location Universally Unique Identifier',
     )
     title: Optional[str] = Field(
@@ -1730,7 +1744,8 @@ class ImplementedComponent(OscalBaseModel):
     ) = Field(
         ...,
         alias='component-uuid',
-        description='A reference to a component that is implemented as part of an inventory item.',
+        description=
+        'A machine-oriented identifier reference to a component that is implemented as part of an inventory item.',
         title='Component Universally Unique Identifier Reference',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1752,7 +1767,7 @@ class InventoryItem(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this inventory item entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this inventory item elsewhere in this or other OSCAL instances. The locally defined UUID of the inventory item can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Inventory Item Universally Unique Identifier',
     )
     description: str = Field(
@@ -1780,7 +1795,8 @@ class IdentifiedSubject(OscalBaseModel):
     ) = Field(
         ...,
         alias='subject-placeholder-uuid',
-        description='References a unique assessment subject placeholder defined by this task.',
+        description=
+        'A machine-oriented identifier reference to a unique assessment subject placeholder defined by this task.',
         title='Assessment Subject Placeholder Universally Unique Identifier Reference',
     )
     subjects: List[AssessmentSubject] = Field(...)
@@ -1798,7 +1814,7 @@ class RelatedTask(OscalBaseModel):
                       ) = Field(
                           ...,
                           alias='task-uuid',
-                          description='References a unique task by UUID.',
+                          description='A machine-oriented identifier reference to a unique task.',
                           title='Task Universally Unique Identifier Reference',
                       )
     props: Optional[List[Property]] = Field(None)
@@ -1827,7 +1843,7 @@ class RelatedResponse(OscalBaseModel):
     ) = Field(
         ...,
         alias='response-uuid',
-        description='References a unique risk response by UUID.',
+        description='A machine-oriented identifier reference to a unique risk response.',
         title='Response Universally Unique Identifier Reference',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1849,7 +1865,7 @@ class AssociatedActivity(OscalBaseModel):
     ) = Field(
         ...,
         alias='activity-uuid',
-        description='References an activity defined in the list of activities.',
+        description='A machine-oriented identifier reference to an activity defined in the list of activities.',
         title='Activity Universally Unique Identifier Reference',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1867,12 +1883,14 @@ class Task(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='Uniquely identifies this assessment task.',
-                     title='Task Universally Unique Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this task elsewhere in this or other OSCAL instances. The locally defined UUID of the task can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Task Universally Unique Identifier',
+    )
     type: constr(
         regex=
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
@@ -1911,7 +1929,8 @@ class UsesComponent(OscalBaseModel):
     ) = Field(
         ...,
         alias='component-uuid',
-        description='A reference to a component that is implemented as part of an inventory item.',
+        description=
+        'A machine-oriented identifier reference to a component that is implemented as part of an inventory item.',
         title='Component Universally Unique Identifier Reference',
     )
     props: Optional[List[Property]] = Field(None)
@@ -1928,12 +1947,14 @@ class AssessmentPlatform(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='Uniquely identifies this assessment Platform.',
-                     title='Assessment Platform Universally Unique Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment platform elsewhere in this or other OSCAL instances. The locally defined UUID of the assessment platform can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Assessment Platform Universally Unique Identifier',
+    )
     title: Optional[str] = Field(
         None,
         description='The title or name for the assessment platform.',

--- a/trestle/oscal/component.py
+++ b/trestle/oscal/component.py
@@ -50,7 +50,7 @@ class Statement(OscalBaseModel):
     ) = Field(
         ...,
         alias='statement-id',
-        description='A reference to a control statement by its identifier',
+        description='A human-oriented identifier reference to a control statement.',
         title='Control Statement Reference',
     )
     uuid: constr(
@@ -58,7 +58,7 @@ class Statement(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this control statement entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this control statement elsewhere in this or other OSCAL instances. The UUID of the control statement in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).',
         title='Control Statement Reference Universally Unique Identifier',
     )
     description: str = Field(
@@ -98,7 +98,7 @@ class SetParameter(OscalBaseModel):
         ...,
         alias='param-id',
         description=
-        "A reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
+        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
         title='Parameter ID',
     )
     values: List[common.Value] = Field(...)
@@ -118,7 +118,7 @@ class IncorporatesComponent(OscalBaseModel):
     ) = Field(
         ...,
         alias='component-uuid',
-        description='A reference to a component by its identifier',
+        description='A machine-oriented identifier reference to a component.',
         title='Component Reference',
     )
     description: str = Field(
@@ -152,19 +152,22 @@ class ImplementedRequirement(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='A unique identifier for a specific control implementation.',
-                     title='Control Implementation Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference a specific control implementation elsewhere in this or other OSCAL instances. The locally defined UUID of the control implementation can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Control Implementation Identifier',
+    )
     control_id: constr(
         regex=
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     description: str = Field(
@@ -189,12 +192,14 @@ class ControlImplementation(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='A unique identifier for the set of implemented controls.',
-                     title='Control Implementation Set Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference a set of implemented controls elsewhere in this or other OSCAL instances. The locally defined UUID of the control implementation set can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Control Implementation Set Identifier',
+    )
     source: str = Field(
         ...,
         description=
@@ -221,12 +226,14 @@ class Capability(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='A unique identifier for a capability.',
-                     title='Capability Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this capability elsewhere in this or other OSCAL instances. The locally defined UUID of the capability can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Capability Identifier',
+    )
     name: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description="The capability's human-readable name.",
@@ -260,12 +267,14 @@ class SystemComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -306,12 +315,14 @@ class DefinedComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -353,7 +364,7 @@ class ComponentDefinition(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier for this component definition instance. This UUID should be changed when this document is revised.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component definition elsewhere in this or other OSCAL instances. The locally defined UUID of the component definition can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Component Definition Universally Unique Identifier',
     )
     metadata: common.Metadata

--- a/trestle/oscal/poam.py
+++ b/trestle/oscal/poam.py
@@ -71,7 +71,7 @@ class SetParameter(OscalBaseModel):
         ...,
         alias='param-id',
         description=
-        "A reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
+        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
         title='Parameter ID',
     )
     values: List[common.Value] = Field(...)
@@ -92,7 +92,8 @@ class SelectControlById(OscalBaseModel):
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     statement_ids: Optional[List[common.StatementId]] = Field(None, alias='statement-ids')
@@ -111,7 +112,7 @@ class RelatedObservation(OscalBaseModel):
     ) = Field(
         ...,
         alias='observation-uuid',
-        description='References an observation defined in the list of observations.',
+        description='A machine-oriented identifier reference to an observation defined in the list of observations.',
         title='Observation Universally Unique Identifier Reference',
     )
 
@@ -160,7 +161,7 @@ class Entry(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a risk log entry. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for this schedule across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk log entry elsewhere in this or other OSCAL instances. The locally defined UUID of the risk log entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Log Entry Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this risk log entry.', title='Title')
@@ -203,12 +204,7 @@ class ControlSelection(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    include_all: Optional[Dict[str, Any]] = Field(
-        None,
-        alias='include-all',
-        description='A key word to indicate all.',
-        title='All',
-    )
+    include_all: Optional[common.IncludeAll] = Field(None, alias='include-all')
     include_controls: Optional[List[SelectControlById]] = Field(None, alias='include-controls')
     exclude_controls: Optional[List[SelectControlById]] = Field(None, alias='exclude-controls')
     remarks: Optional[common.Remarks] = None
@@ -271,7 +267,7 @@ class FindingTarget(OscalBaseModel):
     ) = Field(
         ...,
         alias='target-id',
-        description='Identifies the specific target qualified by the type.',
+        description='A machine-oriented identifier reference for a specific target qualified by the type.',
         title='Finding Target Identifier Reference',
     )
     title: Optional[str] = Field(
@@ -316,12 +312,14 @@ class SystemComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -412,7 +410,7 @@ class Response(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this remediation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given remediation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this remediation elsewhere in this or other OSCAL instances. The locally defined UUID of the risk response can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Remediation Universally Unique Identifier',
     )
     lifecycle: constr(
@@ -451,7 +449,7 @@ class Risk(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this risk. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given risk across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this risk elsewhere in this or other OSCAL instances. The locally defined UUID of the risk can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Risk Universally Unique Identifier',
     )
     title: str = Field(..., description='The title for this risk.', title='Risk Title')
@@ -468,10 +466,7 @@ class Risk(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    status: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(..., description='Describes the status of the associated risk.', title='Status')
+    status: common.RiskStatus
     origins: Optional[List[Origin1]] = Field(None)
     threat_ids: Optional[List[common.ThreatId]] = Field(None, alias='threat-ids')
     characterizations: Optional[List[Characterization]] = Field(None)
@@ -504,7 +499,7 @@ class PoamItem(OscalBaseModel):
     )] = Field(
         None,
         description=
-        'Uniquely identifies the POA&M entry. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for a given POA&M item across revisions of the document.',
+        'A machine-oriented, globally unique identifier with instance scope that can be used to reference this POA&M item entry in this OSCAL instance. This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='POA&M Item Universally Unique Identifier',
     )
     title: str = Field(
@@ -538,7 +533,7 @@ class Observation(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this observation. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. Once assigned, a UUID should be consistently used for a given observation across revisions.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this observation elsewhere in this or other OSCAL instances. The locally defined UUID of the observation can be used to reference the data item locally or globally (e.g., in an imorted OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Observation Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this observation.', title='Observation Title')
@@ -594,7 +589,7 @@ class PlanOfActionAndMilestones(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this POA&M. This UUID must be changed each time the content of the POA&M changes.',
+        'A machine-oriented, globally unique identifier with instancescope that can be used to reference this POA&M instance in this OSCAL instance. This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='POA&M Universally Unique Identifier',
     )
     metadata: common.Metadata
@@ -620,7 +615,7 @@ class Step(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies a step. This UUID may be referenced elsewhere in an OSCAL document when referring to this step. A UUID should be consistently used for a given test step across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this step elsewhere in this or other OSCAL instances. The locally defined UUID of the step (in a series of steps) can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Step Universally Unique Identifier',
     )
     title: Optional[str] = Field(None, description='The title for this step.', title='Step Title')
@@ -649,7 +644,7 @@ class Activity(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'Uniquely identifies this assessment activity. This UUID may be referenced elsewhere in an OSCAL document when referring to this information. A UUID should be consistently used for a given included activity across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment activity elsewhere in this or other OSCAL instances. The locally defined UUID of the activity can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Assessment Activity Universally Unique Identifier',
     )
     title: Optional[str] = Field(

--- a/trestle/oscal/ssp.py
+++ b/trestle/oscal/ssp.py
@@ -83,7 +83,7 @@ class SetParameter(OscalBaseModel):
         ...,
         alias='param-id',
         description=
-        "A reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
+        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
         title='Parameter ID',
     )
     values: List[common.Value] = Field(...)
@@ -142,7 +142,7 @@ class Satisfied(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this satisfied entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this satisfied control implementation entry elsewhere in this or other OSCAL instances. The locally defined UUID of the control implementation can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Satisfied Universally Unique Identifier',
     )
     responsibility_uuid: Optional[constr(
@@ -150,8 +150,9 @@ class Satisfied(OscalBaseModel):
     )] = Field(
         None,
         alias='responsibility-uuid',
-        description="Identifies a 'provided' assembly associated with this assembly.",
-        title='Provided UUID',
+        description=
+        'A machine-oriented identifier reference to a control implementation that satisfies a responsibility imposed by a leveraged system.',
+        title='Responsibility UUID',
     )
     description: str = Field(
         ...,
@@ -178,7 +179,7 @@ class Responsibility(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this responsibility entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this responsibility elsewhere in this or other OSCAL instances. The locally defined UUID of the responsibility can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Responsibility Universally Unique Identifier',
     )
     provided_uuid: Optional[constr(
@@ -186,7 +187,8 @@ class Responsibility(OscalBaseModel):
     )] = Field(
         None,
         alias='provided-uuid',
-        description="Identifies a 'provided' assembly associated with this assembly.",
+        description=
+        'A machine-oriented identifier reference to an inherited control implementation that a leveraging system is inheriting from a leveraged system.',
         title='Provided UUID',
     )
     description: str = Field(
@@ -214,7 +216,7 @@ class Provided(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this provided entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this provided entry elsewhere in this or other OSCAL instances. The locally defined UUID of the provided entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Provided Universally Unique Identifier',
     )
     description: str = Field(
@@ -242,7 +244,7 @@ class Inherited(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this inherited entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this inherited entry elsewhere in this or other OSCAL instances. The locally defined UUID of the inherited control implementation can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Inherited Universally Unique Identifier',
     )
     provided_uuid: Optional[constr(
@@ -250,7 +252,8 @@ class Inherited(OscalBaseModel):
     )] = Field(
         None,
         alias='provided-uuid',
-        description="Identifies a 'provided' assembly associated with this assembly.",
+        description=
+        'A machine-oriented identifier reference to an inherited control implementation that a leveraging system is inheriting from a leveraged system.',
         title='Provided UUID',
     )
     description: str = Field(
@@ -267,7 +270,8 @@ class Inherited(OscalBaseModel):
 class InformationTypeId(OscalBaseModel):
     __root__: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
-        description='An identifier qualified by the given identification system used, such as NIST SP 800-60.',
+        description=
+        'A human-oriented, globally unique identifier qualified by the given identification system used, such as NIST SP 800-60. This identifier has cross-instance scope and can be used to reference this system elsewhere in this or other OSCAL instances. This id should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Information Type Systematized Identifier',
     )
 
@@ -317,17 +321,19 @@ class Diagram(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(..., description='The identifier for this diagram.', title='Diagram ID')
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this diagram elsewhere in this or other OSCAL instances. The locally defined UUID of the diagram can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Diagram ID',
+    )
     description: Optional[str] = Field(None, description='A summary of the diagram.', title='Diagram Description')
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
     caption: Optional[str] = Field(None, description='A brief caption to annotate the diagram.', title='Caption')
-    remarks: Optional[str] = Field(
-        None,
-        description='Commentary about the diagram that enhances it.',
-        title='remarks field',
-    )
+    remarks: Optional[common.Remarks] = None
 
 
 class DateAuthorized(OscalBaseModel):
@@ -389,7 +395,7 @@ class ByComponent(OscalBaseModel):
     ) = Field(
         ...,
         alias='component-uuid',
-        description='A reference to the component that is implementing a given control or control statement.',
+        description='A machine-oriented identifier reference to the component that is implemeting a given control.',
         title='Component Universally Unique Identifier Reference',
     )
     uuid: constr(
@@ -397,7 +403,7 @@ class ByComponent(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this by-component entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this by-component entry elsewhere in this or other OSCAL instances. The locally defined UUID of the by-component entry can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='By-Component Universally Unique Identifier',
     )
     description: str = Field(
@@ -460,11 +466,7 @@ class AuthorizationBoundary(OscalBaseModel):
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
     diagrams: Optional[List[Diagram]] = Field(None)
-    remarks: Optional[str] = Field(
-        None,
-        description="Commentary about the system's authorization boundary that enhances the diagram.",
-        title='remarks field',
-    )
+    remarks: Optional[common.Remarks] = None
 
 
 class Status1(OscalBaseModel):
@@ -499,12 +501,14 @@ class SystemComponent(OscalBaseModel):
     class Config:
         extra = Extra.forbid
 
-    uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                 ) = Field(
-                     ...,
-                     description='The unique identifier for the component.',
-                     title='Component Identifier',
-                 )
+    uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        description=
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
+        title='Component Identifier',
+    )
     type: constr(regex=r'^\S(.*\S)?$') = Field(
         ...,
         description='A category describing the purpose of the component.',
@@ -551,7 +555,7 @@ class Statement(OscalBaseModel):
     ) = Field(
         ...,
         alias='statement-id',
-        description='A reference to a control statement by its identifier',
+        description='A human-oriented identifier reference to a control statement.',
         title='Control Statement Reference',
     )
     uuid: constr(
@@ -559,7 +563,7 @@ class Statement(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this control statement entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this control statement elsewhere in this or other OSCAL instances. The UUID of the control statement in the source OSCAL instance is sufficient to reference the data item locally or globally (e.g., in an imported OSCAL instance).',
         title='Control Statement Reference Universally Unique Identifier',
     )
     props: Optional[List[common.Property]] = Field(None)
@@ -582,7 +586,7 @@ class ImplementedRequirement(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this control requirement entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this control requirement elsewhere in this or other OSCAL instances. The locally defined UUID of the control requirement can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Control Requirement Universally Unique Identifier',
     )
     control_id: constr(
@@ -591,7 +595,8 @@ class ImplementedRequirement(OscalBaseModel):
     ) = Field(
         ...,
         alias='control-id',
-        description='A reference to a control with a corresponding id value.',
+        description=
+        'A human-oriented identifier reference to a control with a corresponding id value. When referencing an externally defined control, the Control Identifier Reference must be used in the context of the external / imported OSCAL instance (e.g., uri-reference).',
         title='Control Identifier Reference',
     )
     props: Optional[List[common.Property]] = Field(None)
@@ -653,7 +658,7 @@ class LeveragedAuthorization(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier that can be used to reference this leveraged authorization entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope and can be used to reference this leveraged authorization elsewhere in this or other OSCAL instances. The locally defined UUID of the leveraged authorization can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Leveraged Authorization Universally Unique Identifier',
     )
     title: str = Field(
@@ -663,13 +668,14 @@ class LeveragedAuthorization(OscalBaseModel):
     )
     props: Optional[List[common.Property]] = Field(None)
     links: Optional[List[common.Link]] = Field(None)
-    party_uuid: constr(regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-                       ) = Field(
-                           ...,
-                           alias='party-uuid',
-                           description='A reference to the party that manages the leveraged system.',
-                           title='party-uuid field',
-                       )
+    party_uuid: constr(
+        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
+    ) = Field(
+        ...,
+        alias='party-uuid',
+        description='A machine-oriented identifier reference to the party that manages the leveraged system.',
+        title='party-uuid field',
+    )
     date_authorized: DateAuthorized = Field(..., alias='date-authorized')
     remarks: Optional[common.Remarks] = None
 
@@ -734,7 +740,7 @@ class InformationType(OscalBaseModel):
     )] = Field(
         None,
         description=
-        'A globally unique identifier that can be used to reference this information type entry elsewhere in an OSCAL document. A UUID should be consistently used for a given resource across revisions of the document.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this information type elsewhere in this or other OSCAL instances. The locally defined UUID of the information type can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='Information Type Universally Unique Identifier',
     )
     title: str = Field(
@@ -842,7 +848,7 @@ class SystemSecurityPlan(OscalBaseModel):
     ) = Field(
         ...,
         description=
-        'A globally unique identifier for this catalog instance. This UUID should be changed when this document is revised.',
+        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this system security plan (SSP) elsewhere in this or other OSCAL instances. The locally defined UUID of the SSP can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance).This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
         title='System Security Plan Universally Unique Identifier',
     )
     metadata: common.Metadata

--- a/trestle/transforms/implementations/osco.py
+++ b/trestle/transforms/implementations/osco.py
@@ -403,7 +403,7 @@ class OscalResultsFactory():
             reviewed_controls=self.reviewed_controls,
         )
         if self.result_properties:
-            prop.prop = self.result_properties
+            prop.props = self.result_properties
         if self.inventory:
             prop.local_definitions = self.local_definitions
         if self.observations:

--- a/trestle/transforms/implementations/tanium.py
+++ b/trestle/transforms/implementations/tanium.py
@@ -607,6 +607,6 @@ class TaniumOscalFactory():
                 observations=observations
             )
             component_ref = component.uuid
-            result.prop = self._get_properties(component_ref)
+            result.props = self._get_properties(component_ref)
             results.append(result)
         return results


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Now support OSCAL version 1.0.2
Regenerated oscal models and changed prop to props in assessment_results
Moved oscal REGEX to support both 1.0.0 and 1.0.2 on import
Files created will be version 1.0.2
BREAKING CHANGE
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
