### PR TITLE
fix: name of subparts added into statement should not be "item"

### DIFF
--- a/tests/data/json/profile_with_alter_subparts.json
+++ b/tests/data/json/profile_with_alter_subparts.json
@@ -41,26 +41,32 @@
                   "id": "ac-1_expected_evidence",
                   "name": "expected_evidence",
                   "prose": "Some evidence prose."
-                },
+                }
+              ]
+            },
+            {
+              "position": "ending",
+              "by-id": "ac-1_smt.a",
+              "parts": [
                 {
-                  "id": "ac-1_above_the_line_guidance",
+                  "id": "ac-1_smt.a.above_the_line_guidance",
                   "name": "above_the_line_guidance",
                   "prose": "",
                   "parts": [
                     {
-                      "id": "ac-1_above_the_line_guidance.part_a",
-                      "name": "part_a.",
+                      "id": "ac-1_smt.a.above_the_line_guidance.add_to_part_a",
+                      "name": "add_to_part_a",
                       "prose": "",
                       "parts": [
                         {
-                          "id": "ac-1_above_the_line_guidance.part_a.implementation_guidance",
+                          "id": "ac-1_smt.a.above_the_line_guidance.add_to_part_a.implementation_guidance",
                           "name": "implementation_guidance",
-                          "prose": "Some ac-1_above_the_line_guidance.part_a.implementation_guidance prose"
+                          "prose": "Some ac-1_smt.a.above_the_line_guidance.add_to_part_a.implementation_guidance prose"
                         },
                         {
-                          "id": "ac-1_above_the_line_guidance.part_a.evidence_guidance",
+                          "id": "ac-1_smt.a.above_the_line_guidance.add_to_part_a.evidence_guidance",
                           "name": "evidence_guidance",
-                          "prose": "Some ac-1_above_the_line_guidance.part_a.evidence_guidance prose."
+                          "prose": "Some ac-1_smt.a.above_the_line_guidance.add_to_part_a.evidence_guidance prose."
                         }
                       ]
                     }

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -246,11 +246,11 @@ def test_jinja_profile_docs_with_selected_sections_and_multiple_parts(
         assert tree
         node1 = tree.get_node_for_key('## The above the line guidance')
         assert node1
-        node2 = tree.get_node_for_key('### part_a.')
+        node2 = tree.get_node_for_key('### add_to_part_a')
         assert node2
         node3 = tree.get_node_for_key('#### Evidence Guidance')
         assert node3
-        tag = '{: #the-above-the-line-guidance-part-a-evidence-guidance}'  # noqa: FS003
+        tag = '{: #the-above-the-line-guidance-add-to-part-a-evidence-guidance}'  # noqa: FS003
         assert tag in node2.content.raw_text
         assert len(tree.content.subnodes_keys) == 7
 

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -118,7 +118,7 @@ control_subparts_dict = {
         ('ac-1_a_guidance.a_subpart.a_subsubpart', 'a_subsubpart', 'A subsubpart prose'),
         ('ac-1_a_guidance.b_subpart', 'b_subpart', 'B subpart prose'),
         ('ac-1_smt.a', 'item', 'Develop, document, and disseminate'),  # this is the original NIST prose
-        ('ac-1_smt.a.a_by_id_subpart', 'item', 'a by_id subpart prose')
+        ('ac-1_smt.a.a_by_id_subpart', 'a_by_id_subpart', 'a by_id subpart prose')
     ],
     'text': control_subparts_text
 }
@@ -699,7 +699,7 @@ More evidence
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     parts = catalog.groups[0].controls[0].parts[0].parts
     assert parts[1].parts[0].id == 'ac-1_smt.b.new_guidance'
-    assert parts[1].parts[0].name == 'item'
+    assert parts[1].parts[0].name == 'new_guidance'
     assert parts[1].parts[0].prose == 'This is my added prose for a part in the statement'
     assert parts[1].parts[1].id == 'ac-1_smt.b.new_evidence'
     assert parts[1].parts[1].prose == 'More evidence'

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -812,8 +812,8 @@ class ControlReader():
                 prose = ControlReader._clean_prose(node2.content.text)
                 prose = '\n'.join(prose)
                 id_ = f'{by_part_id}.{part_name}'
-                part = common.Part(id=id_, name='item', prose=prose)
-                part.parts = ControlReader._add_sub_parts(part.id, node2, 'item')
+                part = common.Part(id=id_, name=part_name, prose=prose)
+                part.parts = ControlReader._add_sub_parts(part.id, node2)
             else:
                 raise TrestleError(f'Unexpected header {node2.key} found in control {control_id}')
             if by_part_id not in by_id_parts:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

If a part was added to a statement part it was added with name "item" but it should be the normal part name.
Adjusted the test profile for jinja to represent a statement part with a subpart.

closes #1183 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
