### PR TITLE
fix: Don't recreate 0.0.1 folder when running `trestle docs validate`

### DIFF
--- a/tests/trestle/core/commands/author/versioning/template_versioning_test.py
+++ b/tests/trestle/core/commands/author/versioning/template_versioning_test.py
@@ -222,3 +222,32 @@ def test_valid_version() -> None:
     assert not TemplateVersioning.is_valid_version('0.1')
     assert not TemplateVersioning.is_valid_version('1')
     assert not TemplateVersioning.is_valid_version('0.0.0.1')
+
+
+def test_empty_folder_is_not_created(tmp_path: pathlib.Path) -> None:
+    """Test that empty folder is not created."""
+    task_path = tmp_path.joinpath('trestle/author/sample_task/')
+    task_path.mkdir(parents=True)
+
+    # run template folder update with empty task
+    TemplateVersioning.update_template_folder_structure(task_path)
+
+    assert not task_path.joinpath('0.0.1/').exists()
+
+    # now create other version of the template
+    newest_version_path = task_path.joinpath('1.0.0')
+    newest_version_path.mkdir(parents=True)
+
+    old_template = newest_version_path.joinpath('template.md')
+    old_template.touch()
+
+    old_folder = newest_version_path.joinpath('images')
+    old_folder.mkdir(parents=True)
+
+    # run template folder update with newest version
+    TemplateVersioning.update_template_folder_structure(task_path)
+
+    # assert everything is stayed the same
+    assert not task_path.joinpath('0.0.1/').exists()
+    assert old_folder.exists()
+    assert old_template.exists()

--- a/trestle/core/commands/author/versioning/template_versioning.py
+++ b/trestle/core/commands/author/versioning/template_versioning.py
@@ -86,6 +86,9 @@ class TemplateVersioning:
 
             if len(all_files_wo_version) == 0:
                 logger.debug('No templates outside of the version folders.')
+                # if the base template folder is empty, delete it
+                if len(list(new_dir.iterdir())) == 0:
+                    new_dir.rmdir()
 
             for f in all_files_wo_version + all_non_template_directories:
                 if f.is_file():


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Don't create empty `0.0.1` if not necessary when running `trestle docs validate`
Also small code refactoring

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

Closes #1083 