### PR TITLE
fix: prevent blowfish warning due to new release of cryptography

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ include_package_data = True
 install_requires =
     attrs~=19.3
     ilcli
+    cryptography == 36.0.2
     paramiko
     ruamel.yaml
     furl

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 install_requires =
     attrs~=19.3
     ilcli
-    cryptography == 36.0.2
+    cryptography == 36.0.2  #37.0.0 introduced blowfish issue.  Open this back up when release fixes it
     paramiko
     ruamel.yaml
     furl


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Force back level version of cryptography so it doesn't warn about blowfish deprecation.

closes #1111 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
