### PR TITLE
fix: Add control id to the generated docs

### DIFF
--- a/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
+++ b/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
@@ -1,3 +1,13 @@
 # Control Page
 
-{{ control_writer.write_control_with_sections(control, group_title, ['statement', 'objective', 'ExpectedEvidence', 'ImplGuidance', 'table_of_parameters'], {'statement':'Control Statement Header', 'objective':'Control Objective Header', 'ExpectedEvidence':'Expected Evidence Header', 'ImplGuidance':'Implementation Guidance', 'table_of_parameters':'Table of Control Parameters'}, True, True) }}
+{{ control_writer.write_control_with_sections(control, group_title,
+['statement', 'objective', 'ExpectedEvidence', 'ImplGuidance', 'table_of_parameters'],
+{
+'statement':'Control Statement Header',
+'objective':'Control Objective Header',
+'ExpectedEvidence':'Expected Evidence Header',
+'ImplGuidance':'Implementation Guidance',
+'table_of_parameters':'Table of Control Parameters'
+},
+True, True)
+}}

--- a/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
+++ b/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
@@ -1,0 +1,3 @@
+# Control Page
+
+{{ control_writer.write_control_with_sections(control, group_title, ['statement', 'objective', 'ExpectedEvidence', 'ImplGuidance', 'table_of_parameters'], {'statement':'Control Statement Header', 'objective':'Control Objective Header', 'ExpectedEvidence':'Expected Evidence Header', 'ImplGuidance':'Implementation Guidance', 'table_of_parameters':'Table of Control Parameters'}, True, True) }}

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -25,10 +25,8 @@ from trestle.core.commands.author.ssp import SSPGenerate
 from trestle.core.markdown.markdown_node import MarkdownNode
 
 
-def test_jinja_ssp_output(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
-    """Test Jinja SSP output."""
-    input_template = 'ssp_template.md.jinja'
-
+def setup_ssp(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Prepare repository for docs generation."""
     args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
     ssp_cmd = SSPGenerate()
     assert ssp_cmd._run(args) == 0
@@ -41,6 +39,11 @@ def test_jinja_ssp_output(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.P
         if os.path.isfile(full_file_name):
             shutil.copy(full_file_name, tmp_trestle_dir)
 
+
+def test_jinja_ssp_output(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
+    """Test Jinja SSP output."""
+    input_template = 'ssp_template.md.jinja'
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
     command_import = f'trestle author jinja -i {input_template} -o output_file.md -ssp ssp_json -p main_profile'
     execute_command_and_assert(command_import, 0, monkeypatch)
 
@@ -60,17 +63,7 @@ def test_jinja_lookup_table(
     """Test Jinja lookup table substitions."""
     input_template = 'use_lookup_table.md.jinja'
     luk_table = 'lookup_table.yaml'
-    args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
-    ssp_cmd = SSPGenerate()
-    assert ssp_cmd._run(args) == 0
-
-    command_ssp_gen = 'trestle author ssp-assemble -m my_ssp -o ssp_json'
-    execute_command_and_assert(command_ssp_gen, 0, monkeypatch)
-
-    for file_name in os.listdir(testdata_dir / 'jinja'):
-        full_file_name = os.path.join(testdata_dir / 'jinja', file_name)
-        if os.path.isfile(full_file_name):
-            shutil.copy(full_file_name, tmp_trestle_dir)
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
     command_import = f'trestle author jinja -i {input_template} -o output_file.md ' \
                      f'-lut {luk_table} -ssp ssp_json -p main_profile -elp lut.prefix'  # noqa: N400
     execute_command_and_assert(command_import, 0, monkeypatch)
@@ -101,17 +94,7 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
     """Test that parameters are substituted with the given formatting."""
     input_template = 'ssp_template.md.jinja'
 
-    args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
-    ssp_cmd = SSPGenerate()
-    assert ssp_cmd._run(args) == 0
-
-    command_ssp_gen = 'trestle author ssp-assemble -m my_ssp -o ssp_json'
-    execute_command_and_assert(command_ssp_gen, 0, monkeypatch)
-
-    for file_name in os.listdir(testdata_dir / 'jinja'):
-        full_file_name = os.path.join(testdata_dir / 'jinja', file_name)
-        if os.path.isfile(full_file_name):
-            shutil.copy(full_file_name, tmp_trestle_dir)
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
 
     command_md_gen = f'trestle author jinja -pf *.* -i {input_template} -o output.md -ssp ssp_json -p main_profile'
     execute_command_and_assert(command_md_gen, 0, monkeypatch)
@@ -165,17 +148,7 @@ def test_jinja_profile_docs(
     """Test Jinja Profile to multiple md files output."""
     input_template = 'profile_to_docs.md.jinja'
 
-    args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
-    ssp_cmd = SSPGenerate()
-    assert ssp_cmd._run(args) == 0
-
-    command_ssp_gen = 'trestle author ssp-assemble -m my_ssp -o ssp_json'
-    execute_command_and_assert(command_ssp_gen, 0, monkeypatch)
-
-    for file_name in os.listdir(testdata_dir / 'jinja'):
-        full_file_name = os.path.join(testdata_dir / 'jinja', file_name)
-        if os.path.isfile(full_file_name):
-            shutil.copy(full_file_name, tmp_trestle_dir)
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
 
     command_import = f'trestle author jinja -i {input_template} -o controls -p test_profile_a --docs-profile'
     execute_command_and_assert(command_import, 0, monkeypatch)
@@ -193,23 +166,35 @@ def test_jinja_profile_docs(
             assert node3
 
 
+def test_jinja_profile_docs_with_group_title(
+    testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Test Jinja Profile to multiple md files output with group title."""
+    input_template = 'profile_to_docs_with_group_title.md.jinja'
+
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
+
+    command_import = f'trestle author jinja -i {input_template} -o controls -p test_profile_a --docs-profile'
+    execute_command_and_assert(command_import, 0, monkeypatch)
+
+    md_control = list((tmp_trestle_dir / 'controls' / 'ac').iterdir())[0]
+    with open(md_control) as md_file:
+        contents = md_file.read()
+        tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))
+        assert tree
+        node1 = tree.get_node_for_key('# Control Page')
+        assert node1
+        node2 = tree.get_node_for_key('# AC-2 - \\[Access Control\\] ACCOUNT MANAGEMENT')
+        assert node2
+
+
 def test_jinja_profile_docs_fails(
     testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
 ) -> None:
     """Test jinja docs generate fails."""
     input_template = 'profile_to_docs.md.jinja'
 
-    args, _, _ = setup_for_ssp(True, True, tmp_trestle_dir, 'main_profile', 'my_ssp')
-    ssp_cmd = SSPGenerate()
-    assert ssp_cmd._run(args) == 0
-
-    command_ssp_gen = 'trestle author ssp-assemble -m my_ssp -o ssp_json'
-    execute_command_and_assert(command_ssp_gen, 0, monkeypatch)
-
-    for file_name in os.listdir(testdata_dir / 'jinja'):
-        full_file_name = os.path.join(testdata_dir / 'jinja', file_name)
-        if os.path.isfile(full_file_name):
-            shutil.copy(full_file_name, tmp_trestle_dir)
+    setup_ssp(testdata_dir, tmp_trestle_dir, monkeypatch)
 
     command_jinja = f'trestle author jinja -i {input_template} -o controls --docs-profile'
     execute_command_and_assert(command_jinja, 2, monkeypatch)

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -177,7 +177,7 @@ def test_jinja_profile_docs_with_group_title(
     command_import = f'trestle author jinja -i {input_template} -o controls -p test_profile_a --docs-profile'
     execute_command_and_assert(command_import, 0, monkeypatch)
 
-    md_control = list((tmp_trestle_dir / 'controls' / 'ac').iterdir())[0]
+    md_control = tmp_trestle_dir / 'controls' / 'ac' / 'ac-2.md'
     with open(md_control) as md_file:
         contents = md_file.read()
         tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))

--- a/trestle/core/control_io.py
+++ b/trestle/core/control_io.py
@@ -155,12 +155,19 @@ class ControlIOWriter():
     ) -> None:
         """Add the control statement and items to the md file."""
         self._md_file.new_paragraph()
-        title = f'{control.id} - \[{group_title}\] {control.title}'
-        if capitalize_title:
-            title = f'{control.id.upper()} - \[{group_title.title()}\] {control.title.title()}'
+        control_id = control.id
+        group_name = ''
+        control_title = control.title
 
-        if not print_group_title:
-            title = re.sub('-.*?]', ' -', title)
+        if print_group_title:
+            group_name = ' \[' + group_title + '\]'
+
+        if capitalize_title:
+            control_id = control_id.upper()
+            group_name = group_name.title()
+            control_title = control_title.upper()
+
+        title = f'{control_id} -{group_name} {control_title}'
 
         header_title = 'Control Statement'
         if sections_dict and sections_dict['statement']:


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Add control id to the generated docs

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
