### PR TITLE
fix: Pull display name from the resolved catalog

### DIFF
--- a/tests/data/jinja/profile_to_docs.md.jinja
+++ b/tests/data/jinja/profile_to_docs.md.jinja
@@ -7,6 +7,10 @@ control_writer.write_control_with_sections(control, profile, group_title,
 'objective':'Control Objective Header',
 'ExpectedEvidence':'Control Expected Evidence Header',
 'ImplGuidance':'Implementation Guidance',
-'table_of_parameters':'Table of Control Parameters'}
+'table_of_parameters':'Table of Control Parameters'
+},
+label_column=True,
+add_group_to_title=True
 )
+| safe
 }}

--- a/tests/data/jinja/profile_to_docs_only_some_sections.md.jinja
+++ b/tests/data/jinja/profile_to_docs_only_some_sections.md.jinja
@@ -8,8 +8,7 @@ group_title,
 'objective':'Control Objective Header'
 },
 label_column=True,
-add_group_to_title=True,
-param_dict={'ac-2_prm_1': 'AC-2 Test'}
+add_group_to_title=True
 )
 | safe
 }}

--- a/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
+++ b/tests/data/jinja/profile_to_docs_with_group_title.md.jinja
@@ -12,8 +12,7 @@ group_title,
 'table_of_parameters':'Table of Control Parameters'
 },
 label_column=True,
-add_group_to_title=True,
-param_dict={'ac-2_prm_1': 'AC-2 Test'}
+add_group_to_title=True
 )
 | safe
 }}

--- a/tests/data/jinja/profile_to_docs_with_subparts.md.jinja
+++ b/tests/data/jinja/profile_to_docs_with_subparts.md.jinja
@@ -8,11 +8,11 @@ group_title,
 'objective':'Control Objective Header',
 'ImplGuidance': "The implementation guidance",
 'above_the_line_guidance': "The above the line guidance",
+'add_to_part_a': 'Add to part a',
 'evidence_guidance': "Evidence Guidance"
 },
 label_column=True,
-add_group_to_title=True,
-param_dict={'ac-2_prm_1': 'AC-2 Test'}
+add_group_to_title=True
 )
 | safe
 }}

--- a/tests/data/json/test_profile_a.json
+++ b/tests/data/json/test_profile_a.json
@@ -43,12 +43,26 @@
           "param-id": "ac-1_prm_1",
             "values": [
               "all alert personnel"
-            ]
+            ],
+            "props": [
+            {
+              "name": "display-name",
+              "ns": "http://www.ibm.com",
+              "value": "AC-1 (a) (1)"
+            }
+          ]
         },
         {  "param-id": "ac-1_prm_2",
             "values": [
               "A thorough"
-            ]
+            ],
+            "props": [
+            {
+              "name": "display-name",
+              "ns": "http://www.ibm.com",
+              "value": "AC-1 (a) (2)"
+            }
+          ]
         },
         {  "param-id": "ac-1_prm_3",
             "values": [
@@ -73,7 +87,14 @@
         {  "param-id": "ac-2_prm_1",
             "values": [
               "passwords"
-            ]
+            ],
+            "props": [
+            {
+              "name": "display-name",
+              "ns": "http://www.ibm.com",
+              "value": "AC-2 (a) (1)"
+            }
+          ]
         },
         {  "param-id": "ac-2_prm_2",
             "values": [
@@ -93,7 +114,14 @@
         {  "param-id": "ac-2_prm_5",
             "values": [
               "personnel"
-            ]
+            ],
+            "props": [
+            {
+              "name": "display-name",
+              "ns": "http://www.ibm.com",
+              "value": "AC-2 (a) (5)"
+            }
+          ]
         },
         {  "param-id": "ac-2_prm_6",
             "values": [

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -197,7 +197,9 @@ def test_jinja_profile_docs_with_group_title(
         assert node3
         assert '{: #table-of-control-parameters}' in node3.content.raw_text  # noqa: FS003 - not f string but tag
         assert '{: #"Parameters for AC-2" caption-side="top"}' in node3.content.raw_text  # noqa: FS003 - not f string
-        assert 'AC-2 Test' in node3.content.tables[2]
+        assert 'AC-2 (a) (1)' in node3.content.tables[2]
+        assert 'AC-2 (a) (5)' in node3.content.tables[6]
+        assert 'ac-2_prm_3' in node3.content.tables[4]
 
 
 def test_jinja_profile_docs_with_selected_sections(
@@ -246,7 +248,7 @@ def test_jinja_profile_docs_with_selected_sections_and_multiple_parts(
         assert tree
         node1 = tree.get_node_for_key('## The above the line guidance')
         assert node1
-        node2 = tree.get_node_for_key('### add_to_part_a')
+        node2 = tree.get_node_for_key('### Add to part a')
         assert node2
         node3 = tree.get_node_for_key('#### Evidence Guidance')
         assert node3

--- a/trestle/common/list_utils.py
+++ b/trestle/common/list_utils.py
@@ -26,7 +26,7 @@ def as_list(list_or_none: Optional[List[TG]]) -> List[TG]:
 
 def as_filtered_list(list_or_none: Optional[List[TG]], filter_condition: Callable[[TG], bool]) -> List[TG]:
     """Convert to list and filter based on the condition."""
-    result_list = list_or_none if list_or_none else []
+    result_list = as_list(list_or_none)
     result_list = list(filter(filter_condition, result_list))
     return result_list
 

--- a/trestle/common/list_utils.py
+++ b/trestle/common/list_utils.py
@@ -24,6 +24,13 @@ def as_list(list_or_none: Optional[List[TG]]) -> List[TG]:
     return list_or_none if list_or_none else []
 
 
+def as_filtered_list(list_or_none: Optional[List[TG]], filter_condition: Callable[[TG], bool]) -> List[TG]:
+    """Convert to list and filter based on the condition."""
+    result_list = list_or_none if list_or_none else []
+    result_list = list(filter(filter_condition, result_list))
+    return result_list
+
+
 def as_dict(dict_or_none: Optional[Dict[TG, TG2]]) -> Dict[TG, TG2]:
     """Convert dict or None object to itself or an empty dict if none."""
     return dict_or_none if dict_or_none else {}

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -544,18 +544,6 @@ class CatalogInterface():
         return set_param_dict
 
     @staticmethod
-    def get_profile_displayname_param_dict(profile: prof.Profile) -> Dict[str, str]:
-        """Get the mapping of param_id to display-name set in the properties of set-params."""
-        displayname_dict: Dict[str, str] = {}
-        if profile.modify:
-            for set_param in as_list(profile.modify.set_parameters):
-                for prop in as_list(set_param.props):
-                    if prop.name == 'display-name':
-                        displayname_dict[set_param.param_id] = prop.value
-
-        return displayname_dict
-
-    @staticmethod
     def _get_profile_param_dict(
         control: cat.Control, profile_param_dict: Dict[str, common.Parameter], values_only: bool
     ) -> Dict[str, common.Parameter]:

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -218,7 +218,6 @@ class JinjaCmd(CommandPlusDocs):
             trestle_root, profile_path, False, False, parameters_formatting
         )
         catalog_interface = CatalogInterface(resolved_catalog)
-        param_dict = catalog_interface.get_profile_displayname_param_dict(profile)
 
         # Generate a single markdown page for each control per each group
         for group in catalog_interface.get_all_groups_from_catalog():
@@ -245,7 +244,6 @@ class JinjaCmd(CommandPlusDocs):
                 lut['control_writer'] = control_writer
                 lut['control'] = control
                 lut['profile'] = profile
-                lut['displayname_param_dict'] = param_dict
                 lut['group_title'] = group_title
                 output = JinjaCmd.render_template(template, lut, template_folder)
 

--- a/trestle/core/docs_control_writer.py
+++ b/trestle/core/docs_control_writer.py
@@ -20,7 +20,7 @@ import trestle.oscal.catalog as cat
 import trestle.oscal.profile as prof
 from trestle.common import const
 from trestle.common.err import TrestleError
-from trestle.common.list_utils import as_list
+from trestle.common.list_utils import as_filtered_list, as_list
 from trestle.core.control_interface import ControlInterface, ParameterRep, PartInfo
 from trestle.core.control_writer import ControlWriter
 from trestle.core.markdown.md_writer import MDWriter
@@ -39,8 +39,7 @@ class DocsControlWriter(ControlWriter):
         sections: List[str],
         sections_dict: Optional[Dict[str, str]] = None,
         label_column: bool = True,
-        add_group_to_title: bool = False,
-        param_dict: Dict[str, str] = None
+        add_group_to_title: bool = False
     ) -> str:
         """Write the control into markdown file with specified sections."""
         self._md_file = MDWriter(None)
@@ -58,12 +57,7 @@ class DocsControlWriter(ControlWriter):
 
             elif 'table_of_parameters' == section:
                 self.get_param_table(
-                    control,
-                    label_column,
-                    section_dict=sections_dict,
-                    tag_pattern=tag_pattern,
-                    param_displayname=param_dict,
-                    md_file=self._md_file
+                    control, label_column, section_dict=sections_dict, tag_pattern=tag_pattern, md_file=self._md_file
                 )
             else:
                 self._add_one_section(control, profile, section, tag_pattern=tag_pattern)
@@ -82,15 +76,14 @@ class DocsControlWriter(ControlWriter):
         label_column: bool = False,
         section_dict: Optional[Dict[str, str]] = None,
         tag_pattern: str = None,
-        param_displayname: str = None,
         md_file: MDWriter = None
     ) -> List[str]:
         """Get parameters of a control as a markdown table for ssp_io, with optional third label column."""
 
         def _get_displayname_if_exists(param_id: str) -> str:
-            if param_displayname:
-                if param_id in param_displayname:
-                    return param_displayname[param_id]
+            for param in as_filtered_list(control.params, lambda p: p.id == param_id):
+                for prop in as_filtered_list(param.props, lambda p: p.name == const.DISPLAY_NAME):
+                    return prop.value
             return param_id
 
         param_dict = ControlInterface.get_control_param_dict(control, False)


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
- Fixed a bug where display-name for the parameters was pulled from the profile instead of the resolved catalog.
- Test that parts can be renamed via Jinja

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
