### PR TITLE
fix: prof resolve should use moustache form as default

### DIFF
--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -824,7 +824,7 @@ def test_profile_resolve(tmp_trestle_dir: pathlib.Path, show_values: bool, monke
     if show_values:
         expected_prose = 'Designate an officer to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
     else:
-        expected_prose = 'Designate an [Assignment: organization-defined official] to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+        expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
     assert ac_1.parts[0].parts[1].prose == expected_prose
 
 

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -470,14 +470,14 @@ class ProfileResolve(AuthorCommonCommand):
             trestle_root: Root directory of the trestle workspace
             profile_path: Path of the profile json file
             catalog_name: Name of the resolved profile catalog
-            show_values: If true, show values of parameters in prose rather than [Assignment:] form
+            show_values: If true, show values of parameters in prose rather than original {{}} form
 
         Returns:
             0 on success and raises exception on error
         """
         if not profile_path.exists():
             raise TrestleNotFoundError(f'Cannot resolve profile catalog: profile {profile_path} does not exist.')
-        param_rep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES if show_values else ParameterRep.ASSIGNMENT_FORM
+        param_rep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES if show_values else ParameterRep.LEAVE_MOUSTACHE
         catalog = ProfileResolver().get_resolved_profile_catalog(
             trestle_root, profile_path, False, False, None, param_rep
         )


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
For CLI profile-resolve command, default mode is now to leave moustaches in prose
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
