### PR TITLE
fix: only show missing value warnings when resolving a profile for ssp

### DIFF
--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -92,7 +92,9 @@ class SSPGenerate(AuthorCommonCommand):
 
             profile_resolver = ProfileResolver()
 
-            resolved_catalog = profile_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
+            resolved_catalog = profile_resolver.get_resolved_profile_catalog(
+                trestle_root, profile_path, show_value_warnings=True
+            )
             catalog_interface = CatalogInterface(resolved_catalog)
 
             sections_dict: Dict[str, str] = {}
@@ -413,7 +415,7 @@ class SSPFilter(AuthorCommonCommand):
         # filter by controls in profile
         if profile_name:
             prof_resolver = ProfileResolver()
-            catalog = prof_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
+            catalog = prof_resolver.get_resolved_profile_catalog(trestle_root, profile_path, show_value_warnings=True)
             catalog_interface = CatalogInterface(catalog)
 
             # The input ssp should reference a superset of the controls referenced by the profile

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -92,6 +92,7 @@ class SSPGenerate(AuthorCommonCommand):
 
             profile_resolver = ProfileResolver()
 
+            # in ssp context we want to see missing value warnings
             resolved_catalog = profile_resolver.get_resolved_profile_catalog(
                 trestle_root, profile_path, show_value_warnings=True
             )

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -35,7 +35,8 @@ class ProfileResolver():
         block_adds: bool = False,
         block_params: bool = False,
         params_format: Optional[str] = None,
-        param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES
+        param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES,
+        show_value_warnings: bool = False
     ) -> cat.Catalog:
         """
         Create the resolved profile catalog given a profile path.
@@ -47,6 +48,7 @@ class ProfileResolver():
             block_params: prevent the application of setparams in the final profile
             params_format: optional pattern with dot to wrap the param string, where dot represents the param string
             param_rep: desired way to convert params to strings
+            show_value_warnings: warn if prose references a value that has not been set
 
         Returns:
             The resolved profile catalog
@@ -54,7 +56,9 @@ class ProfileResolver():
         logger.debug(f'get resolved profile catalog for {profile_path} via generated Import.')
         import_ = prof.Import(href=str(profile_path), include_all={})
         # The final Import has change_prose=True to force parameter substitution in the prose only at the last stage.
-        import_filter = Import(trestle_root, import_, [], True, block_adds, block_params, params_format, param_rep)
+        import_filter = Import(
+            trestle_root, import_, [], True, block_adds, block_params, params_format, param_rep, show_value_warnings
+        )
         logger.debug('launch pipeline')
         result = next(import_filter.process())
         return result

--- a/trestle/core/resolver/_import.py
+++ b/trestle/core/resolver/_import.py
@@ -45,7 +45,8 @@ class Import(Pipeline.Filter):
         block_params: bool = False,
         params_format: str = None,
         param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES,
-        resources: Optional[List[Resource]] = None
+        resources: Optional[List[Resource]] = None,
+        show_value_warnings: bool = False
     ) -> None:
         """Initialize and store trestle root for cache access."""
         self._trestle_root = trestle_root
@@ -57,6 +58,7 @@ class Import(Pipeline.Filter):
         self._params_format = params_format
         self._param_rep = param_rep
         self._resources = resources
+        self.show_value_warnings = show_value_warnings
 
         if self._import.href[0] == '#':
             # Specification section on internal reference resolution:
@@ -109,7 +111,13 @@ class Import(Pipeline.Filter):
                 logger.debug(f'sub_import add pipeline for sub href {sub_import.href} of main href {self._import.href}')
             merge_filter = Merge(profile)
             modify_filter = Modify(
-                profile, self._change_prose, self._block_adds, self._block_params, self._params_format, self._param_rep
+                profile,
+                self._change_prose,
+                self._block_adds,
+                self._block_params,
+                self._params_format,
+                self._param_rep,
+                self.show_value_warnings
             )
             final_pipeline = Pipeline([merge_filter, modify_filter])
             yield next(final_pipeline.process(pipelines))


### PR DESCRIPTION
Signed-off-by: Frank Suits <frankst@au1.ibm.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Prior to this change, any time a profile is resolved there will be warnings for params that do not have assigned values.  This is expected in many resolution contexts except when generating a final ssp - where missing values would mean the ssp is not complete.

Added new show_value_warnings to the profile resolution pipeline so that warnings are only emitted during profile resolution for ssp commands.

closes #1170

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
