### PR TITLE
fix: remove unused classes from the generated oscal files

### DIFF
--- a/scripts/oscal_normalize.py
+++ b/scripts/oscal_normalize.py
@@ -794,6 +794,15 @@ def update_refs_per_file(classes):
 
 
 def _strip_unrefed_files(file_class):
+    """
+    Strip unreferenced classes from each oscal file.
+
+    The generated oscal files include classes that aren't referenced within the file.
+    Those classes need to be removed early since they shouldn't be there at all.
+    A key problem class is SetParameter, but there are others.
+    This does a simple check of the file name being present at all in the body other classes.
+    It could instead be a token-based search but this seems sufficient.
+    """
     dead_names = []
     for c in file_class:
         if c.name == 'Model':

--- a/scripts/oscal_normalize.py
+++ b/scripts/oscal_normalize.py
@@ -793,6 +793,23 @@ def update_refs_per_file(classes):
     return classes
 
 
+def _strip_unrefed_files(file_class):
+    dead_names = []
+    for c in file_class:
+        if c.name == 'Model':
+            continue
+        refd = False
+        for d in file_class:
+            if d.name in [c.name] + dead_names:
+                continue
+            if c.name in d.body_text:
+                refd = True
+                break
+        if not refd:
+            dead_names.append(c.name)
+    return [c for c in file_class if c.name not in dead_names]
+
+
 def normalize_files():
     """Clean up classes to minimise cross reference."""
     all_classes = load_all_classes()
@@ -808,6 +825,10 @@ def normalize_files():
 
     # strip all names and bodies
     file_classes = _strip_all_files(file_classes)
+
+    # strip classes that are never used in file
+    for name, file_class in file_classes.items():
+        file_classes[name] = _strip_unrefed_files(file_class)
 
     # convert dict to single list of classes with expected duplicates
     uc = _file_classes_to_list(file_classes, True)

--- a/trestle/oscal/assessment_plan.py
+++ b/trestle/oscal/assessment_plan.py
@@ -67,25 +67,27 @@ class State(Enum):
     not_satisfied = 'not-satisfied'
 
 
-class SetParameter(OscalBaseModel):
+class Status(OscalBaseModel):
     """
-    Identifies the parameter that will be set by the enclosed value.
+    A determination of if the objective is satisfied or not within a given system.
     """
 
     class Config:
         extra = Extra.forbid
 
-    param_id: constr(
+    state: State = Field(
+        ...,
+        description='An indication as to whether the objective is satisfied or not.',
+        title='Objective Status State',
+    )
+    reason: Optional[constr(
         regex=
         r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(
-        ...,
-        alias='param-id',
-        description=
-        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
-        title='Parameter ID',
+    )] = Field(
+        None,
+        description="The reason the objective was given it's status.",
+        title='Objective Status Reason',
     )
-    values: List[common.Value] = Field(...)
     remarks: Optional[common.Remarks] = None
 
 
@@ -324,74 +326,6 @@ class SystemComponent(OscalBaseModel):
     )
     responsible_roles: Optional[List[common.ResponsibleRole]] = Field(None, alias='responsible-roles')
     protocols: Optional[List[common.Protocol]] = Field(None)
-    remarks: Optional[common.Remarks] = None
-
-
-class Status(OscalBaseModel):
-    """
-    A determination of if the objective is satisfied or not within a given system.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    state: State = Field(
-        ...,
-        description='An indication as to whether the objective is satisfied or not.',
-        title='Objective Status State',
-    )
-    reason: Optional[constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    )] = Field(
-        None,
-        description="The reason the objective was given it's status.",
-        title='Objective Status Reason',
-    )
-    remarks: Optional[common.Remarks] = None
-
-
-class FindingTarget(OscalBaseModel):
-    """
-    Captures an assessor's conclusions regarding the degree to which an objective is satisfied.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    type: common.Type1 = Field(
-        ...,
-        description='Identifies the type of the target.',
-        title='Finding Target Type',
-    )
-    target_id: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(
-        ...,
-        alias='target-id',
-        description='A machine-oriented identifier reference for a specific target qualified by the type.',
-        title='Finding Target Identifier Reference',
-    )
-    title: Optional[str] = Field(
-        None,
-        description='The title for this objective status.',
-        title='Objective Status Title',
-    )
-    description: Optional[str] = Field(
-        None,
-        description=
-        "A human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied.",
-        title='Objective Status Description',
-    )
-    props: Optional[List[common.Property]] = Field(None)
-    links: Optional[List[common.Link]] = Field(None)
-    status: Status = Field(
-        ...,
-        description='A determination of if the objective is satisfied or not within a given system.',
-        title='Objective Status',
-    )
-    implementation_status: Optional[common.ImplementationStatus] = Field(None, alias='implementation-status')
     remarks: Optional[common.Remarks] = None
 
 

--- a/trestle/oscal/assessment_results.py
+++ b/trestle/oscal/assessment_results.py
@@ -56,28 +56,6 @@ class State(Enum):
     not_satisfied = 'not-satisfied'
 
 
-class SetParameter(OscalBaseModel):
-    """
-    Identifies the parameter that will be set by the enclosed value.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    param_id: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(
-        ...,
-        alias='param-id',
-        description=
-        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
-        title='Parameter ID',
-    )
-    values: List[common.Value] = Field(...)
-    remarks: Optional[common.Remarks] = None
-
-
 class SelectControlById(OscalBaseModel):
     """
     Used to select a control for inclusion/exclusion based on one or more control identifiers. A set of statement identifiers can be used to target the inclusion/exclusion to only specific control statements providing more granularity over the specific statements that are within the asessment scope.

--- a/trestle/oscal/common.py
+++ b/trestle/oscal/common.py
@@ -948,33 +948,6 @@ class AssessmentPart(OscalBaseModel):
     links: Optional[List[Link]] = Field(None)
 
 
-class AssessmentMethod(OscalBaseModel):
-    """
-    A local definition of a control objective. Uses catalog syntax for control objective and assessment activities.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    uuid: constr(
-        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-    ) = Field(
-        ...,
-        description=
-        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this assessment method elsewhere in this or other OSCAL instances. The locally defined UUID of the assessment method can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
-        title='Assessment Method Universally Unique Identifier',
-    )
-    description: Optional[str] = Field(
-        None,
-        description='A human-readable description of this assessment method.',
-        title='Assessment Method Description',
-    )
-    props: Optional[List[Property]] = Field(None)
-    links: Optional[List[Link]] = Field(None)
-    part: AssessmentPart
-    remarks: Optional[Remarks] = None
-
-
 class Timing(OscalBaseModel):
     """
     The timing under which the task is intended to occur.

--- a/trestle/oscal/component.py
+++ b/trestle/oscal/component.py
@@ -83,6 +83,18 @@ class State(Enum):
     other = 'other'
 
 
+class Status(OscalBaseModel):
+    """
+    Describes the operational status of the system component.
+    """
+
+    class Config:
+        extra = Extra.forbid
+
+    state: State = Field(..., description='The operational status.', title='State')
+    remarks: Optional[common.Remarks] = None
+
+
 class SetParameter(OscalBaseModel):
     """
     Identifies the parameter that will be set by the enclosed value.
@@ -244,66 +256,6 @@ class Capability(OscalBaseModel):
     links: Optional[List[common.Link]] = Field(None)
     incorporates_components: Optional[List[IncorporatesComponent]] = Field(None, alias='incorporates-components')
     control_implementations: Optional[List[ControlImplementation]] = Field(None, alias='control-implementations')
-    remarks: Optional[common.Remarks] = None
-
-
-class Status(OscalBaseModel):
-    """
-    Describes the operational status of the system component.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    state: State = Field(..., description='The operational status.', title='State')
-    remarks: Optional[common.Remarks] = None
-
-
-class SystemComponent(OscalBaseModel):
-    """
-    A defined component that can be part of an implemented system.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    uuid: constr(
-        regex=r'^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$'
-    ) = Field(
-        ...,
-        description=
-        'A machine-oriented, globally unique identifier with cross-instance scope that can be used to reference this component elsewhere in this or other OSCAL instances. The locally defined UUID of the component can be used to reference the data item locally or globally (e.g., in an imported OSCAL instance). This UUID should be assigned per-subject, which means it should be consistently used to identify the same subject across revisions of the document.',
-        title='Component Identifier',
-    )
-    type: constr(regex=r'^\S(.*\S)?$') = Field(
-        ...,
-        description='A category describing the purpose of the component.',
-        title='Component Type',
-    )
-    title: str = Field(
-        ...,
-        description='A human readable name for the system component.',
-        title='Component Title',
-    )
-    description: str = Field(
-        ...,
-        description='A description of the component, including information about its function.',
-        title='Component Description',
-    )
-    purpose: Optional[str] = Field(
-        None,
-        description='A summary of the technological or business purpose of the component.',
-        title='Purpose',
-    )
-    props: Optional[List[common.Property]] = Field(None)
-    links: Optional[List[common.Link]] = Field(None)
-    status: Status = Field(
-        ...,
-        description='Describes the operational status of the system component.',
-        title='Status',
-    )
-    responsible_roles: Optional[List[common.ResponsibleRole]] = Field(None, alias='responsible-roles')
-    protocols: Optional[List[common.Protocol]] = Field(None)
     remarks: Optional[common.Remarks] = None
 
 

--- a/trestle/oscal/poam.py
+++ b/trestle/oscal/poam.py
@@ -56,28 +56,6 @@ class State(Enum):
     other = 'other'
 
 
-class SetParameter(OscalBaseModel):
-    """
-    Identifies the parameter that will be set by the enclosed value.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    param_id: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(
-        ...,
-        alias='param-id',
-        description=
-        "A human-oriented reference to a parameter within a control, who's catalog has been imported into the current implementation context.",
-        title='Parameter ID',
-    )
-    values: List[common.Value] = Field(...)
-    remarks: Optional[common.Remarks] = None
-
-
 class SelectControlById(OscalBaseModel):
     """
     Used to select a control for inclusion/exclusion based on one or more control identifiers. A set of statement identifiers can be used to target the inclusion/exclusion to only specific control statements providing more granularity over the specific statements that are within the asessment scope.
@@ -248,50 +226,6 @@ class Status1(OscalBaseModel):
     remarks: Optional[common.Remarks] = None
 
 
-class FindingTarget(OscalBaseModel):
-    """
-    Captures an assessor's conclusions regarding the degree to which an objective is satisfied.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    type: common.Type1 = Field(
-        ...,
-        description='Identifies the type of the target.',
-        title='Finding Target Type',
-    )
-    target_id: constr(
-        regex=
-        r'^[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-\.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$'
-    ) = Field(
-        ...,
-        alias='target-id',
-        description='A machine-oriented identifier reference for a specific target qualified by the type.',
-        title='Finding Target Identifier Reference',
-    )
-    title: Optional[str] = Field(
-        None,
-        description='The title for this objective status.',
-        title='Objective Status Title',
-    )
-    description: Optional[str] = Field(
-        None,
-        description=
-        "A human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied.",
-        title='Objective Status Description',
-    )
-    props: Optional[List[common.Property]] = Field(None)
-    links: Optional[List[common.Link]] = Field(None)
-    status: Status1 = Field(
-        ...,
-        description='A determination of if the objective is satisfied or not within a given system.',
-        title='Objective Status',
-    )
-    implementation_status: Optional[common.ImplementationStatus] = Field(None, alias='implementation-status')
-    remarks: Optional[common.Remarks] = None
-
-
 class Status(OscalBaseModel):
     """
     Describes the operational status of the system component.
@@ -352,16 +286,17 @@ class SystemComponent(OscalBaseModel):
     remarks: Optional[common.Remarks] = None
 
 
-class AssessmentAssets(OscalBaseModel):
+class LocalDefinitions(OscalBaseModel):
     """
-    Identifies the assets used to perform this assessment, such as the assessment team, scanning tools, and assumptions.
+    Allows components, and inventory-items to be defined within the POA&M for circumstances where no OSCAL-based SSP exists, or is not delivered with the POA&M.
     """
 
     class Config:
         extra = Extra.forbid
 
     components: Optional[List[SystemComponent]] = Field(None)
-    assessment_platforms: List[common.AssessmentPlatform] = Field(..., alias='assessment-platforms')
+    inventory_items: Optional[List[common.InventoryItem]] = Field(None, alias='inventory-items')
+    remarks: Optional[common.Remarks] = None
 
 
 class RiskLog(OscalBaseModel):
@@ -560,19 +495,6 @@ class Observation(OscalBaseModel):
         'Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios.',
         title='expires field',
     )
-    remarks: Optional[common.Remarks] = None
-
-
-class LocalDefinitions(OscalBaseModel):
-    """
-    Allows components, and inventory-items to be defined within the POA&M for circumstances where no OSCAL-based SSP exists, or is not delivered with the POA&M.
-    """
-
-    class Config:
-        extra = Extra.forbid
-
-    components: Optional[List[SystemComponent]] = Field(None)
-    inventory_items: Optional[List[common.InventoryItem]] = Field(None, alias='inventory-items')
     remarks: Optional[common.Remarks] = None
 
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
The schemas used to create the oscal class files include classes that aren't referenced in the file.  This caused the final oscal files to include classes that were not needed, with SetParameter being the main problem.  Innocuous but undesirable - now fixed.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
