### PR TITLE
fix: profile assemble 'after' and 'by-id' issue, and added resolve_profile_catalog script

### DIFF
--- a/scripts/resolve_profile_catalog.py
+++ b/scripts/resolve_profile_catalog.py
@@ -1,0 +1,65 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to generate resolved profile catalog given profile."""
+import logging
+import sys
+from pathlib import Path
+
+import trestle.oscal.profile as prof
+from trestle.common.file_utils import FileContentType, is_valid_project_root
+from trestle.common.model_utils import ModelUtils
+from trestle.core.profile_resolver import ProfileResolver
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+
+def create_resolved_profile_catalog(profile_name: str, resolved_profile_catalog_name: str) -> int:
+    """Create the catalog from the profile."""
+    trestle_root = Path.cwd()
+    if not is_valid_project_root(trestle_root):
+        logger.info('This script must be run from the top level of a valid trestle project directory.')
+        return 1
+    profile_path = ModelUtils.full_path_for_top_level_model(trestle_root, profile_name, prof.Profile)
+    profile_resolver = ProfileResolver()
+    resolved_cat = profile_resolver.get_resolved_profile_catalog(trestle_root, profile_path)
+    ModelUtils.save_top_level_model(resolved_cat, trestle_root, resolved_profile_catalog_name, FileContentType.JSON)
+    logger.info(
+        f'Successfully created resolved profile catalog {resolved_profile_catalog_name} from profile {profile_name}'
+    )
+    return 0
+
+
+def _usage():
+    logger.info(f'Usage: python {sys.argv[0]} profile_name resolved_profile_catalog_name')
+
+
+def main():
+    """
+    Create the resolved profile catalog.
+
+    Usage:
+        python resolve_profile_catalog.py profile_name resolved_profile_catalog_name
+    """
+    if len(sys.argv) != 3:
+        _usage()
+        return 1
+    return create_resolved_profile_catalog(sys.argv[1], sys.argv[2])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/data/json/test_profile_b.json
+++ b/tests/data/json/test_profile_b.json
@@ -43,12 +43,34 @@
           "param-id": "ac-3.3_prm_1",
             "values": [
               "key power users"
+            ],
+            "props": [
+              {
+                "name": "set_param_prof_b_prop",
+                "value": "set param prof b prop value"
+              }
             ]
         },
         {  "param-id": "ac-3.3_prm_2",
             "values": [
               "full and complete compliance"
             ]
+        }
+      ],
+      "alters": [
+        {
+          "control-id": "ac-3.3",
+          "adds": [
+            {
+              "position": "starting",
+              "props": [
+                {
+                  "name": "add_prof_b_prop",
+                  "value": "add prof b prop value"
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -335,9 +335,14 @@ def setup_for_multi_profile(trestle_root: pathlib.Path, big_profile: bool, impor
         prof_path = JSON_TEST_DATA_PATH / 'simple_test_profile.json'
     repo.load_and_import_model(prof_path, main_profile_name)
 
-    # a loads ac-1, ac-2 and prof_b
-    # b loads ac-3, ac-3.3, ac-4, ac-5 and prof_c
-    # c loads a-2-1, b-2-1 and cat-1
+    # a loads ac-1, ac-2 and pulls a-1, b-2-1, cat-1, ac-3, ac-3.3 from prof_b
+    # b loads ac-3, ac-3.3, ac-4, ac-5 - excludes ac-4 - and prof_c
+    # c loads a-2-1, b-2-1 and cat-1 from complex_cat
+
+    # d loads ac-1 and ac-2 and sets values
+    # e loads a and sets some parameters
+    # f loads b and adds props
+    # g loads b and tests adding props by position after
 
     for letter in 'abcdefg':
         prof_name = f'test_profile_{letter}'

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -604,6 +604,20 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     assert props[0].ns is None
 
 
+def _check_parts(part: com.Part, prose_1: str) -> None:
+    assert part.parts[0].id == 'ac-1_smt.b.new_guidance'
+    assert part.parts[0].name == 'new_guidance'
+    assert part.parts[0].prose == 'This is my added prose for a part in the statement'
+    assert part.parts[1].id == 'ac-1_smt.b.new_evidence'
+    assert part.parts[1].prose == prose_1
+
+
+def _check_multi_section(part: com.Part) -> None:
+    assert part.id == 'ac-1_multi_section'
+    assert part.parts[0].id == 'ac-1_multi_section.sub_a'
+    assert part.parts[0].parts[0].id == 'ac-1_multi_section.sub_a.sub_sub_a'
+
+
 def test_profile_alter_props(tmp_trestle_dir: pathlib.Path) -> None:
     """Test profile alter adds involving props."""
     ac1_path, _, profile_path, markdown_path = setup_profile_generate(tmp_trestle_dir, 'profile_with_alter_props.json')
@@ -716,12 +730,7 @@ More evidence
     assert adds[0].parts[2].parts[0].parts[0].id == 'ac-1_multi_section.sub_a.sub_sub_a'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
-    parts = catalog.groups[0].controls[0].parts[0].parts
-    assert parts[1].parts[0].id == 'ac-1_smt.b.new_guidance'
-    assert parts[1].parts[0].name == 'new_guidance'
-    assert parts[1].parts[0].prose == 'This is my added prose for a part in the statement'
-    assert parts[1].parts[1].id == 'ac-1_smt.b.new_evidence'
-    assert parts[1].parts[1].prose == 'More evidence'
+    _check_parts(catalog.groups[0].controls[0].parts[0].parts[1], 'More evidence')
 
     # Confirm that changed prose in the markdown is retained on new profile-generate
     assert test_utils.substitute_text_in_file(ac1_path, 'More evidence', 'Updated evidence')
@@ -730,15 +739,20 @@ More evidence
         tmp_trestle_dir, prof_name, md_name, assembled_prof_name, True, False, None, sections, None, None, None
     ) == 0
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
-    parts = catalog.groups[0].controls[0].parts[0].parts
-    assert parts[1].parts[0].id == 'ac-1_smt.b.new_guidance'
-    assert parts[1].parts[0].prose == 'This is my added prose for a part in the statement'
-    assert parts[1].parts[1].id == 'ac-1_smt.b.new_evidence'
-    assert parts[1].parts[1].prose == 'Updated evidence'
-    part = catalog.groups[0].controls[0].parts[4]
-    assert part.id == 'ac-1_multi_section'
-    assert part.parts[0].id == 'ac-1_multi_section.sub_a'
-    assert part.parts[0].parts[0].id == 'ac-1_multi_section.sub_a.sub_sub_a'
+    _check_parts(catalog.groups[0].controls[0].parts[0].parts[1], 'Updated evidence')
+    _check_multi_section(part=catalog.groups[0].controls[0].parts[4])
+
+    fresh_md_name = 'fresh_markdown'
+    fresh_md_path = tmp_trestle_dir / fresh_md_name
+    fresh_assem_prof_name = 'fresh_assem'
+    fresh_assem_prof_path = tmp_trestle_dir / 'profiles' / fresh_assem_prof_name / 'profile.json'
+    assert profile_generate.generate_markdown(tmp_trestle_dir, prof_path, fresh_md_path, {}, False, sections, None) == 0
+    assert ProfileAssemble.assemble_profile(
+        tmp_trestle_dir, prof_name, fresh_md_name, fresh_assem_prof_name, True, False, None, sections, None, None, None
+    ) == 0
+    catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, fresh_assem_prof_path)
+    _check_parts(catalog.groups[0].controls[0].parts[0].parts[1], 'Updated evidence')
+    _check_multi_section(part=catalog.groups[0].controls[0].parts[4])
 
 
 def test_adding_removing_sections(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -663,6 +663,20 @@ def test_profile_alter_props(tmp_trestle_dir: pathlib.Path) -> None:
     assert ac1.parts[0].parts[2].props[1].value == 'ac1 new part value'
 
     prose = """
+## Control Multi Section
+
+### Sub A
+
+Text in Sub A
+
+#### Sub Sub A
+
+Text in Sub Sub A
+
+### Sub B
+
+Text in Sub B
+
 ## Part b.
 
 ### New Guidance
@@ -674,6 +688,9 @@ This is my added prose for a part in the statement
 More evidence
 
 """
+    sections['sub_a'] = 'Sub A'
+    sections['sub_sub_a'] = 'Sub Sub A'
+    sections['sub_b'] = 'Sub B'
     sections['newguidance'] = 'New Guidance'
     sections['newevidence'] = 'New Evidence'
 
@@ -694,6 +711,9 @@ More evidence
     assert adds[1].by_id == 'ac-1_smt.a'
     assert adds[2].by_id == 'ac-1_smt.b'
     assert adds[3].by_id == 'ac-1_smt.c'
+    assert adds[0].parts[2].id == 'ac-1_multi_section'
+    assert adds[0].parts[2].parts[0].id == 'ac-1_multi_section.sub_a'
+    assert adds[0].parts[2].parts[0].parts[0].id == 'ac-1_multi_section.sub_a.sub_sub_a'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     parts = catalog.groups[0].controls[0].parts[0].parts
@@ -715,6 +735,10 @@ More evidence
     assert parts[1].parts[0].prose == 'This is my added prose for a part in the statement'
     assert parts[1].parts[1].id == 'ac-1_smt.b.new_evidence'
     assert parts[1].parts[1].prose == 'Updated evidence'
+    part = catalog.groups[0].controls[0].parts[4]
+    assert part.id == 'ac-1_multi_section'
+    assert part.parts[0].id == 'ac-1_multi_section.sub_a'
+    assert part.parts[0].parts[0].id == 'ac-1_multi_section.sub_a.sub_sub_a'
 
 
 def test_adding_removing_sections(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -557,9 +557,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == first_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == first_ns
 
     profile_generate.generate_markdown(tmp_trestle_dir, prof_path, md_path, {}, False, None, None, second_ns)
@@ -572,9 +572,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == second_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == second_ns
 
     # assemble with a different namespace and make sure the default is applied
@@ -585,9 +585,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[0].name == const.DISPLAY_NAME
     assert props[0].ns == third_ns
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns == third_ns
 
     # repeat but with set_parameters False and make sure it has no effect.  A warning to the user is given.
@@ -598,9 +598,9 @@ def test_profile_default_namespace(tmp_trestle_dir: pathlib.Path) -> None:
     props = profile.modify.set_parameters[0].props
     assert props[2].name == const.DISPLAY_NAME
     assert props[2].ns is None
-    props = profile.modify.alters[0].adds[1].props
+    props = profile.modify.alters[0].adds[0].props
     assert props[0].ns == orig_ns
-    props = profile.modify.alters[0].adds[2].props
+    props = profile.modify.alters[0].adds[1].props
     assert props[0].ns is None
 
 
@@ -645,14 +645,13 @@ def test_profile_alter_props(tmp_trestle_dir: pathlib.Path) -> None:
         prof.Profile, FileContentType.JSON
     )
     adds = profile.modify.alters[0].adds
-    assert len(adds) == 4
-    assert adds[0].position == prof.Position.after
-    assert adds[0].by_id == 'ac-1_smt'
+    assert len(adds) == 3
+    assert adds[0].position == prof.Position.ending
+    assert adds[0].by_id is None
     assert len(adds[0].parts) == 2
-    assert adds[0].props is None
-    assert len(adds[1].props) == 2
-    assert adds[2].by_id == 'ac-1_smt.a'
-    assert adds[3].by_id == 'ac-1_smt.c'
+    assert len(adds[0].props) == 2
+    assert adds[1].by_id == 'ac-1_smt.a'
+    assert adds[2].by_id == 'ac-1_smt.c'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     ac1 = catalog.groups[0].controls[0]
@@ -690,11 +689,11 @@ More evidence
         prof.Profile, FileContentType.JSON
     )
     adds = profile.modify.alters[0].adds
-    assert len(adds) == 5
-    assert adds[0].position == prof.Position.after
-    assert adds[2].by_id == 'ac-1_smt.a'
-    assert adds[3].by_id == 'ac-1_smt.b'
-    assert adds[4].by_id == 'ac-1_smt.c'
+    assert len(adds) == 4
+    assert adds[0].position == prof.Position.ending
+    assert adds[1].by_id == 'ac-1_smt.a'
+    assert adds[2].by_id == 'ac-1_smt.b'
+    assert adds[3].by_id == 'ac-1_smt.c'
 
     catalog = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, prof_path)
     parts = catalog.groups[0].controls[0].parts[0].parts

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -440,3 +440,5 @@ NS_HELP = 'Default namespace to use if namespace is not specified for a property
 DEFAULT_NS = 'default-namespace'
 
 DISPLAY_NAME = 'display-name'
+
+RESOLUTION_SOURCE = 'resolution-source'

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -34,6 +34,7 @@ from trestle.core.commands.author.common import AuthorCommonCommand
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.control_context import ContextPurpose, ControlContext
 from trestle.core.models.file_content_type import FileContentType
+from trestle.oscal import OSCAL_VERSION
 from trestle.oscal.catalog import Catalog
 
 logger = logging.getLogger(__name__)
@@ -233,6 +234,8 @@ class CatalogAssemble(AuthorCommonCommand):
             md_catalog, _, _ = ModelUtils.regenerate_uuids(md_catalog)
             logger.debug('regenerating uuids in catalog')
         ModelUtils.update_last_modified(md_catalog)
+
+        md_catalog.metadata.oscal_version = OSCAL_VERSION
 
         # we still may not know the assem_cat_path but can now create it with file content type
         assem_cat_path = ModelUtils.path_for_top_level_model(trestle_root, assem_cat_name, Catalog, new_content_type)

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -38,6 +38,7 @@ from trestle.core.control_context import ContextPurpose, ControlContext
 from trestle.core.control_interface import ParameterRep
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.profile_resolver import ProfileResolver
+from trestle.oscal import OSCAL_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -403,6 +404,8 @@ class ProfileAssemble(AuthorCommonCommand):
 
         if version:
             parent_prof.metadata.version = com.Version(__root__=version)
+
+        parent_prof.metadata.oscal_version = OSCAL_VERSION
 
         assem_prof_path = ModelUtils.path_for_top_level_model(
             trestle_root, assem_prof_name, prof.Profile, new_content_type

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -76,6 +76,13 @@ class PartInfo:
             part['name'] = part_id_map.get(self.name, self.name)
             if self.prose:
                 part['prose'] = self.prose
+            if self.parts:
+                all_subparts = []
+                for subpart in self.parts:
+                    subpart_dict, _ = subpart.to_dicts(part_id_map)
+                    all_subparts.append(subpart_dict)
+                part['sub-parts'] = all_subparts
+
         # otherwise it is a list of props
         else:
             for prop in as_list(self.props):

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -81,7 +81,7 @@ class PartInfo:
                 for subpart in self.parts:
                     subpart_dict, _ = subpart.to_dicts(part_id_map)
                     all_subparts.append(subpart_dict)
-                part['sub-parts'] = all_subparts
+                part['parts'] = all_subparts
 
         # otherwise it is a list of props
         else:

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -917,11 +917,8 @@ class ControlReader():
         adds: List[prof.Add] = []
 
         # add the parts and props at control level
-        # the parts could either go as ending or as after, but the convention here is after
-        if control_parts:
-            adds.append(prof.Add(parts=control_parts, by_id=f'{control_id}_smt', position='after'))
-        if props:
-            adds.append(prof.Add(props=props, position='ending'))
+        if control_parts or props:
+            adds.append(prof.Add(parts=none_if_empty(control_parts), props=none_if_empty(props), position='ending'))
 
         # add the parts and props at the part level, by-id
         by_ids = set(by_id_parts.keys()).union(props_by_id.keys())

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -222,14 +222,14 @@ class ControlWriter():
                 self._insert_comp_info(part_label, dic, comp_def_format)
         self._md_file.new_hr()
 
-    def _dump_subpart_infos(self, level: int, part: PartInfo) -> None:
+    def _dump_subpart_infos(self, level: int, part: Dict[str, Any]) -> None:
         name = part['name']
         title = self._sections_dict.get(name, name) if self._sections_dict else name
         self._md_file.new_header(level=level, title=title)
-        if part.prose:
-            self._md_file.new_paraline(part.prose)
-        for subpart in as_list(part.parts):
-            self._dump_subparts(level + 1, subpart)
+        if 'prose' in part:
+            self._md_file.new_paraline(part['prose'])
+        for subpart in as_list(part.get('parts', None)):
+            self._dump_subpart_infos(level + 1, subpart)
 
     def _dump_subparts(self, level: int, part: Part) -> None:
         name = part.name

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -25,7 +25,7 @@ from trestle.core.control_interface import CompDict, ComponentImpInfo, ControlIn
 from trestle.core.control_reader import ControlReader
 from trestle.core.markdown.md_writer import MDWriter
 from trestle.oscal import profile as prof
-from trestle.oscal.common import ImplementationStatus
+from trestle.oscal.common import ImplementationStatus, Part
 
 logger = logging.getLogger(__name__)
 
@@ -222,6 +222,47 @@ class ControlWriter():
                 self._insert_comp_info(part_label, dic, comp_def_format)
         self._md_file.new_hr()
 
+    def _dump_subpart_infos(self, level: int, part: PartInfo) -> None:
+        name = part['name']
+        title = self._sections_dict.get(name, name) if self._sections_dict else name
+        self._md_file.new_header(level=level, title=title)
+        if part.prose:
+            self._md_file.new_paraline(part.prose)
+        for subpart in as_list(part.parts):
+            self._dump_subparts(level + 1, subpart)
+
+    def _dump_subparts(self, level: int, part: Part) -> None:
+        name = part.name
+        title = self._sections_dict.get(name, name) if self._sections_dict else name
+        self._md_file.new_header(level=level, title=title)
+        if part.prose:
+            self._md_file.new_paraline(part.prose)
+        for subpart in as_list(part.parts):
+            self._dump_subparts(level + 1, subpart)
+
+    def _dump_section(self, level: int, part: Part, added_sections: List[str], prefix: str) -> None:
+        title = self._sections_dict.get(part.name, part.name) if self._sections_dict else part.name
+        title = f'{prefix} {title}' if prefix else title
+        self._md_file.new_header(level=level, title=title)
+        if part.prose:
+            self._md_file.new_paraline(part.prose)
+        for subpart in as_list(part.parts):
+            self._dump_subparts(level + 1, subpart)
+        added_sections.append(part.name)
+
+    def _dump_section_info(self, level: int, part: Dict[str, Any], added_sections: List[str], prefix: str) -> None:
+        part_prose = part.get('prose', None)
+        part_subparts = part.get('sub-parts', None)
+        name = part['name']
+        title = self._sections_dict.get(name, name) if self._sections_dict else name
+        title = f'{prefix} {title}' if prefix else title
+        self._md_file.new_header(level=level, title=title)
+        if part_prose:
+            self._md_file.new_paraline(part_prose)
+        for subpart in as_list(part_subparts):
+            self._dump_subpart_infos(level + 1, subpart)
+        added_sections.append(name)
+
     def _add_additional_content(
         self,
         control: cat.Control,
@@ -231,6 +272,7 @@ class ControlWriter():
         found_alters: List[prof.Alter],
         default_namespace: Optional[str] = None
     ) -> List[str]:
+        # get part and subpart info from adds of the profile
         part_infos = ControlInterface.get_all_add_info(control.id, profile)
         has_content = len(part_infos) > 0
 
@@ -282,19 +324,15 @@ class ControlWriter():
                         # is this a part that goes after the control statement
                         if add.by_id == statement_id:
                             for part in as_list(add.parts):
-                                if part.prose:
-                                    name = part.name
-                                    title = self._sections_dict.get(name, name) if self._sections_dict else name
-                                    self._md_file.new_header(level=2, title=f'Control {title}')
-                                    self._md_file.new_paraline(part.prose)
-                                    added_sections.append(name)
+                                if part.prose or part.parts:
+                                    self._dump_section(2, part, added_sections, 'Control')
                         else:
                             # or is it a sub-part of a statement part
                             part_label = control_part_id_map.get(add.by_id, add.by_id)
                             if add.parts:
                                 self._md_file.new_header(level=2, title=f'Part {part_label}')
                                 for part in as_list(add.parts):
-                                    if part.prose:
+                                    if part.prose or part.parts:
                                         name = part.name
                                         # need special handling for statement parts because their name is 'item'
                                         # get the short name as last piece of the part id after the '.'
@@ -302,16 +340,16 @@ class ControlWriter():
                                             name = part.id.split('.')[-1]
                                         title = self._sections_dict.get(name, name) if self._sections_dict else name
                                         self._md_file.new_header(level=3, title=title)
-                                        self._md_file.new_paraline(part.prose)
+                                        if part.prose:
+                                            self._md_file.new_paraline(part.prose)
+                                        for subpart in as_list(part.parts):
+                                            self._dump_subparts(3, subpart)
                                         added_sections.append(name)
                     else:
                         # if not by_id just add at end of control's parts
                         for part in as_list(add.parts):
-                            name = part.name
-                            title = self._sections_dict.get(name, name) if self._sections_dict else name
-                            self._md_file.new_header(level=2, title=f'Control {title}')
-                            self._md_file.new_paraline(part.prose)
-                            added_sections.append(name)
+                            if part.prose or part.parts:
+                                self._dump_section(2, part, added_sections, 'Control')
                     if add.props:
                         if const.TRESTLE_ADD_PROPS_TAG not in header:
                             header[const.TRESTLE_ADD_PROPS_TAG] = []
@@ -326,30 +364,20 @@ class ControlWriter():
         else:
             # md does not already exist so fill in directly
             in_part = ''
-            # TODO: process subparts as well - issue #1181
             for part_info in part_infos:
                 part, prop_list = part_info.to_dicts(part_id_map.get(control.id, {}))
-                part_prose = part.get('prose', None)
                 # is this part of a statement part
-                if part_info.smt_part and part_prose and part_info.smt_part in control_part_id_map:
+                if part_info.smt_part and part_info.prose and part_info.smt_part in control_part_id_map:
                     # avoid outputting ## Part again if in same part
                     if not part_info.smt_part == in_part:
                         in_part = part_info.smt_part
                         part_label = control_part_id_map.get(part_info.smt_part, part_info.smt_part)
                         self._md_file.new_header(level=2, title=f'Part {part_label}')
-                    name = part['name']
-                    title = self._sections_dict.get(name, name) if self._sections_dict else name
-                    self._md_file.new_header(level=3, title=title)
-                    self._md_file.new_paraline(part_prose)
-                    added_sections.append(name)
+                    self._dump_section_info(2, part, added_sections, '')
                 # is it a control part
-                elif part_prose:
+                elif part_info.prose or part_info.parts:
                     in_part = ''
-                    name = part['name']
-                    title = self._sections_dict.get(name, name) if self._sections_dict else name
-                    self._md_file.new_header(level=2, title=f'Control {title}')
-                    self._md_file.new_paraline(part_prose)
-                    added_sections.append(name)
+                    self._dump_section_info(2, part, added_sections, 'Control')
                 elif prop_list:
                     in_part = ''
                     if const.TRESTLE_ADD_PROPS_TAG not in header:

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -252,7 +252,7 @@ class ControlWriter():
 
     def _dump_section_info(self, level: int, part: Dict[str, Any], added_sections: List[str], prefix: str) -> None:
         part_prose = part.get('prose', None)
-        part_subparts = part.get('sub-parts', None)
+        part_subparts = part.get('parts', None)
         name = part['name']
         title = self._sections_dict.get(name, name) if self._sections_dict else name
         title = f'{prefix} {title}' if prefix else title
@@ -373,7 +373,7 @@ class ControlWriter():
                         in_part = part_info.smt_part
                         part_label = control_part_id_map.get(part_info.smt_part, part_info.smt_part)
                         self._md_file.new_header(level=2, title=f'Part {part_label}')
-                    self._dump_section_info(2, part, added_sections, '')
+                    self._dump_section_info(3, part, added_sections, '')
                 # is it a control part
                 elif part_info.prose or part_info.parts:
                     in_part = ''

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -21,7 +21,6 @@ import trestle.oscal.catalog as cat
 import trestle.oscal.profile as prof
 from trestle.core.control_interface import ParameterRep
 from trestle.core.resolver._import import Import
-from trestle.oscal import OSCAL_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +61,4 @@ class ProfileResolver():
         )
         logger.debug('launch pipeline')
         result = next(import_filter.process())
-        result.metadata.oscal_version = OSCAL_VERSION
-        result.metadata.title = f'Resolved profile catalog for profile {profile_path}'
-        result.metadata.links[0].href = str(profile_path)
         return result

--- a/trestle/core/profile_resolver.py
+++ b/trestle/core/profile_resolver.py
@@ -21,6 +21,7 @@ import trestle.oscal.catalog as cat
 import trestle.oscal.profile as prof
 from trestle.core.control_interface import ParameterRep
 from trestle.core.resolver._import import Import
+from trestle.oscal import OSCAL_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -61,4 +62,7 @@ class ProfileResolver():
         )
         logger.debug('launch pipeline')
         result = next(import_filter.process())
+        result.metadata.oscal_version = OSCAL_VERSION
+        result.metadata.title = f'Resolved profile catalog for profile {profile_path}'
+        result.metadata.links[0].href = str(profile_path)
         return result

--- a/trestle/core/resolver/modify.py
+++ b/trestle/core/resolver/modify.py
@@ -20,12 +20,13 @@ from typing import Dict, Iterator, List, Optional
 import trestle.oscal.catalog as cat
 import trestle.oscal.profile as prof
 from trestle.common.common_types import OBT
+from trestle.common.const import RESOLUTION_SOURCE
 from trestle.common.err import TrestleNotFoundError
 from trestle.common.list_utils import as_list
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.control_interface import ControlInterface, ParameterRep
 from trestle.core.pipeline import Pipeline
-from trestle.oscal import common
+from trestle.oscal import OSCAL_VERSION, common
 
 logger = logging.getLogger(__name__)
 
@@ -416,11 +417,15 @@ class Modify(Pipeline.Filter):
 
         # update the original profile metadata with new contents
         # roles and responsible-parties will be pulled in with new uuid's
+        # the title simply becomes the title of the current profile - and will get overwritten
+        # by any other profiles downstream so that only the final profile title is used
         new_metadata = self._profile.metadata
-        new_metadata.title = f'{catalog.metadata.title}: Resolved by profile {self._profile.metadata.title}'
+        new_metadata.title = self._profile.metadata.title
+        new_metadata.oscal_version = OSCAL_VERSION
+
         links: List[common.Link] = []
         for import_ in self._profile.imports:
-            links.append(common.Link(**{'href': import_.href, 'rel': 'resolution-source'}))
+            links.append(common.Link(**{'href': import_.href, 'rel': RESOLUTION_SOURCE}))
         new_metadata.links = links
 
         # move catalog controls from dummy group '' into the catalog


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Previously profile-assemble would add control sections as parts 'after' the statement.  Now they are just added as 'ending' and with no by_id.
Added script to generate resolved profile catalog
Assign correct oscal version in assembled catalog and profile
Changed metadata title and href in resolved profile catalogs

closes #1181 
closes #1188

Added script to create resolved profile catalog from profile.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
