### PR TITLE
fix: parts labeled Control should be Part

### DIFF
--- a/tests/data/json/profile_with_alter_props.json
+++ b/tests/data/json/profile_with_alter_props.json
@@ -92,12 +92,12 @@
               "parts": [
                 {
                   "id": "ac-1_implgdn",
-                  "name": "ImplGuidance",
+                  "name": "implgdn",
                   "prose": "Maintain compliance"
                 },
                 {
                   "id": "ac-1_expevid",
-                  "name": "ExpectedEvidence",
+                  "name": "expevid",
                   "prose": "Daily logs.",
                   "props": [
                     {

--- a/tests/data/json/simple_test_profile.json
+++ b/tests/data/json/simple_test_profile.json
@@ -132,12 +132,12 @@
               "parts": [
                 {
                   "id": "ac-1_implgdn",
-                  "name": "ImplGuidance",
+                  "name": "implgdn",
                   "prose": "Do it carefully."
                 },
                 {
                   "id": "ac-1_expevid",
-                  "name": "ExpectedEvidence",
+                  "name": "expevid",
                   "prose": "Detailed logs."
                 }
               ]
@@ -153,12 +153,12 @@
               "parts": [
                 {
                   "id": "ac-2_implgdn",
-                  "name": "ImplGuidance",
+                  "name": "implgdn",
                   "prose": "Maintain compliance"
                 },
                 {
                   "id": "ac-2_expevid",
-                  "name": "ExpectedEvidence",
+                  "name": "expevid",
                   "prose": "Daily logs."
                 }
               ]

--- a/tests/data/json/simplified_nist_catalog.json
+++ b/tests/data/json/simplified_nist_catalog.json
@@ -164,6 +164,10 @@
               {
                 "name": "sort-id",
                 "value": "ac-01"
+              },
+              {
+                "name": "extra_prop",
+                "value": "extra value"
               }
             ],
             "links": [
@@ -321,6 +325,12 @@
                         "prose": "Procedures {{ insert: param, ac-1_prm_6 }} and following {{ insert: param, ac-1_prm_7 }}."
                       }
                     ]
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "prop_in_part",
+                    "value": "value in part"
                   }
                 ]
               },

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -146,6 +146,12 @@ def test_catalog_generate_assemble(
         ac1.params = None
         interface_orig.replace_control(ac1)
         orig_cat = interface_orig.get_catalog()
+    if use_orig_cat:
+        ac1 = assembled_cat.groups[0].controls[0]
+        assert ac1.props[2].name == 'extra_prop'
+        assert ac1.props[2].value == 'extra value'
+        assert ac1.parts[0].props[0].name == 'prop_in_part'
+        assert ac1.parts[0].props[0].value == 'value in part'
     assert test_utils.catalog_interface_equivalent(interface_orig, assembled_cat, False)
 
 

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -104,8 +104,6 @@ B subpart prose
 
 ## Part a.
 
-prose for part a. in the statement
-
 ### a by_id subpart
 
 a by_id subpart prose
@@ -119,7 +117,7 @@ control_subparts_dict = {
         ('ac-1_a_guidance.a_subpart', 'a_subpart', 'A subpart prose'),
         ('ac-1_a_guidance.a_subpart.a_subsubpart', 'a_subsubpart', 'A subsubpart prose'),
         ('ac-1_a_guidance.b_subpart', 'b_subpart', 'B subpart prose'),
-        # FIXME ('ac-1_smt.a', 'item', 'prose for part a. in the statement'),
+        ('ac-1_smt.a', 'item', 'Develop, document, and disseminate'),  # this is the original NIST prose
         ('ac-1_smt.a.a_by_id_subpart', 'item', 'a by_id subpart prose')
     ],
     'text': control_subparts_text

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -67,7 +67,7 @@ def test_ssp_generate(import_cat, specify_sections, tmp_trestle_dir: pathlib.Pat
     """Test the ssp generator."""
     args, _, _ = setup_for_ssp(True, False, tmp_trestle_dir, prof_name, ssp_name, import_cat)
     if specify_sections:
-        args.allowed_sections = 'ImplGuidance,ExpectedEvidence'
+        args.allowed_sections = 'implgdn,expevid'
 
     ssp_cmd = SSPGenerate()
     # run the command for happy path

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -108,8 +108,8 @@ def test_ok_when_props_added(tmp_trestle_dir: pathlib.Path) -> None:
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     ac_1 = catalog.groups[0].controls[0]
-    assert ac_1.props[2].name == 'ac1_foo'
-    assert ac_1.props[2].value == 'ac1 bar'
+    assert ac_1.props[3].name == 'ac1_foo'
+    assert ac_1.props[3].value == 'ac1 bar'
     assert ac_1.parts[2].props[0].name == 'part_prop'
     assert ac_1.parts[2].props[0].value == 'part_prop_val'
 

--- a/trestle/common/common_types.py
+++ b/trestle/common/common_types.py
@@ -17,14 +17,14 @@
 from typing import TypeVar
 
 import trestle.oscal.component as comp
+import trestle.oscal.profile as prof
 import trestle.oscal.ssp as ossp
 from trestle.core.base_model import OscalBaseModel
 from trestle.oscal.assessment_plan import AssessmentPlan
 from trestle.oscal.assessment_results import AssessmentResults
-from trestle.oscal.catalog import Catalog, Control
-from trestle.oscal.common import Part, Resource
+from trestle.oscal.catalog import Catalog, Control, Group
+from trestle.oscal.common import AssessmentPart, Part, Resource
 from trestle.oscal.poam import PlanOfActionAndMilestones
-from trestle.oscal.profile import Profile
 
 # model types containing uuids that should not regenerate
 FixedUuidModel = Resource
@@ -36,7 +36,7 @@ TopLevelOscalModel = TypeVar(
     Catalog,
     comp.ComponentDefinition,
     PlanOfActionAndMilestones,
-    Profile,
+    prof.Profile,
     ossp.SystemSecurityPlan
 )
 
@@ -48,8 +48,11 @@ TypeWithProps = TypeVar(
     'TypeWithProps',
     Control,
     Part,
+    AssessmentPart,
     comp.Statement,
     ossp.Statement,
     comp.ImplementedRequirement,
     ossp.ImplementedRequirement
 )
+
+TypeWithParts = TypeVar('TypeWithParts', Control, Part, Group, prof.Add, prof.Group)

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -220,6 +220,8 @@ PART_REGEX = r'(?:##\s+Part\s+)(.*)'
 
 CONTROL_REGEX = r'(?:##\s+Control\s+)(.*)'
 
+AFTER_HASHES_REGEX = r'(?:##*\s+)(.*)'
+
 CACHE_ABS_DIR = '__abs__'
 
 UNIX_CACHE_ROOT = '__root__'

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -841,7 +841,7 @@ class CatalogInterface():
             src: source control with new content
             replace_params: replace the control params with the new ones
         """
-        dest.parts = src.parts
+        ControlInterface.merge_parts(dest, src)
         if replace_params:
             dest.params = src.params
 

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -402,7 +402,7 @@ class ControlInterface:
         src_map = {prop.name: prop for prop in src}
         dest_map = {prop.name: prop for prop in dest}
         all_names = set(src_map.keys()).union(dest_map.keys())
-        for name in all_names:
+        for name in sorted(all_names):
             if name in src_map and name not in dest_map:
                 new_props.append(src_map[name])
             elif name in dest_map and name not in src_map:
@@ -421,7 +421,6 @@ class ControlInterface:
     @staticmethod
     def merge_part(dest: common.Part, src: common.Part) -> common.Part:
         """Merge a source part into the destination part."""
-        logger.info(f'merge part {dest.id} {src.id}')
         dest.name = src.name if src.name else dest.name
         dest.ns = src.ns if src.ns else dest.ns
         dest.props = none_if_empty(ControlInterface.merge_props(dest.props, src.props))
@@ -433,7 +432,6 @@ class ControlInterface:
     @staticmethod
     def merge_parts(dest: TypeWithParts, src: TypeWithParts) -> None:
         """Merge the parts from the source into the destination."""
-        logger.info(f'merge parts {dest.id} {src.id}')
         if not dest.parts:
             dest.parts = src.parts
         elif not src.parts:

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -398,7 +398,7 @@ class ControlInterface:
         """Merge a source list of properties into a destination list."""
         if not src:
             return dest
-        new_props: List[common.Propert] = []
+        new_props: List[common.Property] = []
         src_map = {prop.name: prop for prop in src}
         dest_map = {prop.name: prop for prop in dest}
         all_names = set(src_map.keys()).union(dest_map.keys())

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -887,6 +887,7 @@ class ControlReader():
         adds: List[prof.Add] = []
 
         # add the parts and props at control level
+        # the parts could either go as ending or as after, but the convention here is after
         if control_parts:
             adds.append(prof.Add(parts=control_parts, by_id=f'{control_id}_smt', position='after'))
         if props:

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -887,8 +887,10 @@ class ControlReader():
         adds: List[prof.Add] = []
 
         # add the parts and props at control level
-        if control_parts or props:
-            adds.append(prof.Add(parts=none_if_empty(control_parts), props=none_if_empty(props), position='ending'))
+        if control_parts:
+            adds.append(prof.Add(parts=control_parts, by_id=f'{control_id}_smt', position='after'))
+        if props:
+            adds.append(prof.Add(props=props, position='ending'))
 
         # add the parts and props at the part level, by-id
         by_ids = set(by_id_parts.keys()).union(props_by_id.keys())

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -276,18 +276,31 @@ class ControlWriter():
                 header.pop(const.TRESTLE_ADD_PROPS_TAG)
             for alter in found_alters:
                 for add in as_list(alter.adds):
+                    # by_id could refer to statement (Control) or part (Part)
                     if add.by_id:
-                        part_label = control_part_id_map.get(add.by_id, add.by_id)
-                        if add.parts:
-                            self._md_file.new_header(level=2, title=f'Part {part_label}')
+                        # is this a part that goes after the control statement
+                        if add.by_id == f'{control.id}_smt':
                             for part in as_list(add.parts):
                                 if part.prose:
                                     name = part.name
                                     title = self._sections_dict.get(name, name) if self._sections_dict else name
-                                    self._md_file.new_header(level=3, title=title)
+                                    self._md_file.new_header(level=2, title=f'Control {title}')
                                     self._md_file.new_paraline(part.prose)
                                     added_sections.append(name)
+                        else:
+                            # or is it a sub-part of a statement part
+                            part_label = control_part_id_map.get(add.by_id, add.by_id)
+                            if add.parts:
+                                self._md_file.new_header(level=2, title=f'Part {part_label}')
+                                for part in as_list(add.parts):
+                                    if part.prose:
+                                        name = part.name
+                                        title = self._sections_dict.get(name, name) if self._sections_dict else name
+                                        self._md_file.new_header(level=3, title=title)
+                                        self._md_file.new_paraline(part.prose)
+                                        added_sections.append(name)
                     else:
+                        # if not by_id just add at end of control's parts
                         for part in as_list(add.parts):
                             name = part.name
                             title = self._sections_dict.get(name, name) if self._sections_dict else name
@@ -306,10 +319,12 @@ class ControlWriter():
                                     prop.pop('ns')
                         header[const.TRESTLE_ADD_PROPS_TAG].extend(prop_list)
         else:
+            # md does not already exist so fill in directly
             in_part = ''
             for part_info in part_infos:
                 part, prop_list = part_info.to_dicts(part_id_map.get(control.id, {}))
                 part_prose = part.get('prose', None)
+                # is this part of a statement part
                 if part_info.smt_part and part_prose and part_info.smt_part in control_part_id_map:
                     # avoid outputting ## Part again if in same part
                     if not part_info.smt_part == in_part:
@@ -321,6 +336,7 @@ class ControlWriter():
                     self._md_file.new_header(level=3, title=title)
                     self._md_file.new_paraline(part_prose)
                     added_sections.append(name)
+                # is it a control part
                 elif part_prose:
                     in_part = ''
                     name = part['name']

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -297,7 +297,7 @@ class ControlWriter():
                                     if part.prose:
                                         name = part.name
                                         # need special handling for statement parts because their name is 'item'
-                                        # get the short hame as last piece of the part id after the '.'
+                                        # get the short name as last piece of the part id after the '.'
                                         if name == 'item':
                                             name = part.id.split('.')[-1]
                                         title = self._sections_dict.get(name, name) if self._sections_dict else name

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -269,6 +269,7 @@ class ControlWriter():
         added_sections: List[str] = []
 
         control_part_id_map = part_id_map.get(control.id, {})
+        statement_id = ControlInterface.get_statement_id(control)
 
         # if the file already has markdown content, read its alters
         if self._md_file.exists():
@@ -279,7 +280,7 @@ class ControlWriter():
                     # by_id could refer to statement (Control) or part (Part)
                     if add.by_id:
                         # is this a part that goes after the control statement
-                        if add.by_id == f'{control.id}_smt':
+                        if add.by_id == statement_id:
                             for part in as_list(add.parts):
                                 if part.prose:
                                     name = part.name
@@ -295,6 +296,10 @@ class ControlWriter():
                                 for part in as_list(add.parts):
                                     if part.prose:
                                         name = part.name
+                                        # need special handling for statement parts because their name is 'item'
+                                        # get the short hame as last piece of the part id after the '.'
+                                        if name == 'item':
+                                            name = part.id.split('.')[-1]
                                         title = self._sections_dict.get(name, name) if self._sections_dict else name
                                         self._md_file.new_header(level=3, title=title)
                                         self._md_file.new_paraline(part.prose)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
There was confusion on the headers Part and Control during profile assemble
This was cleared up, and parts at the control level are positioned after the control statement with header Control.
Parts bound to a sub-part of the statement are labeled Part

closes #1175
closes #1178

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
