### PR TITLE
fix: catalog-assemble was writing a new file when there were no changes to the file

### DIFF
--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -157,7 +157,7 @@ def test_catalog_assemble_version(sample_catalog_rich_controls: cat.Catalog, tmp
         tmp_trestle_dir, catalog_path, markdown_path, {}, False
     )
     assert CmdReturnCodes.SUCCESS.value == CatalogAssemble.assemble_catalog(
-        tmp_trestle_dir, md_name, assembled_cat_name, cat_name, False, False, new_version
+        tmp_trestle_dir, md_name, assembled_cat_name, cat_name, True, False, new_version
     )
     assembled_cat, assembled_cat_path = ModelUtils.load_top_level_model(
         tmp_trestle_dir,
@@ -171,7 +171,7 @@ def test_catalog_assemble_version(sample_catalog_rich_controls: cat.Catalog, tmp
 
     # assemble same way again and confirm no new write
     assert CmdReturnCodes.SUCCESS.value == CatalogAssemble.assemble_catalog(
-        tmp_trestle_dir, md_name, assembled_cat_name, assembled_cat_name, False, False, new_version
+        tmp_trestle_dir, md_name, assembled_cat_name, assembled_cat_name, True, False, new_version
     )
 
     assert creation_time == assembled_cat_path.stat().st_mtime

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -153,32 +153,39 @@ def test_catalog_assemble_version(sample_catalog_rich_controls: cat.Catalog, tmp
     sample_catalog_rich_controls.oscal_write(catalog_path)
     markdown_path = tmp_trestle_dir / md_name
     catalog_generate = CatalogGenerate()
+
+    # generate the catalog markdown
     assert CmdReturnCodes.SUCCESS.value == catalog_generate.generate_markdown(
         tmp_trestle_dir, catalog_path, markdown_path, {}, False
     )
+
+    # assemble the catalog the first time
     assert CmdReturnCodes.SUCCESS.value == CatalogAssemble.assemble_catalog(
-        tmp_trestle_dir, md_name, assembled_cat_name, cat_name, True, False, new_version
+        tmp_trestle_dir, md_name, assembled_cat_name, cat_name, False, False, new_version
     )
+
+    # load the freshly assembled catalog
     assembled_cat, assembled_cat_path = ModelUtils.load_top_level_model(
         tmp_trestle_dir,
         assembled_cat_name,
         cat.Catalog
     )
+
+    # confirm it is a fresh file with the version set as requested
     assert assembled_cat.metadata.version.__root__ == new_version
     assert ModelUtils.model_age(assembled_cat) < test_utils.NEW_MODEL_AGE_SECONDS
-
     creation_time = assembled_cat_path.stat().st_mtime
 
     # assemble same way again and confirm no new write
     assert CmdReturnCodes.SUCCESS.value == CatalogAssemble.assemble_catalog(
-        tmp_trestle_dir, md_name, assembled_cat_name, assembled_cat_name, True, False, new_version
+        tmp_trestle_dir, md_name, assembled_cat_name, None, False, False, new_version
     )
 
     assert creation_time == assembled_cat_path.stat().st_mtime
 
-    # assemble same way again but without parent specified and confirm no new write
+    # assemble same way again with parent name specified and confirm no new write
     assert CmdReturnCodes.SUCCESS.value == CatalogAssemble.assemble_catalog(
-        tmp_trestle_dir, md_name, assembled_cat_name, None, False, False, new_version
+        tmp_trestle_dir, md_name, assembled_cat_name, assembled_cat_name, False, False, new_version
     )
 
     assert creation_time == assembled_cat_path.stat().st_mtime

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -801,13 +801,12 @@ class ModelUtils:
     def models_are_equivalent(model_a: Optional[TopLevelOscalModel], model_b: Optional[TopLevelOscalModel]) -> bool:
         """Test if models are equivalent except for last modified and uuid."""
         # set b's extra properties to those of a then later undo so the models are not changed by this routine
-        if (model_b and not model_a) or (model_a and not model_b):
+        if not model_a and not model_b:
+            return True
+        if not model_a or not model_b:
             return False
-        b_last_modified = model_b.metadata.last_modified
-        model_b.metadata.last_modified = model_a.metadata.last_modified
-        b_uuid = model_b.uuid
-        model_b.uuid = model_a.uuid
+        b_last_modified, model_b.metadata.last_modified = model_b.metadata.last_modified, model_a.metadata.last_modified
+        b_uuid, model_b.uuid = model_b.uuid, model_a.uuid
         equivalent = model_a == model_b
-        model_b.metadata.last_modified = b_last_modified
-        model_b.uuid = b_uuid
+        model_b.metadata.last_modified, model_b.uuid = b_last_modified, b_uuid
         return equivalent

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -480,7 +480,7 @@ class CatalogInterface():
             if control_handle.control.id not in ids_in_catalog:
                 self._insert_control_in_catalog(control_handle)
 
-        self._catalog.params = list(self.loose_param_dict.values())
+        self._catalog.params = none_if_empty(list(self.loose_param_dict.values()))
 
     def _find_string_in_part(self, control_id: str, part: common.Part, seek_str: str) -> List[str]:
         hits: List[str] = []
@@ -729,6 +729,7 @@ class CatalogInterface():
                 self._catalog.controls = none_if_empty(control_list)
         self._catalog.groups = none_if_empty(groups)
         self._create_control_dict()
+        self._catalog.params = none_if_empty(self._catalog.params)
         return self._catalog
 
     @staticmethod

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -128,7 +128,7 @@ class CatalogAssemble(AuthorCommonCommand):
         self.add_argument('-m', '--markdown', help=file_help_str, required=True, type=str)
         output_help_str = 'Name of the output generated json Catalog'
         self.add_argument('-o', '--output', help=output_help_str, required=True, type=str)
-        self.add_argument('-sp', '--set-parameters', action='store_true', help=const.HELP_SET_PARAMS, required=False)
+        self.add_argument('-sp', '--set-parameters', action='store_true', help=const.HELP_SET_PARAMS)
         self.add_argument('-r', '--regenerate', action='store_true', help=const.HELP_REGENERATE)
         self.add_argument('-vn', '--version', help=const.HELP_VERSION, required=False, type=str)
 
@@ -193,6 +193,7 @@ class CatalogAssemble(AuthorCommonCommand):
 
         # this is None if it doesn't exist yet
         assem_cat_path = ModelUtils.full_path_for_top_level_model(trestle_root, assem_cat_name, Catalog)
+        logger.debug(f'assem_cat_path is {assem_cat_path}')
 
         # if original cat is not specified, use the assembled cat but only if it already exists
         if not parent_cat_name and assem_cat_path:
@@ -204,6 +205,7 @@ class CatalogAssemble(AuthorCommonCommand):
         # if we have parent catalog then merge the markdown controls into it
         # the parent can be a separate catalog or the destination assembled catalog if it exists
         # but this is the catalog that the markdown is merged into in memory
+        logger.debug(f'parent_cat_name is {parent_cat_name}')
         if parent_cat_name:
             parent_cat, parent_cat_path = ModelUtils.load_top_level_model(trestle_root, parent_cat_name, Catalog)
             parent_cat_interface = CatalogInterface(parent_cat)
@@ -222,9 +224,12 @@ class CatalogAssemble(AuthorCommonCommand):
             if ModelUtils.models_are_equivalent(existing_cat, md_catalog):
                 logger.info('Assembled catalog is not different from existing version, so no update.')
                 return CmdReturnCodes.SUCCESS.value
+            else:
+                logger.debug('new assembled catalog is different from existing one')
 
         if regenerate:
             md_catalog, _, _ = ModelUtils.regenerate_uuids(md_catalog)
+            logger.debug('regenerating uuids in catalog')
         ModelUtils.update_last_modified(md_catalog)
 
         # we still may not know the assem_cat_path but can now create it with file content type

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -28,6 +28,7 @@ import trestle.oscal.common as com
 import trestle.oscal.profile as prof
 from trestle.common import file_utils
 from trestle.common.err import TrestleError, TrestleNotFoundError, handle_generic_command_exception
+from trestle.common.list_utils import none_if_empty
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.author.common import AuthorCommonCommand
@@ -248,7 +249,7 @@ class ProfileAssemble(AuthorCommonCommand):
             new_alters = list(alter_dict.values())
             if profile.modify.alters != new_alters:
                 changed = True
-            profile.modify.alters = new_alters
+            profile.modify.alters = none_if_empty(new_alters)
         return changed
 
     @staticmethod
@@ -279,6 +280,8 @@ class ProfileAssemble(AuthorCommonCommand):
             profile.modify.set_parameters = sorted(
                 new_set_params, key=lambda param: (param_map[param.param_id], param.param_id)
             )
+        if profile.modify:
+            profile.modify.set_parameters = none_if_empty(profile.modify.set_parameters)
         return changed
 
     @staticmethod


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
If you assemble a catalog from markdown and then assemble again, it overwrites when it shouldn't.  But on next assemble it does not overwrite.  This was caused by an empty params list in the assembled catalog that has now been removed.

closes #1136

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
