### PR TITLE
feat: added new parameter rep ASSIGNMENT_FORM to leave params in brackets with text

### DIFF
--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -112,9 +112,12 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
                 if len(cells) < 2:
                     continue
                 value = cells[2].strip()
+                # parameter values now do not appear in the prose
+                if value == 'Param_1_value_in_catalog':
+                    continue
                 is_found = False
                 for line in child2.content.text:
-                    if '*' + value + '*' in line:
+                    if value in line:
                         is_found = True
                         break
                 assert is_found
@@ -134,9 +137,12 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
             if len(cells) < 2:
                 continue
             value = cells[2].strip()
+            # parameter values now do not appear in the prose
+            if value == 'Param_1_value_in_catalog':
+                continue
             is_found = False
             for line in child2.content.text:
-                if 'Prefix:' + value in line:
+                if 'Prefix:' in line and value in line:
                     is_found = True
                     break
             assert is_found

--- a/tests/trestle/core/control_io_test.py
+++ b/tests/trestle/core/control_io_test.py
@@ -372,10 +372,10 @@ def test_get_control_param_dict(tmp_trestle_dir: pathlib.Path) -> None:
     ) == 'choice 1; choice 2'
     assert ControlInterface.param_to_str(
         param_dict['ac-1_prm_1'], ParameterRep.VALUE_OR_LABEL_OR_CHOICES, True
-    ) == 'Choose one or more: choice 1; choice 2'
+    ) == 'Selection (one or more): choice 1; choice 2'
     assert ControlInterface.param_to_str(
         param_dict['ac-1_prm_1'], ParameterRep.VALUE_OR_LABEL_OR_CHOICES, True, True
-    ) == 'Choose one or more: [choice 1; choice 2]'
+    ) == 'Selection (one or more): [choice 1; choice 2]'
 
 
 @pytest.mark.parametrize('overwrite_header_values', [True, False])

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -232,6 +232,17 @@ def test_replace_params(param_id, param_text, prose, result) -> None:
     assert ControlInterface._replace_ids_with_text(prose, ParameterRep.VALUE_OR_STRING_NONE, param_dict) == result
 
 
+def test_replace_params_assignment_mode(simplified_nist_catalog: cat.Catalog) -> None:
+    """Test replacement of params in assignment mode."""
+    cat_interface = CatalogInterface(simplified_nist_catalog)
+    param_dict = cat_interface._get_full_param_dict()
+    ac_44 = cat_interface.get_control('ac-4.4')
+    ControlInterface.replace_control_prose(ac_44, param_dict, None, ParameterRep.ASSIGNMENT_FORM)
+    assert ac_44.parts[
+        0
+    ].prose == 'Prevent encrypted information from bypassing [Assignment: organization-defined information flow control mechanisms] by [Selection (one or more): decrypting the information; blocking the flow of the encrypted information; terminating communications sessions attempting to pass encrypted information; [Assignment: organization-defined procedure or method]].'  # noqa:E501
+
+
 def test_profile_resolver_param_sub() -> None:
     """Test profile resolver param sub via regex."""
     id_1 = 'ac-2_smt.1'

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -29,12 +29,11 @@ from trestle.common.err import TrestleError
 from trestle.common.model_utils import ModelUtils
 from trestle.core import generators as gens
 from trestle.core.catalog_interface import CatalogInterface
-from trestle.core.control_interface import ParameterRep
+from trestle.core.control_interface import ControlInterface, ParameterRep
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.profile_resolver import ProfileResolver
 from trestle.core.repository import Repository
 from trestle.core.resolver.merge import Merge
-from trestle.core.resolver.modify import Modify
 from trestle.oscal import OSCAL_VERSION
 from trestle.oscal import catalog as cat
 from trestle.oscal import common as com
@@ -230,7 +229,7 @@ def test_replace_params(param_id, param_text, prose, result) -> None:
     param = com.Parameter(id=param_id, values=[com.ParameterValue(__root__=param_text)])
     param_10 = com.Parameter(id='ac-2_smt.10', values=[com.ParameterValue(__root__='my 10 str')])
     param_dict = {param_id: param, 'ac-1_smt.10': param_10}
-    assert Modify._replace_ids_with_text(prose, ParameterRep.VALUE_OR_STRING_NONE, param_dict) == result
+    assert ControlInterface._replace_ids_with_text(prose, ParameterRep.VALUE_OR_STRING_NONE, param_dict) == result
 
 
 def test_profile_resolver_param_sub() -> None:
@@ -242,7 +241,7 @@ def test_profile_resolver_param_sub() -> None:
 
     param_text = 'Make sure that {{insert: param, ac-2_smt.1}} is very {{ac-2_smt.10}} today.  Very {{ac-2_smt.10}}!'
     param_dict = {id_1: param_1, id_10: param_10}
-    new_text = Modify._replace_params(param_text, param_dict)
+    new_text = ControlInterface._replace_params(param_text, param_dict)
     assert new_text == 'Make sure that the cat is very well fed today.  Very well fed!'
 
 

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -564,6 +564,20 @@ class CatalogInterface():
                 param_dict[key] = profile_param_dict[key]
         return param_dict
 
+    def _get_full_param_dict(self) -> Dict[str, common.Parameter]:
+        param_dict: Dict[str, common.Parameter] = {}
+        # build the full mapping of params to values from the catalog interface
+        for control in self.get_all_controls_from_dict():
+            param_dict.update(ControlInterface.get_control_param_dict(control, False))
+        return param_dict
+
+    def _change_prose_with_param_values(self, param_format, param_rep, show_value_warnings: bool) -> None:
+        """Go through all controls and change prose based on param values."""
+        param_dict = self._get_full_param_dict()
+        # insert param values into prose of all controls
+        for control in self.get_all_controls_from_dict():
+            ControlInterface.replace_control_prose(control, param_dict, param_format, param_rep, show_value_warnings)
+
     @staticmethod
     def _get_display_name_and_ns(param: common.Parameter) -> Tuple[Optional[str], Optional[str]]:
         for prop in as_list(param.props):

--- a/trestle/core/commands/author/jinja.py
+++ b/trestle/core/commands/author/jinja.py
@@ -33,7 +33,7 @@ from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog_interface import CatalogInterface
 from trestle.core.commands.command_docs import CommandPlusDocs
 from trestle.core.commands.common.return_codes import CmdReturnCodes
-from trestle.core.control_interface import ControlInterface
+from trestle.core.control_interface import ControlInterface, ParameterRep
 from trestle.core.docs_control_writer import DocsControlWriter
 from trestle.core.jinja import MDCleanInclude, MDDatestamp, MDSectionInclude
 from trestle.core.profile_resolver import ProfileResolver
@@ -177,7 +177,7 @@ class JinjaCmd(CommandPlusDocs):
             profile_path = ModelUtils.full_path_for_top_level_model(trestle_root, profile, Profile)
             profile_resolver = ProfileResolver()
             resolved_catalog = profile_resolver.get_resolved_profile_catalog(
-                trestle_root, profile_path, False, False, parameters_formatting
+                trestle_root, profile_path, False, False, parameters_formatting, ParameterRep.ASSIGNMENT_FORM
             )
 
             ssp_writer = SSPMarkdownWriter(trestle_root)
@@ -215,7 +215,7 @@ class JinjaCmd(CommandPlusDocs):
         profile, profile_path = ModelUtils.load_top_level_model(trestle_root, profile_name, Profile)
         profile_resolver = ProfileResolver()
         resolved_catalog = profile_resolver.get_resolved_profile_catalog(
-            trestle_root, profile_path, False, False, parameters_formatting
+            trestle_root, profile_path, False, False, parameters_formatting, ParameterRep.ASSIGNMENT_FORM
         )
         catalog_interface = CatalogInterface(resolved_catalog)
 

--- a/trestle/core/docs_control_writer.py
+++ b/trestle/core/docs_control_writer.py
@@ -181,7 +181,7 @@ class DocsControlWriter(ControlWriter):
         self, control: cat.Control, profile: prof.Profile, section: str, tag_pattern: Optional[str] = None
     ) -> None:
         """Add specific control section."""
-        prose = ControlInterface._get_control_section_prose(control, section)
+        prose = ControlInterface.get_control_section_prose(control, section)
         if prose:
             section_title = self._sections_dict.get(section, section)
             heading_title = f'{section_title}'

--- a/trestle/core/resolver/modify.py
+++ b/trestle/core/resolver/modify.py
@@ -14,7 +14,6 @@
 """Create resolved catalog from profile."""
 
 import logging
-import re
 from typing import Dict, Iterator, List, Optional
 
 import trestle.oscal.catalog as cat
@@ -54,108 +53,6 @@ class Modify(Pipeline.Filter):
         self._param_rep = param_rep
         self.show_value_warnings = show_value_warnings
         logger.debug(f'modify initialize filter with profile {profile.metadata.title}')
-
-    @staticmethod
-    def _replace_ids_with_text(prose: str, param_rep: ParameterRep, param_dict: Dict[str, common.Parameter]) -> str:
-        """Find all instances of param_ids in prose and replace each with corresponding parameter representation.
-
-        Need to check all values in dict for a match
-        Reject matches where the string has an adjacent alphanumeric char: param_1 and param_10 or aparam_1
-        """
-        for param in param_dict.values():
-            if param.id not in prose:
-                continue
-            # create the replacement text for the param_id
-            param_str = ControlInterface.param_to_str(param, param_rep)
-            # non-capturing groups are odd in re.sub so capture all 3 groups and replace the middle one
-            pattern = r'(^|[^a-zA-Z0-9_])' + param.id + r'($|[^a-zA-Z0-9_])'
-            prose = re.sub(pattern, r'\1' + param_str + r'\2', prose)
-        return prose
-
-    @staticmethod
-    def _replace_params(
-        text: str,
-        param_dict: Dict[str, common.Parameter],
-        params_format: Optional[str] = None,
-        param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES,
-        show_value_warnings: bool = False
-    ) -> str:
-        """
-        Replace params found in moustaches with values from the param_dict.
-
-        A single line of prose may contain multiple moustaches.
-        """
-        # first check if there are any moustache patterns in the text
-        if param_rep == ParameterRep.LEAVE_MOUSTACHE:
-            return text
-        staches: List[str] = re.findall(r'{{.*?}}', text)
-        if not staches:
-            return text
-        # now have list of all staches including braces, e.g. ['{{foo}}', '{{bar}}']
-        # clean the staches so they just have the param ids
-        param_ids = []
-        for stache in staches:
-            # remove braces so these are just param_ids but may have extra chars
-            stache_contents = stache[2:(-2)]
-            param_id = stache_contents.replace('insert: param,', '').strip()
-            param_ids.append(param_id)
-
-        # now replace original stache text with param values
-        for i, _ in enumerate(staches):
-            # A moustache may refer to a param_id not listed in the control's params
-            if param_ids[i] not in param_dict:
-                if show_value_warnings:
-                    logger.warning(f'Control prose references param {param_ids[i]} not set in the control: {staches}')
-            elif param_dict[param_ids[i]] is not None:
-                param = param_dict[param_ids[i]]
-                param_str = ControlInterface.param_to_str(param, param_rep, False, False, params_format)
-                text = text.replace(staches[i], param_str, 1).strip()
-                if show_value_warnings and param_rep != ParameterRep.LABEL_OR_CHOICES and not param.values:
-                    logger.warning(f'Parameter {param_id} has no values and was referenced by prose.')
-            elif show_value_warnings:
-                logger.warning(f'Control prose references param {param_ids[i]} with no specified value.')
-        return text
-
-    @staticmethod
-    def _replace_part_prose(
-        control: cat.Control,
-        part: common.Part,
-        param_dict: Dict[str, common.Parameter],
-        params_format: Optional[str] = None,
-        param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES,
-        show_value_warnings: bool = False
-    ) -> None:
-        """Replace the part prose according to set_param."""
-        if part.prose is not None:
-            fixed_prose = Modify._replace_params(part.prose, param_dict, params_format, param_rep, show_value_warnings)
-            # change the prose in the control itself
-            part.prose = fixed_prose
-        for prt in as_list(part.parts):
-            Modify._replace_part_prose(control, prt, param_dict, params_format, param_rep, show_value_warnings)
-        for sub_control in as_list(control.controls):
-            for prt in as_list(sub_control.parts):
-                Modify._replace_part_prose(sub_control, prt, param_dict, params_format, param_rep, show_value_warnings)
-
-    @staticmethod
-    def _replace_control_prose(
-        control: cat.Control,
-        param_dict: Dict[str, common.Parameter],
-        params_format: Optional[str] = None,
-        param_rep: ParameterRep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES,
-        show_value_warnings: bool = False
-    ) -> None:
-        """Replace the control prose according to set_param."""
-        for param in as_list(control.params):
-            Modify._replace_param_choices(param, param_dict, show_value_warnings)
-        for part in as_list(control.parts):
-            if part.prose is not None:
-                fixed_prose = Modify._replace_params(
-                    part.prose, param_dict, params_format, param_rep, show_value_warnings
-                )
-                # change the prose in the control itself
-                part.prose = fixed_prose
-            for prt in as_list(part.parts):
-                Modify._replace_part_prose(control, prt, param_dict, params_format, param_rep, show_value_warnings)
 
     @staticmethod
     def _add_adds_to_part(part: common.Part, add: prof.Add, added_parts=False) -> None:
@@ -348,21 +245,9 @@ class Modify(Pipeline.Filter):
         param_dict.update(self._catalog_interface.loose_param_dict)
         # insert param values into prose of all controls
         for control in self._catalog_interface.get_all_controls_from_dict():
-            self._replace_control_prose(
+            ControlInterface._replace_control_prose(
                 control, param_dict, self._params_format, self._param_rep, self.show_value_warnings
             )
-
-    @staticmethod
-    def _replace_param_choices(
-        param: common.Parameter, param_dict: Dict[str, common.Parameter], show_value_warnings: bool
-    ) -> None:
-        """Set values for all choices param that refer to params with values."""
-        if param.select:
-            new_choices: List[str] = []
-            for choice in as_list(param.select.choice):
-                new_choice = Modify._replace_params(choice, param_dict, show_value_warnings)
-                new_choices.append(new_choice)
-            param.select.choice = new_choices
 
     def _modify_controls(self, catalog: cat.Catalog) -> cat.Catalog:
         """Modify the controls based on the profile."""


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Provided new ASSIGNMENT_FORM parameter rep and made it default for the jinja output of the resolved profile catalog
Refactored functions from Modify to ControlInterface and made some functions public
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
