### PR TITLE
fix: prevent output of default namespace in markdown

### DIFF
--- a/tests/data/json/profile_with_alter_props.json
+++ b/tests/data/json/profile_with_alter_props.json
@@ -78,6 +78,11 @@
                   "name": "ac1_a_foo",
                   "value": "ac1 a bar",
                   "remarks": "ac1 a good stuff"
+                },
+                {
+                  "name": "ac1_first",
+                  "value": "ac1_first value",
+                  "ns": "http://first"
                 }
               ]
             },

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -498,6 +498,7 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     profile_generate = ProfileGenerate()
     profile_generate.generate_markdown(tmp_trestle_dir, prof_path, md_path, {}, False, None, None, first_ns)
     assert test_utils.confirm_text_in_file(ac1_path, '', f'{const.DEFAULT_NS}: {first_ns}')
+    assert not test_utils.confirm_text_in_file(ac1_path, ' ns: ', first_ns)
     assert ProfileAssemble.assemble_profile(
         tmp_trestle_dir, prof_name, md_name, assembled_prof_name, True, False, None, None, None, None, first_ns
     ) == 0
@@ -512,6 +513,7 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
 
     profile_generate.generate_markdown(tmp_trestle_dir, prof_path, md_path, {}, False, None, None, second_ns)
     assert test_utils.confirm_text_in_file(ac1_path, '', f'{const.DEFAULT_NS}: {second_ns}')
+    assert not test_utils.confirm_text_in_file(ac1_path, ' ns: ', second_ns)
     assert ProfileAssemble.assemble_profile(
         tmp_trestle_dir, prof_name, md_name, assembled_prof_name, True, False, None, None, None, None, second_ns
     ) == 0

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -360,6 +360,10 @@ class ProfileAssemble(AuthorCommonCommand):
         if not parent_prof_name:
             parent_prof_name = assem_prof_name
 
+        parent_prof_path = ModelUtils.full_path_for_top_level_model(trestle_root, parent_prof_name, prof.Profile)
+        if parent_prof_path is None:
+            raise TrestleError(f'Profile {parent_prof_name} does not exist.  An existing profile must be provided.')
+
         parent_prof, parent_prof_path = load_validate_model_name(trestle_root, parent_prof_name, prof.Profile)
         new_content_type = FileContentType.path_to_content_type(parent_prof_path)
 

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -228,7 +228,8 @@ class ControlWriter():
         profile: prof.Profile,
         header: Dict[str, Any],
         part_id_map: Dict[str, str],
-        found_alters: List[prof.Alter]
+        found_alters: List[prof.Alter],
+        default_namespace: Optional[str] = None
     ) -> List[str]:
         part_infos = ControlInterface.get_all_add_info(control.id, profile)
         has_content = len(part_infos) > 0
@@ -299,6 +300,10 @@ class ControlWriter():
                         by_id = add.by_id
                         part_info = PartInfo(name='', prose='', props=add.props, smt_part=by_id)
                         _, prop_list = part_info.to_dicts(part_id_map.get(control.id, {}))
+                        if default_namespace:
+                            for prop in prop_list:
+                                if prop.get('ns', None) == default_namespace:
+                                    prop.pop('ns')
                         header[const.TRESTLE_ADD_PROPS_TAG].extend(prop_list)
         else:
             in_part = ''
@@ -327,6 +332,10 @@ class ControlWriter():
                     in_part = ''
                     if const.TRESTLE_ADD_PROPS_TAG not in header:
                         header[const.TRESTLE_ADD_PROPS_TAG] = []
+                    if default_namespace:
+                        for prop in prop_list:
+                            if prop.get('ns', None) == default_namespace:
+                                prop.pop('ns')
                     header[const.TRESTLE_ADD_PROPS_TAG].extend(prop_list)
         return added_sections
 
@@ -413,12 +422,20 @@ class ControlWriter():
         if context.prompt_responses:
             self._add_implementation_response_prompts(control, comp_dict, context.comp_def is not None)
 
+        # get the default namespace in order to cull it on writing of markdown
+        default_namespace = context.yaml_header.get(const.TRESTLE_GLOBAL_TAG, {}).get(const.DEFAULT_NS, None)
+        if default_namespace:
+            set_params = merged_header.get(const.SET_PARAMS_TAG, {})
+            for param in set_params.values():
+                if param.get('ns', None) == default_namespace:
+                    param.pop('ns')
+
         # only used for profile-generate
         # add sections corresponding to added parts in the profile
         added_sections: List[str] = []
         if context.additional_content:
             added_sections = self._add_additional_content(
-                control, context.profile, merged_header, part_id_map, found_alters
+                control, context.profile, merged_header, part_id_map, found_alters, default_namespace
             )
 
         self._add_yaml_header(merged_header)

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -270,7 +270,7 @@ class ControlWriter():
 
         control_part_id_map = part_id_map.get(control.id, {})
 
-        # if the file already has markdown content, use its alters directly
+        # if the file already has markdown content, read its alters
         if self._md_file.exists():
             if const.TRESTLE_ADD_PROPS_TAG in header:
                 header.pop(const.TRESTLE_ADD_PROPS_TAG)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
the default ns was being output.
new behavior is never to output the default ns into markdown
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
