### PR TITLE
fix: Add subparts to the markdown docs

### DIFF
--- a/tests/data/jinja/profile_to_docs_with_subparts.md.jinja
+++ b/tests/data/jinja/profile_to_docs_with_subparts.md.jinja
@@ -1,0 +1,18 @@
+# Control Page
+
+{{ control_writer.write_control_with_sections(control,
+profile,
+group_title,
+['objective', 'ImplGuidance', 'above_the_line_guidance', 'expected_evidence'],
+{
+'objective':'Control Objective Header',
+'ImplGuidance': "The implementation guidance",
+'above_the_line_guidance': "The above the line guidance",
+'evidence_guidance': "Evidence Guidance"
+},
+label_column=True,
+add_group_to_title=True,
+param_dict={'ac-2_prm_1': 'AC-2 Test'}
+)
+| safe
+}}

--- a/tests/data/json/profile_with_alter_subparts.json
+++ b/tests/data/json/profile_with_alter_subparts.json
@@ -1,0 +1,76 @@
+{
+  "profile": {
+    "uuid": "A0000000-0000-4000-8000-000000000000",
+    "metadata": {
+      "title": "Profile with subparts",
+      "last-modified": "2021-01-01T00:00:00.000+00:00",
+      "version": "2021-01-01",
+      "oscal-version": "1.0.0"
+    },
+    "imports": [
+      {
+        "href": "trestle://catalogs/nist_cat/catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "ac-1",
+              "ac-2"
+            ]
+          }
+        ]
+      }
+    ],
+    "merge": {
+      "as-is": true
+    },
+    "modify": {
+      "alters": [
+        {
+          "control-id": "ac-1",
+          "adds": [
+            {
+              "position": "after",
+              "by-id": "ac-1_smt",
+              "parts": [
+                {
+                  "id": "ac-1_implgdn",
+                  "name": "ImplGuidance",
+                  "prose": "New part in subpart"
+                },
+                {
+                  "id": "ac-1_expected_evidence",
+                  "name": "expected_evidence",
+                  "prose": "Some evidence prose."
+                },
+                {
+                  "id": "ac-1_above_the_line_guidance",
+                  "name": "above_the_line_guidance",
+                  "prose": "",
+                  "parts": [
+                    {
+                      "id": "ac-1_above_the_line_guidance.part_a",
+                      "name": "part_a.",
+                      "prose": "",
+                      "parts": [
+                        {
+                          "id": "ac-1_above_the_line_guidance.part_a.implementation_guidance",
+                          "name": "implementation_guidance",
+                          "prose": "Some ac-1_above_the_line_guidance.part_a.implementation_guidance prose"
+                        },
+                        {
+                          "id": "ac-1_above_the_line_guidance.part_a.evidence_guidance",
+                          "name": "evidence_guidance",
+                          "prose": "Some ac-1_above_the_line_guidance.part_a.evidence_guidance prose."
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -230,6 +230,8 @@ TRESTLE_HREF_HEADING = 'trestle://'
 
 TRESTLE_HREF_REGEX = '^trestle://[^/]'
 
+MATCH_ALL_EXCEPT_LETTERS_UNDERSCORE_SPACE_REGEX = '[^a-zA-Z0-9-_ \n]'
+
 # extracts foo and bar from ...[foo](bar)...
 MARKDOWN_URL_REGEX = r'\[([^\]]+)\]\(([^)]+)\)'
 

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -301,16 +301,15 @@ class ControlInterface:
     def _get_part_and_subpart_info(part: common.Part, add_by_id: str) -> List[PartInfo]:
         """Get part and its subparts info needed for markdown purposes."""
         part_infos = []
-        if not part.parts:
-            return part_infos
-
-        for part in part.parts:
+        for subpart in as_list(part.parts):
             subpart_info = None
-            if part.parts:
+            if subpart.parts:
                 # Recursively add subparts info
-                subpart_info = ControlInterface._get_part_and_subpart_info(part, add_by_id)
+                subpart_info = ControlInterface._get_part_and_subpart_info(subpart, add_by_id)
             part_infos.append(
-                PartInfo(name=part.name, prose=part.prose, smt_part=add_by_id, props=part.props, parts=subpart_info)
+                PartInfo(
+                    name=subpart.name, prose=subpart.prose, smt_part=add_by_id, props=subpart.props, parts=subpart_info
+                )
             )
 
         return part_infos

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -301,15 +301,17 @@ class ControlInterface:
     def _get_part_and_subpart_info(part: common.Part, add_by_id: str) -> List[PartInfo]:
         """Get part and its subparts info needed for markdown purposes."""
         part_infos = []
-        for part in as_list(part.parts):
+        if not part.parts:
+            return part_infos
+
+        for part in part.parts:
             subpart_info = None
             if part.parts:
                 # Recursively add subparts info
                 subpart_info = ControlInterface._get_part_and_subpart_info(part, add_by_id)
-            part_info = PartInfo(
-                name=part.name, prose=part.prose, smt_part=add_by_id, props=part.props, parts=subpart_info
+            part_infos.append(
+                PartInfo(name=part.name, prose=part.prose, smt_part=add_by_id, props=part.props, parts=subpart_info)
             )
-            part_infos.append(part_info)
 
         return part_infos
 

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -326,6 +326,7 @@ class ControlWriter():
         else:
             # md does not already exist so fill in directly
             in_part = ''
+            # TODO: process subparts as well - issue #1181
             for part_info in part_infos:
                 part, prop_list = part_info.to_dicts(part_id_map.get(control.id, {}))
                 part_prose = part.get('prose', None)

--- a/trestle/core/docs_control_writer.py
+++ b/trestle/core/docs_control_writer.py
@@ -218,7 +218,7 @@ class DocsControlWriter(ControlWriter):
 
         heading_title = f'{section_title}'
         tag_section_name = section_prefix + f'{section_title}'
-        tag_section_name = re.sub('[^a-zA-Z0-9-_ \n]', '', tag_section_name)
+        tag_section_name = re.sub(const.MATCH_ALL_EXCEPT_LETTERS_UNDERSCORE_SPACE_REGEX, '', tag_section_name)
         tag_section_name = tag_section_name.replace(' ', '-').replace('_', '-').lower()
         self._md_file.new_header(level=heading_level, title=heading_title, add_new_line_after_header=not tag_pattern)
         if tag_pattern:


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
- Added subparts to the part info returned by `ControlInterface`
- Added subparts to the markdown docs.
- Allowed subparts to be renamed via Jinja template.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

Closes #1164 