### PR TITLE
fix: Improve logging when validating headings in gov docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ dev =
     mypy
     # # Docs website
     mkdocs
-    mkdocstrings
+    mkdocstrings==0.18.0 ## See issue 1135
     mkdocs-material
     markdown-include
     pymdown-extensions

--- a/trestle/core/commands/author/folders.py
+++ b/trestle/core/commands/author/folders.py
@@ -384,7 +384,7 @@ class Folders(AuthorCommonCommand):
                         + f'{self.task_name} on directory {self.rel_dir(task_instance)}'
                     )
             else:
-                logger.warning(
+                logger.info(
                     f'Unexpected file {self.rel_dir(task_instance)} identified in {self.task_name}'
                     + ' directory, ignoring.'
                 )


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Improved logging for when validation of the headings fails for governed docs. Now it will notify the user which heading was expected.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.


Closes #1132 