### PR TITLE
fix: ssp-assemble now ignores case and space in comp names

### DIFF
--- a/docs/trestle_author.md
+++ b/docs/trestle_author.md
@@ -314,4 +314,6 @@ If filtering by components, a colon-delimited list of components should be provi
 
 You may filter by a combination of a profile and a list of component names.
 
+As with the other related author commands, if an existing destination file already exists, it is not updated if no changes would be made.
+
 For more details on its usage please see [the ssp authoring tutorial](https://ibm.github.io/compliance-trestle/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring).

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -442,7 +442,7 @@ also do the bar stuff
 
     assert orig_uuid == test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
 
-    # filter again to confirm uuid is different with regen
+    # filter again to confirm uuid does not change even with regen because contents are the same
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir,
         name=ssp_name,
@@ -456,7 +456,7 @@ also do the bar stuff
     ssp_filter = SSPFilter()
     assert ssp_filter._run(args) == 0
 
-    assert orig_uuid != test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
+    assert orig_uuid == test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
 
     # now filter without profile or components to trigger error
     args = argparse.Namespace(

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -428,10 +428,10 @@ also do the bar stuff
         FileContentType.JSON
     )
 
-    # confirm the imp_reqs have been culled by profile_d two only two controls
+    # confirm the imp_reqs have been culled by profile_d to only two controls
     assert len(ssp.control_implementation.implemented_requirements) == 2
 
-    # confirm there are three by_comps for this system, foo, bar
+    # confirm there are three by_comps for: this system, foo, bar
     assert len(ssp.control_implementation.implemented_requirements[0].statements[0].by_components) == 3
 
     # confirm uuid was not regenerated

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -395,6 +395,12 @@ also do the bar stuff
     # confirm all by_comps are there for this system, foo, bar
     assert len(ssp.control_implementation.implemented_requirements[1].statements[0].by_components) == 3
 
+    # get the original uuid
+    orig_uuid = ssp.uuid
+
+    # confirm there are seven controls and corresponding imp_reqs
+    assert len(ssp.control_implementation.implemented_requirements) == 7
+
     new_setparam = ossp.SetParameter(param_id='ac-1_prm_1', values=['new_value'])
     ssp.control_implementation.set_parameters = [new_setparam]
     ModelUtils.save_top_level_model(ssp, tmp_trestle_dir, ssp_name, FileContentType.JSON)
@@ -410,6 +416,36 @@ also do the bar stuff
         verbose=0,
         regenerate=False,
         version=None,
+        components=None
+    )
+    ssp_filter = SSPFilter()
+    assert ssp_filter._run(args) == 0
+
+    ssp, _ = ModelUtils.load_top_level_model(
+        tmp_trestle_dir,
+        filtered_name,
+        ossp.SystemSecurityPlan,
+        FileContentType.JSON
+    )
+
+    # confirm the imp_reqs have been culled by profile_d two only two controls
+    assert len(ssp.control_implementation.implemented_requirements) == 2
+
+    # confirm there are three by_comps for this system, foo, bar
+    assert len(ssp.control_implementation.implemented_requirements[0].statements[0].by_components) == 3
+
+    # confirm uuid was not regenerated
+    assert ssp.uuid == orig_uuid
+
+    # now filter the ssp by components
+    args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir,
+        name=ssp_name,
+        profile=None,
+        output=filtered_name,
+        verbose=0,
+        regenerate=True,
+        version=None,
         components='this system:foo'
     )
     ssp_filter = SSPFilter()
@@ -421,42 +457,29 @@ also do the bar stuff
         ossp.SystemSecurityPlan,
         FileContentType.JSON
     )
+
+    # get the uuid and confirm it was regenerated this time
+    new_uuid = ssp.uuid
+    assert new_uuid != orig_uuid
+
     # confirm the bar by_comp has been filtered out
-    assert len(ssp.control_implementation.implemented_requirements[0].statements[0].by_components) == 2
+    assert len(ssp.control_implementation.implemented_requirements[1].statements[0].by_components) == 2
 
-    orig_uuid = test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
-
-    # filter it again to confirm uuid is same
+    # filter the filtered ssp again to confirm uuid does not change even with regen because contents are the same
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir,
-        name=ssp_name,
-        profile='test_profile_d',
-        output=filtered_name,
-        verbose=0,
-        regenerate=False,
-        version=None,
-        components=None
-    )
-    ssp_filter = SSPFilter()
-    assert ssp_filter._run(args) == 0
-
-    assert orig_uuid == test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
-
-    # filter again to confirm uuid does not change even with regen because contents are the same
-    args = argparse.Namespace(
-        trestle_root=tmp_trestle_dir,
-        name=ssp_name,
-        profile='test_profile_d',
+        name=filtered_name,
+        profile=None,
         output=filtered_name,
         verbose=0,
         regenerate=True,
         version=None,
-        components=None
+        components='this system:foo'
     )
     ssp_filter = SSPFilter()
     assert ssp_filter._run(args) == 0
 
-    assert orig_uuid == test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
+    assert new_uuid == test_utils.get_model_uuid(tmp_trestle_dir, filtered_name, ossp.SystemSecurityPlan)
 
     # now filter without profile or components to trigger error
     args = argparse.Namespace(

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -363,7 +363,6 @@ class SSPFilter(AuthorCommonCommand):
         # load the ssp
         ssp: ossp.SystemSecurityPlan
         ssp, _ = ModelUtils.load_top_level_model(trestle_root, ssp_name, ossp.SystemSecurityPlan, FileContentType.JSON)
-        existing_ssp = ssp.copy(deep=True)
         profile_path = ModelUtils.path_for_top_level_model(
             trestle_root, profile_name, prof.Profile, FileContentType.JSON
         )
@@ -441,9 +440,12 @@ class SSPFilter(AuthorCommonCommand):
         if version:
             ssp.metadata.version = com.Version(__root__=version)
 
-        if ModelUtils.models_are_equivalent(existing_ssp, ssp):
-            logger.info('No changes to filtered ssp so ssp not written out.')
-            return CmdReturnCodes.SUCCESS.value
+        existing_ssp_path = ModelUtils.full_path_for_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
+        if existing_ssp_path is not None:
+            existing_ssp = ModelUtils.load_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
+            if ModelUtils.models_are_equivalent(existing_ssp, ssp):
+                logger.info('No changes to filtered ssp so ssp not written out.')
+                return CmdReturnCodes.SUCCESS.value
 
         if regenerate:
             ssp, _, _ = ModelUtils.regenerate_uuids(ssp)

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -442,7 +442,7 @@ class SSPFilter(AuthorCommonCommand):
 
         existing_ssp_path = ModelUtils.full_path_for_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
         if existing_ssp_path is not None:
-            existing_ssp = ModelUtils.load_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
+            existing_ssp, _ = ModelUtils.load_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
             if ModelUtils.models_are_equivalent(existing_ssp, ssp):
                 logger.info('No changes to filtered ssp so ssp not written out.')
                 return CmdReturnCodes.SUCCESS.value


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
ssp-assemble now ignores case and space in component names
ssp-filter now blocks overwrite of output ssp if no changes relative to existing file.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
