### PR TITLE
fix: Allow subfolders in the template folders

### DIFF
--- a/scripts/have_files_changed.py
+++ b/scripts/have_files_changed.py
@@ -70,7 +70,7 @@ class FilesChanged(Command):
     def has_changed(repo_root: pathlib.Path, excludes: List[str]) -> bool:
         """Determine if files have changed."""
         # Ensure no periods are passed.
-        excludes = list(map(lambda x: x.lstrip('.'), excludes))
+        excludes = [x.lstrip('.') for x in excludes]
         repo = Repo(repo_root)
         if repo.bare:
             raise Exception('Cannot operate on a bare git repository.')

--- a/tests/trestle/core/commands/author/versioning/template_versioning_test.py
+++ b/tests/trestle/core/commands/author/versioning/template_versioning_test.py
@@ -33,14 +33,19 @@ def test_template_version_folder_update(tmp_path: pathlib.Path) -> None:
     old_template = task_path.joinpath('template.md')
     old_template.touch()
 
+    old_folder = task_path.joinpath('images')
+    old_folder.mkdir(parents=True)
+
     with pytest.raises(TrestleError):
         TemplateVersioning.update_template_folder_structure(old_template)
 
-    # make sure file gets put to first version
+    # make sure file and folder gets put to first version
     TemplateVersioning.update_template_folder_structure(task_path)
 
     assert task_path.joinpath('0.0.1/').joinpath('template.md').exists()
+    assert task_path.joinpath('0.0.1/').joinpath('images').exists()
     assert not old_template.exists()
+    assert not old_folder.exists()
 
     # make sure new file also gets put to the first version
     another_template = task_path.joinpath('missplaced_template.md')

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -221,6 +221,9 @@ TRESTLE_HREF_REGEX = '^trestle://[^/]'
 # extracts foo and bar from ...[foo](bar)...
 MARKDOWN_URL_REGEX = r'\[([^\]]+)\]\(([^)]+)\)'
 
+# Governed header template version
+TEMPLATE_VERSION_REGEX = r'[0-9]+.[0-9]+.[0-9]+'
+
 # extracts standalone uuid's from anywhere in string
 UUID_REGEX = r'(?:^|[0-9A-Za-f])([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})(?:$|[^0-9A-Za-z])'  # noqa FS003 E501
 

--- a/trestle/core/commands/author/common.py
+++ b/trestle/core/commands/author/common.py
@@ -79,7 +79,6 @@ class AuthorCommonCommand(CommandPlusDocs):
             self.template_dir = old_template_dir / args.template_version
 
         if old_template_dir.exists():
-            TemplateVersioning.validate_template_folder(old_template_dir)
             TemplateVersioning.update_template_folder_structure(old_template_dir)
 
         return CmdReturnCodes.SUCCESS.value

--- a/trestle/core/commands/author/folders.py
+++ b/trestle/core/commands/author/folders.py
@@ -168,7 +168,7 @@ class Folders(AuthorCommonCommand):
                 else:
                     logger.info(
                         f'File: {self.rel_dir(template_file)} within the template directory was ignored'
-                        + 'as it is not markdown.'
+                        + ' as it is not markdown.'
                     )
             except Exception as ex:
                 raise TrestleError(
@@ -233,7 +233,12 @@ class Folders(AuthorCommonCommand):
 
                 if instance_version not in all_versioned_templates.keys():
                     templates = list(
-                        filter(lambda p: file_utils.is_local_and_visible(p), versioned_template_dir.iterdir())
+                        filter(
+                            lambda p: file_utils.is_local_and_visible(p) and p.is_file()
+                            and  # noqa: W504 - conflicting lint and formatting
+                            (p.suffix == '.md' or p.suffix == '.drawio'),
+                            versioned_template_dir.iterdir()
+                        )
                     )
                     if not readme_validate:
                         templates = list(filter(lambda p: p.name.lower() != 'readme.md', templates))
@@ -278,7 +283,12 @@ class Folders(AuthorCommonCommand):
 
                 if instance_version not in all_versioned_templates.keys():
                     templates = list(
-                        filter(lambda p: file_utils.is_local_and_visible(p), versioned_template_dir.iterdir())
+                        filter(
+                            lambda p: file_utils.is_local_and_visible(p) and p.is_file()
+                            and  # noqa: W504 - conflicting lint and formatting
+                            (p.suffix == '.md' or p.suffix == '.drawio'),
+                            versioned_template_dir.iterdir()
+                        )
                     )
                     if not readme_validate:
                         templates = list(filter(lambda p: p.name.lower() != 'readme.md', templates))

--- a/trestle/core/commands/author/folders.py
+++ b/trestle/core/commands/author/folders.py
@@ -232,16 +232,7 @@ class Folders(AuthorCommonCommand):
                     template_file = versioned_template_dir / instance_file_name
 
                 if instance_version not in all_versioned_templates.keys():
-                    templates = list(
-                        filter(
-                            lambda p: file_utils.is_local_and_visible(p) and p.is_file()
-                            and  # noqa: W504 - conflicting lint and formatting
-                            (p.suffix == '.md' or p.suffix == '.drawio'),
-                            versioned_template_dir.iterdir()
-                        )
-                    )
-                    if not readme_validate:
-                        templates = list(filter(lambda p: p.name.lower() != 'readme.md', templates))
+                    templates = self._get_templates(versioned_template_dir, readme_validate)
 
                     all_versioned_templates[instance_version] = dict.fromkeys(
                         [t.relative_to(versioned_template_dir) for t in templates], False
@@ -282,16 +273,7 @@ class Folders(AuthorCommonCommand):
                     template_file = versioned_template_dir / instance_file_name
 
                 if instance_version not in all_versioned_templates.keys():
-                    templates = list(
-                        filter(
-                            lambda p: file_utils.is_local_and_visible(p) and p.is_file()
-                            and  # noqa: W504 - conflicting lint and formatting
-                            (p.suffix == '.md' or p.suffix == '.drawio'),
-                            versioned_template_dir.iterdir()
-                        )
-                    )
-                    if not readme_validate:
-                        templates = list(filter(lambda p: p.name.lower() != 'readme.md', templates))
+                    templates = self._get_templates(versioned_template_dir, readme_validate)
 
                     all_versioned_templates[instance_version] = dict.fromkeys(
                         [t.relative_to(versioned_template_dir) for t in templates], False
@@ -324,6 +306,21 @@ class Folders(AuthorCommonCommand):
                     return False
 
         return True
+
+    def _get_templates(self, versioned_template_dir: pathlib.Path, readme_validate: bool) -> List[pathlib.Path]:
+        """Get templates for the given version."""
+        templates = list(
+            filter(
+                lambda p: file_utils.is_local_and_visible(p) and p.is_file()
+                and  # noqa: W504 - conflicting lint and formatting
+                (p.suffix == '.md' or p.suffix == '.drawio'),
+                versioned_template_dir.iterdir()
+            )
+        )
+        if not readme_validate:
+            templates = list(filter(lambda p: p.name.lower() != 'readme.md', templates))
+
+        return templates
 
     def create_sample(self) -> int:
         """

--- a/trestle/core/commands/author/versioning/template_versioning.py
+++ b/trestle/core/commands/author/versioning/template_versioning.py
@@ -72,16 +72,28 @@ class TemplateVersioning:
                 filter(lambda p: p.is_file(), file_utils.iterdir_without_hidden_files(task_path))
             )
 
+            version_regex = r'[0-9]+.[0-9]+.[0-9]+'
+            pattern = re.compile(version_regex)
+            all_non_template_directories = list(
+                filter(
+                    lambda p: p.is_dir() and pattern.search(p.parts[-1]) is None,
+                    file_utils.iterdir_without_hidden_files(task_path)
+                )
+            )
+
             new_dir = Path(f'{task_path}/{START_TEMPLATE_VERSION}')
             new_dir.mkdir(parents=True, exist_ok=True)
 
             if len(all_files_wo_version) == 0:
                 logger.debug('No templates outside of the version folders.')
 
-            for f in all_files_wo_version:
-                shutil.copy(f, new_dir)
+            for f in all_files_wo_version + all_non_template_directories:
+                if f.is_file():
+                    shutil.copy(f, new_dir)
+                elif f.is_dir():
+                    shutil.copytree(f, new_dir / f.name)
 
-            for p in all_files_wo_version:
+            for p in all_files_wo_version + all_non_template_directories:
                 if p.is_dir():
                     shutil.rmtree(p)
                 else:
@@ -91,20 +103,6 @@ class TemplateVersioning:
             raise TrestleError(f'Error while updating template folder: {e}')
         except Exception as e:
             raise TrestleError(f'Unexpected error while updating template folder: {e}')
-
-    @staticmethod
-    def validate_template_folder(template_dir: Path):
-        """Validate template folder confirms to the versioned path style and has no other subdirectories."""
-        TemplateVersioning._check_if_exists_and_dir(template_dir)
-
-        version_regex = r'[0-9]+.[0-9]+.[0-9]+'
-        pattern = re.compile(version_regex)
-        subdirectories = list(
-            filter(lambda p: p.is_dir() and pattern.search(p.parts[-1]) is None, template_dir.iterdir())
-        )
-
-        if len(subdirectories) > 0:
-            raise TrestleError(f'Subdirectories are not allowed in template folders: {subdirectories}')
 
     @staticmethod
     def get_versioned_template_dir(task_path: Path, version: Optional[str] = None) -> Path:

--- a/trestle/core/commands/author/versioning/template_versioning.py
+++ b/trestle/core/commands/author/versioning/template_versioning.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple
 from pkg_resources import resource_filename
 
 from trestle.common import file_utils
+from trestle.common.const import TEMPLATE_VERSION_REGEX
 from trestle.common.err import TrestleError
 from trestle.core.commands.author.consts import START_TEMPLATE_VERSION, TEMPLATE_VERSION_HEADER, TRESTLE_RESOURCES
 from trestle.core.draw_io import DrawIO
@@ -72,8 +73,7 @@ class TemplateVersioning:
                 filter(lambda p: p.is_file(), file_utils.iterdir_without_hidden_files(task_path))
             )
 
-            version_regex = r'[0-9]+.[0-9]+.[0-9]+'
-            pattern = re.compile(version_regex)
+            pattern = re.compile(TEMPLATE_VERSION_REGEX)
             all_non_template_directories = list(
                 filter(
                     lambda p: p.is_dir() and pattern.search(p.parts[-1]) is None,
@@ -144,8 +144,7 @@ class TemplateVersioning:
     @staticmethod
     def get_all_versions_for_task(task_path: Path) -> List[str]:
         """Get all versions for the task."""
-        version_regex = r'[0-9]+.[0-9]+.[0-9]+'
-        pattern = re.compile(version_regex)
+        pattern = re.compile(TEMPLATE_VERSION_REGEX)
         all_versions = []
         max_version = START_TEMPLATE_VERSION
         for p in task_path.iterdir():


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
- Allowed subfolders to be inside of the template folders.
- Ignored PNG and any other files that are not drawio or markdown from validation
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

Closes #1105 
