### PR TITLE
fix: Do not validate extra files when author folders

### DIFF
--- a/tests/trestle/core/commands/author/folders_test.py
+++ b/tests/trestle/core/commands/author/folders_test.py
@@ -576,6 +576,38 @@ def test_fail_when_no_task(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
     assert rc == 1
 
 
+def test_passes_when_extra_md_file(
+    testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Test extra file in the correct folder."""
+    task_template_folder = tmp_trestle_dir / '.trestle/author/test_task/'
+    test_template_folder = testdata_dir / 'author/governed_folders/template_folder'
+    test_instances_folder = testdata_dir / 'author/governed_folders/good_instance_with_readme'
+    task_instance_folder = tmp_trestle_dir / 'test_task/folder_1'
+
+    hidden_file = testdata_dir / pathlib.Path(
+        'author/governed_folders/template_folder_with_drawio/.hidden_does_not_affect'
+    )
+    test_utils.make_file_hidden(hidden_file)
+
+    test_utils.copy_tree_or_file_with_hidden(test_template_folder, task_template_folder)
+
+    shutil.copytree(test_instances_folder, task_instance_folder)
+
+    # Add that extra file
+    (task_instance_folder / 'extra_document.md').touch()
+
+    command_string_validate_content = 'trestle author folders validate -tn test_task -hv'
+    monkeypatch.setattr(sys, 'argv', command_string_validate_content.split())
+    rc = trestle.cli.Trestle().run()
+    assert rc == 0
+
+    command_string_validate_content = 'trestle author folders validate -tn test_task'
+    monkeypatch.setattr(sys, 'argv', command_string_validate_content.split())
+    rc = trestle.cli.Trestle().run()
+    assert rc == 0
+
+
 def test_instance_no_header(
     testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
 ) -> None:

--- a/trestle/core/commands/author/folders.py
+++ b/trestle/core/commands/author/folders.py
@@ -231,9 +231,23 @@ class Folders(AuthorCommonCommand):
                     )
                     template_file = versioned_template_dir / instance_file_name
 
-                if instance_version not in all_versioned_templates.keys():
-                    templates = self._get_templates(versioned_template_dir, readme_validate)
+                # Check if instance is in the available templates,
+                # additional files are allowed but should not be validated.
+                templates = self._get_templates(versioned_template_dir, readme_validate)
+                is_template_present = False
+                for template in templates:
+                    if template.name == str(instance_file_name):
+                        is_template_present = True
+                        break
 
+                if not is_template_present:
+                    logger.info(
+                        f'INFO: File{instance_file} will not be validated '
+                        f'as its name does not match any template file.'
+                    )
+                    continue
+
+                if instance_version not in all_versioned_templates.keys():
                     all_versioned_templates[instance_version] = dict.fromkeys(
                         [t.relative_to(versioned_template_dir) for t in templates], False
                     )


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Currently `author folders` will validate extra files in the task folder, which cause validation to fail in some cases. Those files should be skipped instead. This is a small fix to handle this edge case.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
