### PR TITLE
fix: allow catalog groups with no id and fix validation of links and reference matching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0  # Use the ref you want to point at
+    rev: v4.3.0  # Use the ref you want to point at
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/docs/api_reference/trestle.common.load_validate.md
+++ b/docs/api_reference/trestle.common.load_validate.md
@@ -1,0 +1,2 @@
+::: trestle.common.load_validate
+handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - err: api_reference/trestle.common.err.md
       - file_utils: api_reference/trestle.common.file_utils.md
       - list_utils: api_reference/trestle.common.list_utils.md
+      - load_validate: api_reference/trestle.common.load_validate.md
       - log: api_reference/trestle.common.log.md
       - model_utils: api_reference/trestle.common.model_utils.md
       - str_utils: api_reference/trestle.common.str_utils.md

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -448,5 +448,6 @@ def test_pulled_params_in_choice(
 def test_generate_group_id() -> None:
     """Test the generation of group ids."""
     cat_int = CatalogInterface()
-    assert cat_int._generate_group_id() == 'trestle_group_0000'
-    assert cat_int._generate_group_id() == 'trestle_group_0001'
+    group = cat.Group(title='my test title')
+    assert cat_int._generate_group_id(group) == 'trestle_group_0000'
+    assert cat_int._generate_group_id(group) == 'trestle_group_0001'

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for the catalog author module."""
 
+import argparse
 import copy
 import pathlib
 import shutil
@@ -30,6 +31,7 @@ from trestle.cli import Trestle
 from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.author.catalog import CatalogAssemble, CatalogGenerate, CatalogInterface
 from trestle.core.commands.common.return_codes import CmdReturnCodes
+from trestle.core.commands.import_ import ImportCmd
 from trestle.core.control_io import ControlIOReader, ParameterRep
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.profile_resolver import ProfileResolver
@@ -451,3 +453,45 @@ def test_generate_group_id() -> None:
     group = cat.Group(title='my test title')
     assert cat_int._generate_group_id(group) == 'trestle_group_0000'
     assert cat_int._generate_group_id(group) == 'trestle_group_0001'
+
+
+def test_validate_catalog_missing_group_id(
+    tmp_trestle_dir: pathlib.Path, tmp_path_factory: pytest.TempPathFactory, sample_catalog_rich_controls: cat.Catalog
+) -> None:
+    """Test validation of catalog with groups that dont have ids."""
+    # kill one of the group id's
+    sample_catalog_rich_controls.groups[0].id = None
+    cat_name = 'my_cat'
+    tmp_cat_path = tmp_path_factory.mktemp('temp_dir') / (cat_name + '.json')
+
+    # write catalog with missing group id to tmp location
+    sample_catalog_rich_controls.oscal_write(tmp_cat_path)
+    import_cmd = ImportCmd()
+    args = argparse.Namespace(
+        trestle_root=tmp_trestle_dir, file=str(tmp_cat_path), output=cat_name, verbose=1, regenerate=False
+    )
+
+    # import the file with missing group id into the trestle workspace
+    # this should validate the file and assign the missing id a new value in memory - then save the file
+    rc = import_cmd._run(args)
+    assert rc == 0
+
+    # load the file without doing validation - to make sure the file itself has the group id assigned
+    new_cat, new_cat_path = ModelUtils.load_top_level_model(tmp_trestle_dir, cat_name, cat.Catalog)
+    assert new_cat.groups[0].id == 'trestle_group_0000'
+
+    md_name = 'md_cat'
+    md_path = tmp_trestle_dir / md_name
+    md_path.mkdir(parents=True, exist_ok=True)
+    cat_generate = CatalogGenerate()
+    assert cat_generate.generate_markdown(
+        tmp_trestle_dir, new_cat_path, md_path, {}, False
+    ) == CmdReturnCodes.SUCCESS.value
+
+    assem_cat_name = 'assem_cat'
+    cat_assemble = CatalogAssemble()
+    cat_assemble.assemble_catalog(tmp_trestle_dir, md_name, assem_cat_name, None, False, False, None)
+
+    # load the file without doing validation - to make sure the file itself has the group id assigned
+    assem_cat, _ = ModelUtils.load_top_level_model(tmp_trestle_dir, assem_cat_name, cat.Catalog)
+    assert new_cat.groups[0].id == 'trestle_group_0000'

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -443,3 +443,10 @@ def test_pulled_params_in_choice(
     assert param.links[1].text == 'new link text'
     assert param.constraints[1].description == 'new constraint'
     assert param.guidelines[1].prose == 'new guideline'
+
+
+def test_generate_group_id() -> None:
+    """Test the generation of group ids."""
+    cat_int = CatalogInterface()
+    assert cat_int._generate_group_id() == 'trestle_group_0000'
+    assert cat_int._generate_group_id() == 'trestle_group_0001'

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -287,8 +287,9 @@ def test_validate_catalog_params(sample_catalog_rich_controls: Catalog) -> None:
 
 
 def test_validate_catalog_missing_group_id(sample_catalog_rich_controls: Catalog) -> None:
-    """Test validation of unique param ids in catalog."""
+    """Test validation of catalog with groups that dont have ids."""
     args = argparse.Namespace(mode=const.VAL_MODE_CATALOG)
     validator: Validator = validator_factory.get(args)
+    # kill one of the group id's
     sample_catalog_rich_controls.groups[0].id = None
     assert validator.model_is_valid(sample_catalog_rich_controls, True)

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -268,7 +268,7 @@ def test_validate_distributed(
         trestle_root=tmp_trestle_dir
     )
     _ = SplitCmd()._run(args)
-    test_args = 'trestle validate -a'.split(' ')
+    test_args = 'trestle validate -a -v'.split(' ')
     monkeypatch.setattr(sys, 'argv', test_args)
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         cli.run()
@@ -279,8 +279,16 @@ def test_validate_distributed(
 def test_validate_catalog_params(sample_catalog_rich_controls: Catalog) -> None:
     """Test validation of unique param ids in catalog."""
     args = argparse.Namespace(mode=const.VAL_MODE_CATALOG)
-    validator = validator_factory.get(args)
+    validator: Validator = validator_factory.get(args)
     assert validator.model_is_valid(sample_catalog_rich_controls, True)
     param_0_id = sample_catalog_rich_controls.groups[0].controls[0].params[0].id
     sample_catalog_rich_controls.groups[0].controls[0].params[1].id = param_0_id
     assert not validator.model_is_valid(sample_catalog_rich_controls, False)
+
+
+def test_validate_catalog_missing_group_id(sample_catalog_rich_controls: Catalog) -> None:
+    """Test validation of unique param ids in catalog."""
+    args = argparse.Namespace(mode=const.VAL_MODE_CATALOG)
+    validator: Validator = validator_factory.get(args)
+    sample_catalog_rich_controls.groups[0].id = None
+    assert validator.model_is_valid(sample_catalog_rich_controls, True)

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -30,6 +30,9 @@ import trestle.common.const as const
 import trestle.oscal.assessment_plan as ap
 from trestle import cli
 from trestle.cli import Trestle
+from trestle.common.file_utils import FileContentType
+from trestle.common.load_validate import load_validate_model_name
+from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.commands.split import SplitCmd
 from trestle.core.generators import generate_sample_model
@@ -286,10 +289,13 @@ def test_validate_catalog_params(sample_catalog_rich_controls: Catalog) -> None:
     assert not validator.model_is_valid(sample_catalog_rich_controls, False)
 
 
-def test_validate_catalog_missing_group_id(sample_catalog_rich_controls: Catalog) -> None:
+def test_validate_catalog_missing_group_id(
+    tmp_trestle_dir: pathlib.Path, sample_catalog_rich_controls: Catalog
+) -> None:
     """Test validation of catalog with groups that dont have ids."""
-    args = argparse.Namespace(mode=const.VAL_MODE_CATALOG)
-    validator: Validator = validator_factory.get(args)
     # kill one of the group id's
     sample_catalog_rich_controls.groups[0].id = None
-    assert validator.model_is_valid(sample_catalog_rich_controls, True)
+    cat_name = 'my_cat'
+    ModelUtils.save_top_level_model(sample_catalog_rich_controls, tmp_trestle_dir, cat_name, FileContentType.JSON)
+    new_cat, _ = load_validate_model_name(tmp_trestle_dir, cat_name, Catalog)
+    assert new_cat.groups[0].id == 'trestle_group_0000'

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -30,9 +30,6 @@ import trestle.common.const as const
 import trestle.oscal.assessment_plan as ap
 from trestle import cli
 from trestle.cli import Trestle
-from trestle.common.file_utils import FileContentType
-from trestle.common.load_validate import load_validate_model_name
-from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.commands.split import SplitCmd
 from trestle.core.generators import generate_sample_model
@@ -287,15 +284,3 @@ def test_validate_catalog_params(sample_catalog_rich_controls: Catalog) -> None:
     param_0_id = sample_catalog_rich_controls.groups[0].controls[0].params[0].id
     sample_catalog_rich_controls.groups[0].controls[0].params[1].id = param_0_id
     assert not validator.model_is_valid(sample_catalog_rich_controls, False)
-
-
-def test_validate_catalog_missing_group_id(
-    tmp_trestle_dir: pathlib.Path, sample_catalog_rich_controls: Catalog
-) -> None:
-    """Test validation of catalog with groups that dont have ids."""
-    # kill one of the group id's
-    sample_catalog_rich_controls.groups[0].id = None
-    cat_name = 'my_cat'
-    ModelUtils.save_top_level_model(sample_catalog_rich_controls, tmp_trestle_dir, cat_name, FileContentType.JSON)
-    new_cat, _ = load_validate_model_name(tmp_trestle_dir, cat_name, Catalog)
-    assert new_cat.groups[0].id == 'trestle_group_0000'

--- a/trestle/common/load_validate.py
+++ b/trestle/common/load_validate.py
@@ -1,0 +1,51 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Function to load and validate files while avoiding circular imports."""
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional, Tuple, Type
+
+from trestle.common import const
+from trestle.common.common_types import TopLevelOscalModel
+from trestle.common.file_utils import FileContentType
+from trestle.common.model_utils import ModelUtils
+from trestle.core.validator import Validator
+from trestle.core.validator_factory import validator_factory
+
+logger = logging.getLogger(__name__)
+
+
+def load_validate_model_path(trestle_root: Path, model_path: Path) -> TopLevelOscalModel:
+    """Load a model by its path and validate it."""
+    _, _, model = ModelUtils.load_distributed(model_path, trestle_root)
+    args = argparse.Namespace(mode=const.VAL_MODE_ALL, quiet=True)
+    validator: Validator = validator_factory.get(args)
+    if not validator.model_is_valid(model, True):
+        logger.warning(f'Model loaded at {model_path} fails validation, but is being loaded anyway.')
+    return model
+
+
+def load_validate_model_name(
+    trestle_root: Path,
+    model_name: str,
+    model_class: Type[TopLevelOscalModel],
+    file_content_type: Optional[FileContentType] = None
+) -> Tuple[TopLevelOscalModel, Path]:
+    """Load a model by its name and type and validate it."""
+    model_path = ModelUtils.path_for_top_level_model(trestle_root, model_name, model_class, file_content_type)
+    model = load_validate_model_path(trestle_root, model_path)
+    return model, model_path

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -65,6 +65,10 @@ class ModelUtils:
             Model Alias (e.g. 'catalog.metadata') and Instance of the Model.
             If the model is decomposed/split/distributed, the instance of the model contains
             the decomposed models loaded recursively.
+
+        Note:
+            This does not validate the model.  You must either validate the model separately or use the load_validate
+            utilities.
         """
         # if trying to load file that does not exist, load path instead
         if not abs_path.exists():
@@ -162,6 +166,8 @@ class ModelUtils:
 
         If you need to load an existing model but its content type may not be known, use this method.
         But the file content type should be specified if it is somehow known.
+
+        Note:  This does not validate the model.  If you want to validate the model use the load_validate utilities.
         """
         root_model_path = ModelUtils._root_path_for_top_level_model(trestle_root, model_name, model_class)
         if file_content_type is None:
@@ -323,21 +329,6 @@ class ModelUtils:
         return full_list
 
     @staticmethod
-    def path_for_top_level_model(
-        trestle_root: pathlib.Path,
-        model_name: str,
-        model_class: Type[TopLevelOscalModel],
-        file_content_type: FileContentType
-    ) -> pathlib.Path:
-        """
-        Find the full path of a model given its name, model type and file content type.
-
-        This does not inspect the file system or confirm the needed path and file exists.
-        """
-        root_path = ModelUtils._root_path_for_top_level_model(trestle_root, model_name, model_class)
-        return root_path.with_suffix(FileContentType.to_file_extension(file_content_type))
-
-    @staticmethod
     def full_path_for_top_level_model(
         trestle_root: pathlib.Path,
         model_name: str,
@@ -355,6 +346,23 @@ class ModelUtils:
         if not FileContentType.is_readable_file(file_content_type):
             return None
         return root_model_path.with_suffix(FileContentType.to_file_extension(file_content_type))
+
+    @staticmethod
+    def path_for_top_level_model(
+        trestle_root: pathlib.Path,
+        model_name: str,
+        model_class: Type[TopLevelOscalModel],
+        file_content_type: Optional[FileContentType]
+    ) -> pathlib.Path:
+        """
+        Find the full path of a model given its name, model type and file content type.
+
+        If file_content_type is given it will not inspect the file system or confirm the needed path and file exists.
+        """
+        if file_content_type is None:
+            return ModelUtils.full_path_for_top_level_model(trestle_root, model_name, model_class)
+        root_path = ModelUtils._root_path_for_top_level_model(trestle_root, model_name, model_class)
+        return root_path.with_suffix(FileContentType.to_file_extension(file_content_type))
 
     @staticmethod
     def get_singular_alias(alias_path: str, relative_path: Optional[pathlib.Path] = None) -> str:

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -658,24 +658,23 @@ class ModelUtils:
     @staticmethod
     def find_uuid_refs(object_of_interest: BaseModel) -> Set[str]:
         """Find uuid references made in prose and links."""
-        # links have href of form #foo or #uuid
-        links_list: List[List[trestle.common.Link]] = ModelUtils.find_values_by_name(object_of_interest, 'links')
-        uuid_strs = [link.href for links in links_list for link in links]
+        # hrefs have form #foo or #uuid
+        uuid_strs = ModelUtils.find_values_by_name(object_of_interest, 'href')
 
         # prose has uuid refs in markdown form: [foo](#bar) or [foo](#uuid)
         prose_list = ModelUtils.find_values_by_name(object_of_interest, 'prose')
-        uuid_strs.extend(
-            [
-                match[1] for prose in prose_list for matches in re.findall(const.MARKDOWN_URL_REGEX, prose)
-                for match in matches
-            ]
-        )
+        for prose in prose_list:
+            matches = re.findall(const.MARKDOWN_URL_REGEX, prose)
+            # the [1] is to extract the inner of 3 capture patterns
+            new_uuids = [match[1] for match in matches]
+            uuid_strs.extend(new_uuids)
 
         # collect the strings that start with # and are potential uuids
         uuid_strs = [uuid_str for uuid_str in uuid_strs if uuid_str and uuid_str[0] == '#']
 
         # go through all matches and build set of those that are uuids
-        return {uuid_match[0] for uuid_str in uuid_strs for uuid_match in re.findall(const.UUID_REGEX, uuid_str[1:])}
+        uuid_set = {uuid_match for uuid_str in uuid_strs for uuid_match in re.findall(const.UUID_REGEX, uuid_str[1:])}
+        return uuid_set
 
     @staticmethod
     def _regenerate_uuids_in_place(object_of_interest: Any, uuid_lut: Dict[str, str]) -> Tuple[Any, Dict[str, str]]:

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -114,14 +114,14 @@ class CatalogInterface():
 
     def _add_group_controls(self, group: cat.Group, control_dict: Dict[str, ControlHandle], path: List[str]) -> None:
         """Add all controls in the group recursively, including sub groups and sub controls."""
+        group.id = self._generate_group_id() if group.id is None else group.id
         if group.controls is not None:
             group_path = path[:]
-            group_id = group.id if group.id is not None else self._generate_group_id()
-            if not group_path or group_path[-1] != group_id:
-                group_path.append(group_id)
+            if not group_path or group_path[-1] != group.id:
+                group_path.append(group.id)
             for control in group.controls:
                 control_handle = CatalogInterface.ControlHandle(
-                    group_id=group_id,
+                    group_id=group.id,
                     group_title=group.title,
                     group_class=group.class_,
                     control=control,
@@ -131,12 +131,11 @@ class CatalogInterface():
                 self._add_sub_controls(control_handle, control_dict, group_path)
         if group.groups is not None:
             group_path = path[:]
-            group_id = group.id if group.id is not None else self._generate_group_id()
-            group_path.append(group_id)
+            group_path.append(group.id)
             for sub_group in group.groups:
                 new_path = group_path[:]
-                sub_group_id = sub_group.id if sub_group.id is not None else self._generate_group_id()
-                new_path.append(sub_group_id)
+                sub_group.id = self._generate_group_id() if sub_group.id is None else sub_group.id
+                new_path.append(sub_group.id)
                 self._add_group_controls(sub_group, control_dict, new_path)
 
     def _create_control_dict(self) -> Dict[str, ControlHandle]:

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -76,11 +76,11 @@ class CatalogInterface():
         self.loose_param_dict: Dict[str, common.Parameter] = {param.id: param
                                                               for param in as_list(catalog.params)} if catalog else {}
 
-    def _generate_group_id(self) -> str:
+    def _generate_group_id(self, group: cat.Group) -> str:
         """Generate sequential group ids."""
         group_id = f'trestle_group_{self._generate_group_index:04d}'
         self._generate_group_index += 1
-        logger.warning(f'Group missing id has been assigned {group_id}')
+        logger.warning(f'Group titled "{group.title}" has no id and has been assigned id: {group_id}')
         return group_id
 
     def _add_params_to_map(self, control: cat.Control) -> None:
@@ -114,7 +114,7 @@ class CatalogInterface():
 
     def _add_group_controls(self, group: cat.Group, control_dict: Dict[str, ControlHandle], path: List[str]) -> None:
         """Add all controls in the group recursively, including sub groups and sub controls."""
-        group.id = self._generate_group_id() if group.id is None else group.id
+        group.id = self._generate_group_id(group) if group.id is None else group.id
         if group.controls is not None:
             group_path = path[:]
             if not group_path or group_path[-1] != group.id:
@@ -134,7 +134,7 @@ class CatalogInterface():
             group_path.append(group.id)
             for sub_group in group.groups:
                 new_path = group_path[:]
-                sub_group.id = self._generate_group_id() if sub_group.id is None else sub_group.id
+                sub_group.id = self._generate_group_id(sub_group) if sub_group.id is None else sub_group.id
                 new_path.append(sub_group.id)
                 self._add_group_controls(sub_group, control_dict, new_path)
 

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -80,6 +80,7 @@ class CatalogInterface():
         """Generate sequential group ids."""
         group_id = f'trestle_group_{self._generate_group_index:04d}'
         self._generate_group_index += 1
+        logger.warning(f'Group missing id has been assigned {group_id}')
         return group_id
 
     def _add_params_to_map(self, control: cat.Control) -> None:

--- a/trestle/core/commands/assemble.py
+++ b/trestle/core/commands/assemble.py
@@ -20,6 +20,7 @@ import logging
 
 from trestle.common import const, file_utils, log
 from trestle.common.err import TrestleError, TrestleRootError, handle_generic_command_exception
+from trestle.common.load_validate import load_validate_model_path
 from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.common.return_codes import CmdReturnCodes
@@ -84,8 +85,7 @@ class AssembleCmd(CommandPlusDocs):
             if not root_model_filepath.exists():
                 raise TrestleError(f'No top level model file at {root_model_dir}')
 
-            # distributed load
-            _, _, assembled_model = ModelUtils.load_distributed(root_model_filepath, args.trestle_root)
+            assembled_model = load_validate_model_path(args.trestle_root, root_model_filepath)
             plural_alias = ModelUtils.model_type_to_model_dir(model_alias)
 
             assembled_model_dir = trestle_root / const.TRESTLE_DIST_DIR / plural_alias

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -27,6 +27,7 @@ import trestle.common.log as log
 import trestle.oscal.common as com
 from trestle.common import file_utils
 from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
+from trestle.common.load_validate import load_validate_model_name, load_validate_model_path
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -92,7 +93,7 @@ class CatalogGenerate(AuthorCommonCommand):
     ) -> int:
         """Generate markdown for the controls in the catalog."""
         try:
-            _, _, catalog = ModelUtils.load_distributed(catalog_path, trestle_root)
+            catalog = load_validate_model_path(trestle_root, catalog_path)
             catalog_interface = CatalogInterface(catalog)
             catalog_interface.write_catalog_as_markdown(
                 md_path=markdown_path,
@@ -205,7 +206,7 @@ class CatalogAssemble(AuthorCommonCommand):
         # the parent can be a separate catalog or the destination assembled catalog if it exists
         # but this is the catalog that the markdown is merged into in memory
         if parent_cat_name:
-            parent_cat, parent_cat_path = ModelUtils.load_top_level_model(trestle_root, parent_cat_name, Catalog)
+            parent_cat, parent_cat_path = load_validate_model_name(trestle_root, parent_cat_name, Catalog)
             parent_cat_interface = CatalogInterface(parent_cat)
             # merge the just-read md catalog into the original json
             parent_cat_interface.merge_catalog(md_catalog, set_parameters)
@@ -218,7 +219,7 @@ class CatalogAssemble(AuthorCommonCommand):
         # now check the destination catalog to see if the in-memory catalog matches it
         if assem_cat_path:
             new_content_type = FileContentType.path_to_content_type(assem_cat_path)
-            _, _, existing_cat = ModelUtils.load_distributed(assem_cat_path, trestle_root)
+            existing_cat = load_validate_model_path(trestle_root, assem_cat_path)
             if ModelUtils.models_are_equivalent(existing_cat, md_catalog):
                 logger.info('Assembled catalog is not different from existing version, so no update.')
                 return CmdReturnCodes.SUCCESS.value

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -28,6 +28,7 @@ from ruamel.yaml import YAML
 
 from trestle.common import const, log
 from trestle.common.err import TrestleIncorrectArgsError, handle_generic_command_exception
+from trestle.common.load_validate import load_validate_model_name
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.command_docs import CommandPlusDocs
@@ -170,9 +171,9 @@ class JinjaCmd(CommandPlusDocs):
 
         if ssp:
             # name lookup
-            ssp_data, _ = ModelUtils.load_top_level_model(trestle_root, ssp, SystemSecurityPlan)
+            ssp_data, _ = load_validate_model_name(trestle_root, ssp, SystemSecurityPlan)
             lut['ssp'] = ssp_data
-            _, profile_path = ModelUtils.load_top_level_model(trestle_root, profile, Profile)
+            profile_path = ModelUtils.full_path_for_top_level_model(trestle_root, profile, Profile)
             profile_resolver = ProfileResolver()
             resolved_catalog = profile_resolver.get_resolved_profile_catalog(
                 trestle_root, profile_path, False, False, parameters_formatting
@@ -209,7 +210,7 @@ class JinjaCmd(CommandPlusDocs):
         template_folder = pathlib.Path.cwd()
 
         # Output to multiple markdown files
-        _, profile_path = ModelUtils.load_top_level_model(trestle_root, profile, Profile)
+        profile_path = ModelUtils.full_path_for_top_level_model(trestle_root, profile, Profile)
         profile_resolver = ProfileResolver()
         resolved_catalog = profile_resolver.get_resolved_profile_catalog(
             trestle_root, profile_path, False, False, parameters_formatting

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -28,8 +28,8 @@ import trestle.oscal.common as com
 import trestle.oscal.profile as prof
 from trestle.common import file_utils
 from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
-from trestle.common.load_validate import load_validate_model_name
 from trestle.common.list_utils import none_if_empty
+from trestle.common.load_validate import load_validate_model_name
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -28,6 +28,7 @@ import trestle.oscal.common as com
 import trestle.oscal.profile as prof
 from trestle.common import file_utils
 from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
+from trestle.common.load_validate import load_validate_model_name
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -325,7 +326,7 @@ class ProfileAssemble(AuthorCommonCommand):
         if not parent_prof_name:
             parent_prof_name = assem_prof_name
 
-        parent_prof, parent_prof_path = ModelUtils.load_top_level_model(trestle_root, parent_prof_name, prof.Profile)
+        parent_prof, parent_prof_path = load_validate_model_name(trestle_root, parent_prof_name, prof.Profile)
         new_content_type = FileContentType.path_to_content_type(parent_prof_path)
 
         required_sections_list = required_sections.split(',') if required_sections else []

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -28,6 +28,7 @@ import trestle.oscal.ssp as ossp
 from trestle.common import const, file_utils, log
 from trestle.common.err import TrestleError, handle_generic_command_exception
 from trestle.common.list_utils import as_list, none_if_empty
+from trestle.common.load_validate import load_validate_model_name
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -362,7 +363,7 @@ class SSPFilter(AuthorCommonCommand):
         """
         # load the ssp
         ssp: ossp.SystemSecurityPlan
-        ssp, _ = ModelUtils.load_top_level_model(trestle_root, ssp_name, ossp.SystemSecurityPlan, FileContentType.JSON)
+        ssp, _ = load_validate_model_name(trestle_root, ssp_name, ossp.SystemSecurityPlan, FileContentType.JSON)
         profile_path = ModelUtils.path_for_top_level_model(
             trestle_root, profile_name, prof.Profile, FileContentType.JSON
         )
@@ -442,7 +443,7 @@ class SSPFilter(AuthorCommonCommand):
 
         existing_ssp_path = ModelUtils.full_path_for_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
         if existing_ssp_path is not None:
-            existing_ssp, _ = ModelUtils.load_top_level_model(trestle_root, out_name, ossp.SystemSecurityPlan)
+            existing_ssp, _ = load_validate_model_name(trestle_root, out_name, ossp.SystemSecurityPlan)
             if ModelUtils.models_are_equivalent(existing_ssp, ssp):
                 logger.info('No changes to filtered ssp so ssp not written out.')
                 return CmdReturnCodes.SUCCESS.value

--- a/trestle/core/commands/href.py
+++ b/trestle/core/commands/href.py
@@ -21,7 +21,7 @@ import pathlib
 
 import trestle.common.log as log
 from trestle.common.err import TrestleError, handle_generic_command_exception
-from trestle.common.model_utils import ModelUtils
+from trestle.common.load_validate import load_validate_model_name
 from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.oscal.profile import Profile
@@ -119,7 +119,7 @@ class HrefCmd(CommandPlusDocs):
             Allow full chaining of linked catalogs and profiles.
 
         """
-        profile_data, profile_path = ModelUtils.load_top_level_model(trestle_root, profile_name, Profile)
+        profile_data, profile_path = load_validate_model_name(trestle_root, profile_name, Profile)
         n_imports = len(profile_data.imports)
         if not new_href:
             logger.info(f'List of imports for profile {profile_name}:')

--- a/trestle/core/commands/import_.py
+++ b/trestle/core/commands/import_.py
@@ -86,9 +86,8 @@ class ImportCmd(CommandPlusDocs):
                                                                 ).resolve()
 
             if desired_model_path.exists():
-                raise TrestleError(
-                    f'Cannot import because file to be imported here: {desired_model_path} already exists.'
-                )
+                logger.warning(f'Cannot import because file to be imported here: {desired_model_path} already exists.')
+                return CmdReturnCodes.COMMAND_ERROR.value
 
             if args.regenerate:
                 logger.debug(f'regenerating uuids in imported file {input_uri}')
@@ -121,7 +120,7 @@ class ImportCmd(CommandPlusDocs):
                     logger.warning(f'Validation of imported file {desired_model_path} did not pass.  Stopping import.')
                     rollback = True
             except TrestleError as err:
-                logger.warning(f'Import of {str(input_uri)} failed with validation error: {err}')
+                logger.error(f'Import of {str(input_uri)} failed with validation error: {err}')
                 rollback = True
 
             if rollback:

--- a/trestle/core/links_validator.py
+++ b/trestle/core/links_validator.py
@@ -62,7 +62,7 @@ class LinksValidator(Validator):
         if in_links:
             if not quiet:
                 logger.warning(f'Resources have {len(links)} uuids and {len(in_links)} are not referenced by model.')
-            logger.debug(f'Resources have {len(in_links)} not in referenced by model: {in_links}')
+            logger.debug(f'Resources have {len(in_links)} uuids not referenced by model: {in_links}')
 
         # This validator is intended just to give warnings, so it always returns True
         return True

--- a/trestle/core/repository.py
+++ b/trestle/core/repository.py
@@ -29,6 +29,7 @@ import trestle.core.commands.split as splitcmd
 import trestle.core.commands.validate as validatecmd
 from trestle.common import file_utils, log
 from trestle.common.err import TrestleError
+from trestle.common.load_validate import load_validate_model_path
 from trestle.common.model_utils import ModelUtils
 from trestle.common.str_utils import AliasMode, classname_to_alias
 from trestle.core import parser
@@ -79,7 +80,7 @@ class ManagedOSCAL:
     def read(self) -> OscalBaseModel:
         """Read OSCAL model from repository."""
         logger.debug(f'Reading model {self.model_name}.')
-        _, _, model = ModelUtils.load_distributed(self.filepath, self.root_dir)
+        model = load_validate_model_path(self.root_dir, self.filepath)
         return model
 
     def write(self, model: OscalBaseModel) -> bool:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Catalog group id's are optional so now create ids for any groups missing id's on import and give warning
Fixed bug counting links and references during validation
Added new load_validate.py file to validate files during load - which will also create group id's if needed
Then replaced all functions like load_top_level... to use the load_validate instead.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
