### PR TITLE
feat: filter ssp by component

### DIFF
--- a/docs/trestle_author.md
+++ b/docs/trestle_author.md
@@ -306,6 +306,12 @@ For more details on its usage please see [the ssp authoring tutorial](https://ib
 
 ## `trestle author ssp-filter`
 
-The `ssp-filter` sub-command takes a given SSP and filters its contents based on a given profile.  The SSP is assumed to contain a superset of controls needed by the profile, and the filter operation generates a new SSP with just the controls needed by that profile.  If the profile references a control not in the SSP, the routine fails with an error.
+The `ssp-filter` sub-command takes a given SSP and filters its contents based on a given profile and/or list of components.
+
+If filtering by profile, the SSP is assumed to contain a superset of controls needed by the profile, and the filter operation generates a new SSP with just the controls needed by that profile.  If the profile references a control not in the SSP, the routine fails with an error.
+
+If filtering by components, a colon-delimited list of components should be provided, with `This system` as the default name for the overall required component for the entire system.  Case and spaces are ignored in the component names, so the names could be specified as `--components "this system: my component"`.  The resulting, filtered ssp will have updated implementated requirements with filtered by_components on each requirement, and filtered by_components on each statement.
+
+You may filter by a combination of a profile and a list of component names.
 
 For more details on its usage please see [the ssp authoring tutorial](https://ibm.github.io/compliance-trestle/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring).

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -458,6 +458,20 @@ also do the bar stuff
 
     assert orig_uuid != test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
 
+    # now filter without profile or components to trigger error
+    args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir,
+        name=ssp_name,
+        profile=None,
+        output=filtered_name,
+        verbose=0,
+        regenerate=True,
+        version=None,
+        components=None
+    )
+    ssp_filter = SSPFilter()
+    assert ssp_filter._run(args) == 1
+
     # now filter the ssp through test_profile_b to force error because b references controls not in the ssp
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir,

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -395,6 +395,12 @@ class SSPFilter(AuthorCommonCommand):
                         new_statements.append(statement)
                     imp_req.statements = none_if_empty(new_statements)
                 ssp.control_implementation.implemented_requirements = new_imp_reqs
+                # now remove any unused components from the ssp
+                new_comp_list: List[ossp.SystemComponent] = []
+                for comp in ssp.system_implementation.components:
+                    if comp.uuid in comp_uuids:
+                        new_comp_list.append(comp)
+                ssp.system_implementation.components = new_comp_list
 
         # filter by controls in profile
         if profile_name:

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -324,6 +324,9 @@ class SSPFilter(AuthorCommonCommand):
             comp_names: Optional[List[str]] = None
             if args.components:
                 comp_names = args.components.split(':')
+            elif not args.profile:
+                logger.warning('You must specify either a profile or list of component names for ssp-filter.')
+                return 1
 
             return self.filter_ssp(
                 trestle_root, args.name, args.profile, args.output, args.regenerate, args.version, comp_names

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -301,26 +301,33 @@ class SSPAssemble(AuthorCommonCommand):
 
 
 class SSPFilter(AuthorCommonCommand):
-    """Filter the controls in an ssp based on files included by profile."""
+    """Filter the controls in an ssp based on files included by profile and/or list of component names."""
 
     name = 'ssp-filter'
 
     def _init_arguments(self) -> None:
         file_help_str = 'Name of the input ssp'
         self.add_argument('-n', '--name', help=file_help_str, required=True, type=str)
-        file_help_str = 'Name of the input profile that defines set of controls in output ssp'
-        self.add_argument('-p', '--profile', help=file_help_str, required=True, type=str)
+        file_help_str = 'Name of the optional input profile that defines set of controls in filtered ssp'
+        self.add_argument('-p', '--profile', help=file_help_str, required=False, type=str)
         output_help_str = 'Name of the output generated SSP'
         self.add_argument('-o', '--output', help=output_help_str, required=True, type=str)
         self.add_argument('-r', '--regenerate', action='store_true', help=const.HELP_REGENERATE)
         self.add_argument('-vn', '--version', help=const.HELP_VERSION, required=False, type=str)
+        comp_help_str = 'Colon-delimited list of component names to include in filtered ssp.'
+        self.add_argument('-c', '--components', help=comp_help_str, required=False, type=str)
 
     def _run(self, args: argparse.Namespace) -> int:
         try:
             log.set_log_level_from_args(args)
             trestle_root = pathlib.Path(args.trestle_root)
+            comp_names: Optional[List[str]] = None
+            if args.components:
+                comp_names = args.components.split(':')
 
-            return self.filter_ssp(trestle_root, args.name, args.profile, args.output, args.regenerate, args.version)
+            return self.filter_ssp(
+                trestle_root, args.name, args.profile, args.output, args.regenerate, args.version, comp_names
+            )
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Error generating the filtered ssp')
 
@@ -331,60 +338,95 @@ class SSPFilter(AuthorCommonCommand):
         profile_name: str,
         out_name: str,
         regenerate: bool,
-        version: Optional[str]
+        version: Optional[str],
+        components: Optional[List[str]] = None
     ) -> int:
         """
-        Filter the ssp based on controls included by the profile and output new ssp.
+        Filter the ssp based on controls included by the profile and/or components and output new ssp.
 
         Args:
             trestle_root: root directory of the trestle project
             ssp_name: name of the ssp model
-            profile_name: name of the profile model used for filtering
+            profile_name: name of the optional profile model used for filtering
             out_name: name of the output ssp model with filtered controls
             regenerate: whether to regenerate the uuid's in the ssp
             version: new version for the model
+            components: optional list of component names used for filtering
 
         Returns:
             0 on success, 1 otherwise
         """
+        # load the ssp
         ssp: ossp.SystemSecurityPlan
-
         ssp, _ = ModelUtils.load_top_level_model(trestle_root, ssp_name, ossp.SystemSecurityPlan, FileContentType.JSON)
         profile_path = ModelUtils.path_for_top_level_model(
             trestle_root, profile_name, prof.Profile, FileContentType.JSON
         )
 
-        prof_resolver = ProfileResolver()
-        catalog = prof_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
-        catalog_interface = CatalogInterface(catalog)
+        if components:
+            raw_comp_names = [name.lower().replace(' ', '') for name in components]
+            comp_uuids: List[str] = []
+            for component in ssp.system_implementation.components:
+                if component.title.lower().replace(' ', '') in raw_comp_names:
+                    comp_uuids.append(component.uuid)
+            # imp_reqs can be by comp
+            # and imp_reqs can have statements that are by comp
+            if comp_uuids:
+                new_imp_reqs: List[ossp.ImplementedRequirement] = []
+                # these are all required to be present
+                for imp_req in ssp.control_implementation.implemented_requirements:
+                    new_by_comps: List[ossp.ByComponent] = []
+                    # by_comps is optional
+                    for by_comp in as_list(imp_req.by_components):
+                        if by_comp.component.uuid in comp_uuids:
+                            new_by_comps.append(by_comp)
+                    imp_req.by_components = none_if_empty(new_by_comps)
+                    new_imp_reqs.append(imp_req)
+                    new_statements: List[ossp.Statement] = []
+                    for statement in as_list(imp_req.statements):
+                        new_by_comps: List[ossp.ByComponent] = []
+                        for by_comp in as_list(statement.by_components):
+                            if by_comp.component_uuid in comp_uuids:
+                                new_by_comps.append(by_comp)
+                        statement.by_components = none_if_empty(new_by_comps)
+                        new_statements.append(statement)
+                    imp_req.statements = none_if_empty(new_statements)
+                ssp.control_implementation.implemented_requirements = new_imp_reqs
 
-        # The input ssp should reference a superset of the controls referenced by the profile
-        # Need to cull references in the ssp to controls not in the profile
-        # Also make sure the output ssp contains imp reqs for all controls in the profile
-        control_imp = ssp.control_implementation
-        ssp_control_ids: Set[str] = set()
+        # filter by controls in profile
+        if profile_name:
+            prof_resolver = ProfileResolver()
+            catalog = prof_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
+            catalog_interface = CatalogInterface(catalog)
 
-        new_set_params: List[ossp.SetParameter] = []
-        for set_param in as_list(control_imp.set_parameters):
-            control = catalog_interface.get_control_by_param_id(set_param.param_id)
-            if control is not None:
-                new_set_params.append(set_param)
-                ssp_control_ids.add(control.id)
-        control_imp.set_parameters = new_set_params if new_set_params else None
+            # The input ssp should reference a superset of the controls referenced by the profile
+            # Need to cull references in the ssp to controls not in the profile
+            # Also make sure the output ssp contains imp reqs for all controls in the profile
+            control_imp = ssp.control_implementation
+            ssp_control_ids: Set[str] = set()
 
-        new_imp_requirements: List[ossp.ImplementedRequirement] = []
-        for imp_requirement in as_list(control_imp.implemented_requirements):
-            control = catalog_interface.get_control(imp_requirement.control_id)
-            if control is not None:
-                new_imp_requirements.append(imp_requirement)
-                ssp_control_ids.add(control.id)
-        control_imp.implemented_requirements = new_imp_requirements
+            new_set_params: List[ossp.SetParameter] = []
+            for set_param in as_list(control_imp.set_parameters):
+                control = catalog_interface.get_control_by_param_id(set_param.param_id)
+                if control is not None:
+                    new_set_params.append(set_param)
+                    ssp_control_ids.add(control.id)
+            control_imp.set_parameters = none_if_empty(new_set_params)
 
-        # make sure all controls in the profile have implemented reqs in the final ssp
-        if not ssp_control_ids.issuperset(catalog_interface.get_control_ids()):
-            raise TrestleError('Unable to filter the ssp because the profile references controls not in it.')
+            new_imp_requirements: List[ossp.ImplementedRequirement] = []
+            for imp_requirement in as_list(control_imp.implemented_requirements):
+                control = catalog_interface.get_control(imp_requirement.control_id)
+                if control is not None:
+                    new_imp_requirements.append(imp_requirement)
+                    ssp_control_ids.add(control.id)
+            control_imp.implemented_requirements = new_imp_requirements
 
-        ssp.control_implementation = control_imp
+            # make sure all controls in the profile have implemented reqs in the final ssp
+            if not ssp_control_ids.issuperset(catalog_interface.get_control_ids()):
+                raise TrestleError('Unable to filter the ssp because the profile references controls not in it.')
+
+            ssp.control_implementation = control_imp
+
         if regenerate:
             ssp, _, _ = ModelUtils.regenerate_uuids(ssp)
         if version:

--- a/trestle/core/ssp_io.py
+++ b/trestle/core/ssp_io.py
@@ -205,13 +205,19 @@ class SSPMarkdownWriter():
         md_list = self._write_list_with_header('FedRamp Control Origination.', control_origination, level)
         return md_list
 
-    def get_control_response(self, control_id: str, level: int, write_empty_responses=False) -> str:
+    def get_control_response(self, control_id: str, level: int, write_empty_responses=False, show_comp=True) -> str:
         """
         Get the full control implemented requirements, broken down based on the available control responses.
 
-        For components the following structure is assumed:
+        Args:
+            control_id: id of the control
+            level: level of indentation
+            write_empty_responses: write response even if empty
+            show_comp: show the component name in the response
 
-        'The System' is the default response, and all other components are treated as sub-headings per response item.
+        Notes:
+            For components the following structure is assumed:
+            'The System' is the default response, and other components are treated as sub-headings per response item.
         """
         if not self._resolved_catalog:
             raise TrestleError('Cannot get control response, set resolved catalog first.')
@@ -247,7 +253,7 @@ class SSPMarkdownWriter():
                         if component_key == SSP_MAIN_COMP_NAME and idx == 0:
                             # special case ignore header but print contents
                             md_writer.new_paragraph()
-                        else:
+                        elif show_comp:
                             md_writer.new_header(level=2, title=component_key)
                         md_writer.set_indent_level(-1)
                         md_writer.new_line(response_per_component[component_key])


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

## Key links:
Added new ability to filter ssp by component
This filters from OSCAL/json to OSCAL/json using a mixture of profile and/or component names

closes #1040

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
