### PR TITLE
fix: combine parts props into a single add rather than two separate ones

### DIFF
--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -505,9 +505,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == first_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == first_ns
 
     profile_generate.generate_markdown(tmp_trestle_dir, prof_path, md_path, {}, False, None, None, second_ns)
@@ -519,9 +519,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == second_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == second_ns
 
     # assemble with a different namespace and make sure the default is applied
@@ -532,9 +532,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == third_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == third_ns
 
     # repeat but with set_parameters False and make sure it has no effect.  A warning to the user is given.
@@ -545,9 +545,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[2].name == const.DISPLAY_NAME
     assert props[2].ns is None
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns is None
 
 

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -467,10 +467,7 @@ def test_profile_alter_adds(sample_profile: prof.Profile) -> None:
 
 def test_profile_alter_props(tmp_trestle_dir: pathlib.Path) -> None:
     """Test profile alter adds involving props."""
-    ac1_path, assembled_prof_dir, profile_path, markdown_path = setup_profile_generate(
-        tmp_trestle_dir,
-        'profile_with_alter_props.json'
-    )
+    ac1_path, _, profile_path, markdown_path = setup_profile_generate(tmp_trestle_dir, 'profile_with_alter_props.json')
     sections = {
         'ImplGuidance': 'Implementation Guidance', 'ExpectedEvidence': 'Expected Evidence', 'guidance': 'Guidance'
     }
@@ -504,9 +501,11 @@ def test_profile_alter_props(tmp_trestle_dir: pathlib.Path) -> None:
         prof.Profile, FileContentType.JSON
     )
     alters = profile.modify.alters
-    assert len(alters[0].adds) == 4
-    assert alters[0].adds[2].by_id == 'ac-1_smt.c'
-    assert alters[0].adds[3].by_id == 'ac-1_smt.a'
+    assert len(alters[0].adds) == 3
+    assert len(alters[0].adds[0].parts) == 2
+    assert len(alters[0].adds[0].props) == 2
+    assert alters[0].adds[1].by_id == 'ac-1_smt.c'
+    assert alters[0].adds[2].by_id == 'ac-1_smt.a'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     ac1 = catalog.groups[0].controls[0]
@@ -544,9 +543,9 @@ More evidence
         prof.Profile, FileContentType.JSON
     )
     alters = profile.modify.alters
-    assert len(alters[0].adds) == 5
-    assert alters[0].adds[1].by_id == 'ac-1_smt.b'
-    assert alters[0].adds[3].by_id == 'ac-1_smt.c'
+    assert len(alters[0].adds) == 4
+    assert alters[0].adds[1].by_id == 'ac-1_smt.c'
+    assert alters[0].adds[3].by_id == 'ac-1_smt.a'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     ac1 = catalog.groups[0].controls[0]

--- a/trestle/common/file_utils.py
+++ b/trestle/common/file_utils.py
@@ -278,16 +278,16 @@ def insert_text_in_file(file_path: pathlib.Path, tag: Optional[str], text: str) 
         raise TrestleError(f'Test file {file_path} not found.')
     if tag:
         lines: List[str] = []
-        with file_path.open('r', encoding='utf-8') as f:
+        with file_path.open('r', encoding=const.FILE_ENCODING) as f:
             lines = f.readlines()
         for ii, line in enumerate(lines):
             if line.find(tag) >= 0:
                 lines.insert(ii + 1, text)
-                with file_path.open('w', encoding='utf-8') as f:
+                with file_path.open('w', encoding=const.FILE_ENCODING) as f:
                     f.writelines(lines)
                 return True
     else:
-        with file_path.open('a') as f:
+        with file_path.open('a', encoding=const.FILE_ENCODING) as f:
             f.writelines(text)
         return True
     return False

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -868,7 +868,7 @@ class ControlReader():
             adds.append(prof.Add(parts=none_if_empty(implicit_parts), props=none_if_empty(props), position='ending'))
 
         by_ids = set(after_parts.keys()).union(props_by_id.keys())
-        for by_id in by_ids:
+        for by_id in sorted(by_ids):
             parts = after_parts.get(by_id, None)
             props = props_by_id.get(by_id, None)
             adds.append(prof.Add(parts=parts, props=props, position='ending', by_id=by_id))


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
A single alter->add is created for parts and props rather than two separate ones

closes #1169

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
