### PR TITLE
fix: add profile title to comp-generate md and remove profile option

### DIFF
--- a/tests/data/json/comp_def.json
+++ b/tests/data/json/comp_def.json
@@ -97,51 +97,51 @@
                 "value": "0.1.58"
               },
               {
-                "name": "rule_name_id",
+                "name": "Rule_Id",
                 "ns": "http://foo_ns",
                 "value": "XCCDF",
-                "class": "rule_name_id",
+                "class": "Rule_Id",
                 "remarks": "rule_1"
               },
               {
-                "name": "rule_description",
+                "name": "Rule_Description",
                 "ns": "http://foo_ns",
                 "value": "The XCCDF must be compliant",
                 "remarks": "rule_1"
               },
               {
-                "name": "rule_name_id",
+                "name": "Rule_Id",
                 "ns": "http://foo_ns",
                 "value": "FancyXtraRule",
-                "class": "rule_name_id",
+                "class": "Rule_Id",
                 "remarks": "rule_2"
               },
               {
-                "name": "rule_description",
+                "name": "Rule_Description",
                 "ns": "http://foo_ns",
                 "value": "This is a fancy extra rule",
-                "class": "rule_description",
+                "class": "Rule_Description",
                 "remarks": "rule_2"
               },
               {
-                "name": "param_id",
+                "name": "Parameter_Id",
                 "ns": "http://foo_ns",
                 "value": "foo_length",
-                "class": "param_id",
+                "class": "Parameter_Id",
                 "remarks": "rule_1"
               },
               {
-                "name": "param_description",
+                "name": "Parameter_Description",
                 "ns": "http://foo_ns",
                 "value": "minimum_foo_length",
-                "class": "param_description",
+                "class": "Parameter_Description",
                 "remarks": "rule_1"
               },
               {
-                "name": "param_options",
+                "name": "Parameter_Value_Alternatives",
                 "ns": "http://foo_ns",
                 "value": "[\"6\", \"9\"]",
-                "class": "param_options",
+                "class": "Parameter_Value_Alternatives",
                 "remarks": "rule_1"
               }
             ],
@@ -161,12 +161,12 @@
                 "description": "Ensure that the API server pod specification file permissions are set to 644 or more restrictive",
                 "props": [
                   {
-                    "name": "rule-name-id",
+                    "name": "Rule_Id",
                     "value": "XCCDF"
                   },
                   {
                     "name": "implementation-status",
-                    "value": "operational",
+                    "value": "implemented",
                     "remarks": "ac1 remark"
                   }
                 ],
@@ -199,7 +199,7 @@
                     "props": [
                       {
                         "name": "implementation-status",
-                        "value": "under-development"
+                        "value": "partial"
                       }
                     ]
                   }
@@ -424,20 +424,20 @@
                 "description": "Ensure that garbage collection is configured as appropriate",
                 "props": [
                   {
-                    "name": "rule_name_id",
+                    "name": "Rule_Id",
                     "ns": "http://foo_ns",
-                    "class": "rule_name_id",
+                    "class": "Rule_Id",
                     "value": "XCCDF"
                   },
                   {
-                    "name": "rule_name_id",
+                    "name": "Rule_Id",
                     "ns": "http://foo_ns",
-                    "class": "rule_name_id",
+                    "class": "Rule_Id",
                     "value": "FancyXtraRule"
                   },
                   {
                     "name": "implementation-status",
-                    "value": "under-development",
+                    "value": "partial",
                     "remarks": "this is my remark"
                   }
                 ],
@@ -466,14 +466,14 @@
               {
                 "uuid": "c1541519-ba7e-44ca-afd0-4068d307a9b0",
                 "control-id": "ac-2.13",
-                "description": "Ensure that garbage collection is configured as appropriate",
+                "description": "Ensure that temperature is ok.",
                 "set-parameters": [
                   {
-                    "param-id": "kubelet_eviction_thresholds_set_soft_nodefs_available",
+                    "param-id": "temperature_tolerance",
                     "values": [
                       "10%"
                     ],
-                    "remarks": "Node FS Available for the EvictionSoft threshold to trigger."
+                    "remarks": "Keep it cool."
                   }
                 ],
                 "responsible-roles": [

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -19,8 +19,6 @@ from typing import Any, Dict, Tuple
 
 from _pytest.monkeypatch import MonkeyPatch
 
-import pytest
-
 from tests import test_utils
 
 import trestle.core.generic_oscal as generic
@@ -81,6 +79,8 @@ def check_common_contents(header: Dict[str, Any]) -> None:
     vals = header[const.COMP_DEF_PARAM_VALS_TAG]
     assert len(vals) == 1
     assert vals == {'quantity_available': '500'}
+    assert header[const.TRESTLE_GLOBAL_TAG][
+        const.PROFILE_TITLE] == 'NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE'  # noqa E501
 
 
 def check_ac1_contents(ac1_path: pathlib.Path) -> None:
@@ -110,16 +110,13 @@ def check_ac5_contents(ac5_path: pathlib.Path) -> None:
     check_common_contents(header)
 
 
-@pytest.mark.parametrize('profile_arg', [True, False])
-def test_component_generate(tmp_trestle_dir: pathlib.Path, profile_arg: bool, monkeypatch: MonkeyPatch) -> None:
+def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test component generate."""
-    comp_name, prof_name, _ = setup_component_generate(tmp_trestle_dir)
+    comp_name, _, _ = setup_component_generate(tmp_trestle_dir)
     ac1_path = tmp_trestle_dir / f'{md_path}/OSCO/ac/ac-1.md'
     ac5_path = tmp_trestle_dir / f'{md_path}/OSCO/ac/ac-5.md'
 
     generate_cmd = f'trestle author component-generate -n {comp_name} -o {md_path}'
-    if profile_arg:
-        generate_cmd += f' -p {prof_name}'
 
     # generate the md first time
     test_utils.execute_command_and_assert(generate_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -134,7 +134,10 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
     # all files should be the same
     assert file_checker.files_unchanged()
 
-    # make edits to status and remarks
+    # make edits to status and remarks and control level prose
+    assert test_utils.substitute_text_in_file(ac1_path, '644', '567')
+    control_prose = '567 or more restrictive'
+    assert test_utils.confirm_text_in_file(ac1_path, 'Enter possible prose', control_prose)
     assert test_utils.substitute_text_in_file(ac5_path, 'Status: partial', 'Status: implemented')
     assert test_utils.confirm_text_in_file(ac5_path, 'garbage collection', 'Status: implemented')
     assert test_utils.substitute_text_in_file(ac5_path, 'my remark', 'my new remark')
@@ -154,6 +157,9 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
     new_status = ControlInterface.get_status_from_props(imp_reqs[0])
     assert new_status.state == 'implemented'
     assert new_status.remarks.__root__ == 'this is my new remark'
+    imp_reqs = ControlInterface.get_control_imp_reqs(component, 'ac-1')
+    assert control_prose in imp_reqs[0].description
+
     orig_uuid = assem_comp_def.uuid
 
     orig_file_creation = orig_comp_def_path.stat().st_mtime

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -69,13 +69,9 @@ def setup_component_generate(trestle_root: pathlib.Path) -> Tuple[pathlib.Path, 
 
 def check_common_contents(header: Dict[str, Any]) -> None:
     """Check common features of controls markdown."""
-    rules = header[const.COMP_DEF_RULES_TAG]
-    assert len(rules) == 2
-    assert rules[0] == {'name': 'XCCDF', 'description': 'The XCCDF must be compliant'}
-    assert rules[1] == {'name': 'FancyXtraRule', 'description': 'This is a fancy extra rule'}
     params = header[const.COMP_DEF_PARAMS_TAG]
     assert len(params) == 1
-    assert params[0] == {'XCCDF': {'name': 'foo_length', 'description': 'minimum_foo_length', 'options': '["6", "9"]'}}
+    assert params[0] == {'name': 'foo_length', 'description': 'minimum_foo_length', 'options': '["6", "9"]'}
     vals = header[const.COMP_DEF_PARAM_VALS_TAG]
     assert len(vals) == 1
     assert vals == {'quantity_available': '500'}
@@ -86,13 +82,16 @@ def check_common_contents(header: Dict[str, Any]) -> None:
 def check_ac1_contents(ac1_path: pathlib.Path) -> None:
     """Check the contents of ac-1 md."""
     assert test_utils.confirm_text_in_file(ac1_path, 'enter one of:', 'set to 644')
-    assert test_utils.confirm_text_in_file(ac1_path, 'set to 644', 'Status: operational')
-    assert test_utils.confirm_text_in_file(ac1_path, 'Status: operational', 'ac1 remark')
-    assert test_utils.confirm_text_in_file(ac1_path, 'ac-1_smt.c', 'Status: other')
+    assert test_utils.confirm_text_in_file(ac1_path, 'set to 644', 'Status: implemented')
+    assert test_utils.confirm_text_in_file(ac1_path, 'Status: implemented', 'ac1 remark')
+    assert test_utils.confirm_text_in_file(ac1_path, 'ac-1_smt.c', 'Status: planned')
     markdown_processor = MarkdownProcessor()
     header, _ = markdown_processor.read_markdown_wo_processing(ac1_path)
     assert header[const.SET_PARAMS_TAG]['ac-1_prm_1']['label'] == 'organization-defined personnel or roles'
     assert header[const.SET_PARAMS_TAG]['ac-1_prm_1']['values'] == 'Param_1_value_in_catalog'
+    rules = header[const.COMP_DEF_RULES_TAG]
+    assert len(rules) == 1
+    assert rules[0] == {'name': 'XCCDF', 'description': 'The XCCDF must be compliant'}
     check_common_contents(header)
 
 
@@ -103,10 +102,12 @@ def check_ac5_contents(ac5_path: pathlib.Path) -> None:
     assert header[const.SET_PARAMS_TAG
                   ]['ac-5_prm_1']['label'] == 'organization-defined duties of individuals requiring separation'
     assert test_utils.confirm_text_in_file(
-        ac5_path,
-        '### Implementation Status: under-development',
-        '### Implementation Status Remarks: this is my remark'
+        ac5_path, '### Implementation Status: partial', '### Implementation Status Remarks: this is my remark'
     )
+    rules = header[const.COMP_DEF_RULES_TAG]
+    assert len(rules) == 2
+    assert rules[0] == {'name': 'XCCDF', 'description': 'The XCCDF must be compliant'}
+    assert rules[1] == {'name': 'FancyXtraRule', 'description': 'This is a fancy extra rule'}
     check_common_contents(header)
 
 
@@ -134,7 +135,7 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
     assert file_checker.files_unchanged()
 
     # make edits to status and remarks
-    assert test_utils.substitute_text_in_file(ac5_path, 'Status: under-development', 'Status: implemented')
+    assert test_utils.substitute_text_in_file(ac5_path, 'Status: partial', 'Status: implemented')
     assert test_utils.confirm_text_in_file(ac5_path, 'garbage collection', 'Status: implemented')
     assert test_utils.substitute_text_in_file(ac5_path, 'my remark', 'my new remark')
     assert test_utils.confirm_text_in_file(ac5_path, 'garbage collection', 'my new remark')

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -386,6 +386,10 @@ STATUS_ALL = [
 
 STATUS_PROMPT = f'<!-- For implementation status enter one of: {STATUS_IMPLEMENTED}, {STATUS_PARTIAL}, {STATUS_PLANNED}, {STATUS_ALTERNATIVE}, {STATUS_NOT_APPLICABLE} -->'  # noqa E501
 
+RULES_WARNING = '<!-- Note that the list of rules under ### Rules: is read-only and changes will not be captured after assembly to JSON -->'  # noqa E501
+
+CONTROL_PROSE_PROMPT = '<!-- Enter possible prose for implementation response at the control level here, after this comment -->'  # noqa E501
+
 RESPONSIBLE_ROLE = 'responsible-role'
 
 RESPONSIBLE_ROLES = 'responsible-roles'

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -384,7 +384,7 @@ STATUS_ALL = [
     STATUS_UNDER_MAJOR_MODIFICATION
 ]
 
-STATUS_PROMPT = f'<!-- For implementation status enter one of: {STATUS_OPERATIONAL} {STATUS_UNDER_DEVELOPMENT} {STATUS_DISPOSITION} {STATUS_OTHER} -->'  # noqa E501
+STATUS_PROMPT = f'<!-- For implementation status enter one of: {STATUS_IMPLEMENTED}, {STATUS_PARTIAL}, {STATUS_PLANNED}, {STATUS_ALTERNATIVE}, {STATUS_NOT_APPLICABLE} -->'  # noqa E501
 
 RESPONSIBLE_ROLE = 'responsible-role'
 
@@ -446,3 +446,13 @@ DISPLAY_NAME = 'display-name'
 RESOLUTION_SOURCE = 'resolution-source'
 
 TRESTLE_INHERITED_PROPS = 'trestle_inherited_props'
+
+RULE_ID = 'Rule_Id'
+
+RULE_DESCRIPTION = 'Rule_Description'
+
+PARAMETER_ID = 'Parameter_Id'
+
+PARAMETER_DESCRIPTION = 'Parameter_Description'
+
+PARAMETER_VALUE_ALTERNATIVES = 'Parameter_Value_Alternatives'

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -834,6 +834,26 @@ class ModelUtils:
         return equivalent
 
     @staticmethod
+    def imp_reqs_are_equivalent(imp_a: comp.ImplementedRequirement, imp_b: comp.ImplementedRequirement) -> bool:
+        """Determine if imp_reqs are equivalent."""
+        if imp_a.props != imp_b.props:
+            return False
+        if imp_a.set_parameters != imp_b.set_parameters:
+            return False
+        if imp_a.remarks != imp_b.remarks:
+            return False
+        if len(as_list(imp_a.statements)) != len(as_list(imp_b.statements)):
+            return False
+        for kk, state_a in enumerate(as_list(imp_a.statements)):
+            state_b = imp_b.statements[kk]
+            b_uuid, state_b.uuid = state_b.uuid, state_a.uuid
+            statements_equiv = state_a == state_b
+            state_b.uuid = b_uuid
+            if not statements_equiv:
+                return False
+        return True
+
+    @staticmethod
     def component_defs_are_equivalent(
         model_a: Optional[comp.ComponentDefinition], model_b: Optional[comp.ComponentDefinition]
     ) -> bool:
@@ -855,19 +875,13 @@ class ModelUtils:
                 return False
             for jj, cimp_a in enumerate(as_list(c_a.control_implementations)):
                 cimp_b = c_b.control_implementations[jj]
+                if cimp_a.props != cimp_b.props:
+                    return False
+                if cimp_a.set_parameters != cimp_b.set_parameters:
+                    return False
                 if len(as_list(cimp_a.implemented_requirements)) != len(as_list(cimp_b.implemented_requirements)):
                     return False
                 for kk, imp_a in enumerate(as_list(cimp_a.implemented_requirements)):
-                    imp_b = cimp_b.implemented_requirements[kk]
-                    if len(as_list(imp_a.statements)) != len(as_list(imp_b.statements)):
+                    if not ModelUtils.imp_reqs_are_equivalent(imp_a, cimp_b.implemented_requirements[kk]):
                         return False
-                    for nn, s_a in enumerate(as_list(imp_a.statements)):
-                        # set uuids to same and then check equality
-                        s_b = imp_b.statements[nn]
-                        b_uuid, s_b.uuid = s_b.uuid, s_a.uuid
-                        statements_equivalent = s_b == s_a
-                        s_b.uuid = b_uuid
-                        if not statements_equivalent:
-                            return False
-
         return True

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -836,6 +836,8 @@ class ModelUtils:
     @staticmethod
     def imp_reqs_are_equivalent(imp_a: comp.ImplementedRequirement, imp_b: comp.ImplementedRequirement) -> bool:
         """Determine if imp_reqs are equivalent."""
+        if imp_a.description != imp_b.description:
+            return False
         if imp_a.props != imp_b.props:
             return False
         if imp_a.set_parameters != imp_b.set_parameters:

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -586,6 +586,18 @@ class CatalogInterface():
                 return prop.value, ns
         return None, None
 
+    @staticmethod
+    def _get_all_rules_params_and_vals(context: ControlContext) -> None:
+        context.rules_dict = {}
+        context.params = {}
+        context.param_vals = {}
+        def_comp = ControlInterface.get_component_by_name(context.comp_def, context.comp_name)
+        if def_comp:
+            for control_imp in as_list(def_comp.control_implementations):
+                context.rules_dict.update(ControlInterface.get_rules_from_item(control_imp))
+                context.params.update(ControlInterface.get_params_from_item(control_imp))
+                context.param_vals.update(ControlInterface.get_param_vals_from_control_imp(control_imp))
+
     def write_catalog_as_markdown(self, context: ControlContext, part_id_map: Dict[str, Dict[str, str]]) -> None:
         """
         Write out the catalog controls from dict as markdown files to the specified directory.
@@ -613,6 +625,9 @@ class CatalogInterface():
         # this is just from the set_params
         full_profile_param_dict = CatalogInterface._get_full_profile_param_dict(context.profile
                                                                                 ) if context.profile else {}
+
+        if context.purpose == ContextPurpose.COMPONENT and context.comp_def:
+            CatalogInterface._get_all_rules_params_and_vals(context)
 
         label_map = self.get_part_id_map(True)
         found_alters, _, _ = CatalogInterface.read_additional_content(

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -88,7 +88,7 @@ class ComponentGenerate(AuthorCommonCommand):
         markdown_dir_path: pathlib.Path,
         cat_interface_dict: Dict[str, CatalogInterface]
     ) -> int:
-        """Create markdown based on the component and profile."""
+        """Create markdown for the component using its source profiles."""
         logger.debug(f'Creating markdown for component {component.title}.')
         context.md_root = markdown_dir_path
         context.comp_name = component.title
@@ -100,10 +100,10 @@ class ComponentGenerate(AuthorCommonCommand):
                 )
                 local_catalog_interface = CatalogInterface(resolved_catalog)
                 cat_interface_dict[source_profile_uri] = local_catalog_interface
+            # insert the profile title (from title of resolved catalog) into the yaml header so it appears in md
             context.yaml_header = {}
             context.yaml_header[const.TRESTLE_GLOBAL_TAG] = {}
             context.yaml_header[const.TRESTLE_GLOBAL_TAG][const.PROFILE_TITLE] = resolved_catalog.metadata.title
-
             part_id_map = local_catalog_interface.get_part_id_map(False) if local_catalog_interface else {}
             cat_interface_dict[source_profile_uri].write_catalog_as_markdown(context, part_id_map)
         return CmdReturnCodes.SUCCESS.value

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -25,7 +25,6 @@ import trestle.common.log as log
 import trestle.core.generic_oscal as generic
 import trestle.oscal.common as com
 import trestle.oscal.component as comp
-import trestle.oscal.profile as prof
 from trestle.common import file_utils
 from trestle.common.err import TrestleError, handle_generic_command_exception
 from trestle.common.list_utils import as_list
@@ -51,36 +50,24 @@ class ComponentGenerate(AuthorCommonCommand):
     def _init_arguments(self) -> None:
         name_help_str = 'Name of the source component model in the trestle workspace'
         self.add_argument('-n', '--name', help=name_help_str, required=True, type=str)
-        profile_help_str = 'Optional name of the profile model in the trestle workspace'
-        self.add_argument('-p', '--profile', help=profile_help_str, required=False, type=str)
         self.add_argument('-o', '--output', help=const.HELP_MARKDOWN_NAME, required=True, type=str)
 
     def _run(self, args: argparse.Namespace) -> int:
         try:
             log.set_log_level_from_args(args)
 
-            return self.component_generate_all(args.trestle_root, args.name, args.profile, args.output)
+            return self.component_generate_all(args.trestle_root, args.name, args.output)
 
         except Exception as e:  # pragma: no cover
             return handle_generic_command_exception(e, logger, 'Generation of the component markdown failed')
 
-    def component_generate_all(
-        self, trestle_root: pathlib.Path, comp_def_name: str, profile_name: Optional[str], markdown_dir_name: str
-    ) -> int:
+    def component_generate_all(self, trestle_root: pathlib.Path, comp_def_name: str, markdown_dir_name: str) -> int:
         """Generate markdown for all components in comp def."""
         if not file_utils.is_directory_name_allowed(markdown_dir_name):
             raise TrestleError(f'{markdown_dir_name} is not an allowed directory name')
         md_path = trestle_root / markdown_dir_name
         md_path.mkdir(parents=True, exist_ok=True)
         component_def, _ = load_validate_model_name(trestle_root, comp_def_name, comp.ComponentDefinition)
-
-        # if profile is specified, create catalog interface from it
-        catalog_interface = None
-        if profile_name:
-            profile_path = ModelUtils.full_path_for_top_level_model(trestle_root, profile_name, prof.Profile)
-            profile_resolver = ProfileResolver()
-            resolved_catalog = profile_resolver.get_resolved_profile_catalog(trestle_root, str(profile_path))
-            catalog_interface = CatalogInterface(resolved_catalog)
 
         context = ControlContext.generate(ContextPurpose.COMPONENT, True, trestle_root, md_path)
         context.prompt_responses = True
@@ -89,9 +76,7 @@ class ComponentGenerate(AuthorCommonCommand):
         rc = CmdReturnCodes.SUCCESS.value
         cat_interface_dict: Dict[str, CatalogInterface] = {}
         for component in as_list(component_def.components):
-            rc = self.component_generate_by_name(
-                context, component, md_path / component.title, catalog_interface, cat_interface_dict
-            )
+            rc = self.component_generate_by_name(context, component, md_path / component.title, cat_interface_dict)
             if rc != CmdReturnCodes.SUCCESS.value:
                 break
         return rc
@@ -101,7 +86,6 @@ class ComponentGenerate(AuthorCommonCommand):
         context: ControlContext,
         component: comp.DefinedComponent,
         markdown_dir_path: pathlib.Path,
-        catalog_interface: Optional[CatalogInterface],
         cat_interface_dict: Dict[str, CatalogInterface]
     ) -> int:
         """Create markdown based on the component and profile."""
@@ -109,18 +93,19 @@ class ComponentGenerate(AuthorCommonCommand):
         context.md_root = markdown_dir_path
         context.comp_name = component.title
         for control_imp in as_list(component.control_implementations):
-            if catalog_interface:
-                catalog_interface.write_catalog_as_markdown(context, catalog_interface.get_part_id_map(False))
-            else:
-                source_profile = control_imp.source
-                if source_profile not in cat_interface_dict:
-                    resolved_catalog = ProfileResolver.get_resolved_profile_catalog(
-                        context.trestle_root, source_profile
-                    )
-                    local_catalog_interface = CatalogInterface(resolved_catalog)
-                    cat_interface_dict[source_profile] = local_catalog_interface
-                part_id_map = local_catalog_interface.get_part_id_map(False) if local_catalog_interface else {}
-                cat_interface_dict[source_profile].write_catalog_as_markdown(context, part_id_map)
+            source_profile_uri = control_imp.source
+            if source_profile_uri not in cat_interface_dict:
+                resolved_catalog = ProfileResolver.get_resolved_profile_catalog(
+                    context.trestle_root, source_profile_uri
+                )
+                local_catalog_interface = CatalogInterface(resolved_catalog)
+                cat_interface_dict[source_profile_uri] = local_catalog_interface
+            context.yaml_header = {}
+            context.yaml_header[const.TRESTLE_GLOBAL_TAG] = {}
+            context.yaml_header[const.TRESTLE_GLOBAL_TAG][const.PROFILE_TITLE] = resolved_catalog.metadata.title
+
+            part_id_map = local_catalog_interface.get_part_id_map(False) if local_catalog_interface else {}
+            cat_interface_dict[source_profile_uri].write_catalog_as_markdown(context, part_id_map)
         return CmdReturnCodes.SUCCESS.value
 
 

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -244,6 +244,7 @@ class ComponentAssemble(AuthorCommonCommand):
 
         for component in parent_comp.components:
             context.comp_name = component.title
+            context.comp_def = parent_comp
             ComponentAssemble._update_component_with_markdown(md_dir, component, context)
 
     @staticmethod

--- a/trestle/core/control_context.py
+++ b/trestle/core/control_context.py
@@ -18,7 +18,7 @@ import copy
 import pathlib
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from trestle.common.list_utils import as_dict
 from trestle.oscal import component as comp
@@ -54,6 +54,9 @@ class ControlContext:
     comp_def: Optional[comp.ComponentDefinition] = None
     comp_name: Optional[str] = None
     inherited_props: Optional[Dict[str, Any]] = None
+    rules_dict: Optional[Dict[str, Dict[str, str]]] = None
+    params: Optional[Dict[str, Dict[str, Any]]] = None
+    param_vals: Optional[List[Dict[str, str]]] = None
 
     @classmethod
     def generate(
@@ -73,7 +76,10 @@ class ControlContext:
         allowed_sections: Optional[str] = None,
         comp_def: Optional[comp.ComponentDefinition] = None,
         comp_name: Optional[str] = None,
-        inherited_props: Optional[Dict[str, Any]] = None
+        inherited_props: Optional[Dict[str, Any]] = None,
+        rules_dict: Optional[Dict[str, Dict[str, str]]] = None,
+        params: Optional[Dict[str, Dict[str, Any]]] = None,
+        param_vals: Optional[List[Dict[str, str]]] = None
     ) -> ControlContext:
         """Generate control context of the needed type."""
         context = cls(
@@ -92,7 +98,10 @@ class ControlContext:
             allowed_sections=allowed_sections,
             comp_def=comp_def,
             comp_name=comp_name,
-            inherited_props=inherited_props
+            inherited_props=inherited_props,
+            rules_dict=rules_dict,
+            params=params,
+            param_vals=param_vals
         )
         context.yaml_header = as_dict(yaml_header)
         context.sections_dict = as_dict(sections_dict)
@@ -120,6 +129,9 @@ class ControlContext:
             allowed_sections=context.allowed_sections,
             comp_def=context.comp_def,
             comp_name=context.comp_name,
-            inherited_props=copy.deepcopy(context.inherited_props)
+            inherited_props=copy.deepcopy(context.inherited_props),
+            rules_dict=context.rules_dict,
+            params=context.params,
+            param_vals=context.param_vals
         )
         return new_context

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -865,6 +865,7 @@ class ControlInterface:
                 if imp_req.control_id == new_imp_req.control_id:
                     status = ControlInterface.get_status_from_props(new_imp_req)
                     ControlInterface.insert_status_in_props(imp_req, status)
+                    imp_req.description = new_imp_req.description
                     statement_dict = {stat.statement_id: stat for stat in as_list(imp_req.statements)}
                     new_statements: List[comp.Statement] = []
                     for statement in as_list(new_imp_req.statements):

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -51,7 +51,7 @@ class ComponentImpInfo:
 
     prose: str
     rules: List[str]
-    status: common.ImplementationStatus = common.ImplementationStatus(state=const.STATUS_OTHER)
+    status: common.ImplementationStatus = common.ImplementationStatus(state=const.STATUS_PLANNED)
 
 
 # provide name for this type
@@ -364,10 +364,10 @@ class ControlInterface:
         desc = ''
         id_ = ''
         for prop in as_list(item.props):
-            if prop.name == 'rule_name_id':
+            if prop.name == const.RULE_ID:
                 name = prop.value
                 id_ = string_from_root(prop.remarks)
-            elif prop.name == 'rule_description':
+            elif prop.name == const.RULE_DESCRIPTION:
                 desc = prop.value
             # grab each pair in case there are multiple pairs
             # then clear and look for new pair
@@ -379,7 +379,7 @@ class ControlInterface:
     @staticmethod
     def get_rule_list_for_item(item: TypeWithProps) -> List[str]:
         """Get the list of rules applying to this item."""
-        return [prop.value for prop in as_filtered_list(item.props, lambda p: p.name == 'rule_name_id')]
+        return [prop.value for prop in as_filtered_list(item.props, lambda p: p.name == const.RULE_ID)]
 
     @staticmethod
     def get_params_from_item(item: TypeWithProps) -> Dict[str, Dict[str, Any]]:
@@ -388,20 +388,20 @@ class ControlInterface:
         # params is dict with rule_id as key and value contains: param_name, description and choices
         params = {}
         for prop in as_list(item.props):
-            if prop.name == 'param_id':
+            if prop.name == const.PARAMETER_ID:
                 rule_id = string_from_root(prop.remarks)
                 param_name = prop.value
                 if rule_id in params:
                     raise TrestleError(f'Duplicate param {param_name} found for rule {rule_id}')
                 # create new param for this rule
                 params[rule_id] = {'name': param_name}
-            elif prop.name == 'param_description':
+            elif prop.name == const.PARAMETER_DESCRIPTION:
                 rule_id = string_from_root(prop.remarks)
                 if rule_id in params:
                     params[rule_id]['description'] = prop.value
                 else:
                     raise TrestleError(f'Param description for rule {rule_id} found with no param_id')
-            elif prop.name == 'param_options':
+            elif prop.name == const.PARAMETER_VALUE_ALTERNATIVES:
                 rule_id = string_from_root(prop.remarks)
                 if rule_id in params:
                     params[rule_id]['options'] = prop.value
@@ -826,7 +826,7 @@ class ControlInterface:
     @staticmethod
     def get_status_from_props(item: TypeWithProps) -> common.ImplementationStatus:
         """Get the status of an item from its props."""
-        status = common.ImplementationStatus(state=const.STATUS_OTHER)
+        status = common.ImplementationStatus(state=const.STATUS_PLANNED)
         for prop in as_list(item.props):
             if prop.name == const.IMPLEMENTATION_STATUS:
                 status = ControlInterface._prop_as_status(prop)

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -440,40 +440,32 @@ class ControlReader():
 
     @staticmethod
     def _add_component_to_dict(
-        control: Optional[cat.Control],
-        comp_dict: CompDict,
-        comp_def: Optional[comp.ComponentDefinition],
-        comp_name: Optional[str]
+        control: Optional[cat.Control], comp_dict: CompDict, def_comp: comp.DefinedComponent
     ) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, Any]], Dict[str, str]]:
         """Add imp_reqs for this control and this component to the component dictionary."""
         control_id = control.id if control else 'temp'
-        rules_dict = {}
+        sub_comp_dict: Dict[str, ComponentImpInfo] = {}
         params = {}
-        param_vals = {}
-        if comp_def:
-            sub_comp = ControlInterface.get_component_by_name(comp_def, comp_name)
-            for control_imp in as_list(sub_comp.control_implementations):
-                rules_dict.update(ControlInterface.get_rules_from_item(control_imp))
-                params.update(ControlInterface.get_params_from_item(control_imp))
-                param_vals.update(ControlInterface.get_param_vals_from_control_imp(control_imp))
-            sub_comp_dict: Dict[str, ComponentImpInfo] = {}
-            for imp_req in ControlInterface.get_control_imp_reqs(sub_comp, control_id):
-                # if description is same as control id regard it as not having prose
-                # add top level control guidance with no statement id
-                prose = imp_req.description if imp_req.description != control_id else ''
-                params.update(ControlInterface.get_params_from_item(imp_req))
-                rules_list = ControlInterface.get_rule_list_for_item(imp_req)
-                status = ControlInterface.get_status_from_props(imp_req)
-                sub_comp_dict[''] = ComponentImpInfo(prose=prose, status=status, rules=rules_list)
-                for statement in as_list(imp_req.statements):
-                    rules_list = ControlInterface.get_rule_list_for_item(statement)
-                    status = ControlInterface.get_status_from_props(statement)
-                    label = ControlReader._get_statement_label(control, statement.statement_id)
-                    prose = statement.description if statement.description != statement.statement_id else ''
-                    sub_comp_dict[label] = ComponentImpInfo(prose=prose, status=status, rules=rules_list)
-            if sub_comp_dict:
-                comp_dict[sub_comp.title] = sub_comp_dict
-        return rules_dict, params, param_vals
+        all_rules = set()
+        for imp_req in ControlInterface.get_control_imp_reqs(def_comp, control_id):
+            # if description is same as control id regard it as not having prose
+            # add top level control guidance with no statement id
+            prose = imp_req.description if imp_req.description != control_id else ''
+            params.update(ControlInterface.get_params_from_item(imp_req))
+            rules_list = ControlInterface.get_rule_list_for_item(imp_req)
+            all_rules.update(rules_list)
+            status = ControlInterface.get_status_from_props(imp_req)
+            sub_comp_dict[''] = ComponentImpInfo(prose=prose, status=status, rules=rules_list)
+            for statement in as_list(imp_req.statements):
+                rules_list = ControlInterface.get_rule_list_for_item(statement)
+                all_rules.update(rules_list)
+                status = ControlInterface.get_status_from_props(statement)
+                label = ControlReader._get_statement_label(control, statement.statement_id)
+                prose = statement.description if statement.description != statement.statement_id else ''
+                sub_comp_dict[label] = ComponentImpInfo(prose=prose, status=status, rules=rules_list)
+        if sub_comp_dict:
+            comp_dict[def_comp.title] = sub_comp_dict
+        return params, sorted(all_rules)
 
     @staticmethod
     def _insert_header_content(
@@ -594,21 +586,26 @@ class ControlReader():
 
         comp_dict: CompDict = {}
         yaml_header = {}
-        # pull possible prose and rules from component definition if provided
-        rules, params, param_vals = ControlReader._add_component_to_dict(
-            control,
-            comp_dict,
-            context.comp_def,
-            comp_name
-        )
-        if rules:
-            yaml_header[const.COMP_DEF_RULES_TAG] = list(rules.values())
-        if params:
-            if not set(rules.keys()).issuperset(params.keys()):
-                raise TrestleError(f'Control {control_id} has a parameter assigned to a rule that is not defined.')
-            yaml_header[const.COMP_DEF_PARAMS_TAG] = [{rules[id_]['name']: params[id_] for id_ in params.keys()}]
-        if param_vals:
-            yaml_header[const.COMP_DEF_PARAM_VALS_TAG] = param_vals
+        if context.comp_def:
+            def_comp = ControlInterface.get_component_by_name(context.comp_def, comp_name)
+            # pull possible prose and rules from component definition if provided
+            if def_comp:
+                params, rules = ControlReader._add_component_to_dict(control, comp_dict, def_comp)
+                all_params = []
+                if rules:
+                    rule_ids = [id_ for id_ in context.rules_dict.keys() if context.rules_dict[id_]['name'] in rules]
+                    yaml_header[const.COMP_DEF_RULES_TAG] = [context.rules_dict[id_] for id_ in rule_ids]
+                    all_params.extend([context.params[id_] for id_ in rule_ids if id_ in context.params])
+                if params:
+                    if not set(rules.keys()).issuperset(params.keys()):
+                        raise TrestleError(
+                            f'Control {control_id} has a parameter assigned to a rule that is not defined.'
+                        )
+                    all_params.extend([{context.rules_dict[id_]['name']: params[id_] for id_ in params.keys()}])
+                if all_params:
+                    yaml_header[const.COMP_DEF_PARAMS_TAG] = all_params
+                if context.param_vals:
+                    yaml_header[const.COMP_DEF_PARAM_VALS_TAG] = context.param_vals
 
         if not control_file.exists():
             return comp_dict, yaml_header

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -140,7 +140,7 @@ class ControlWriter():
             self._insert_rules(info.rules, level)
             self._insert_status(info.status, level)
         else:
-            self._insert_status(ImplementationStatus(state=const.STATUS_OTHER), level)
+            self._insert_status(ImplementationStatus(state=const.STATUS_PLANNED), level)
 
     def _add_component_control_prompts(self, comp_dict: CompDict, comp_def_format=False) -> bool:
         """Add prompts to the markdown for the control itself, per component."""
@@ -205,7 +205,7 @@ class ControlWriter():
                             wrote_label_content = True
                         if not wrote_label_content:
                             level = 3 if comp_def_format else 4
-                            self._insert_status(ImplementationStatus(state=const.STATUS_OTHER), level)
+                            self._insert_status(ImplementationStatus(state=const.STATUS_PLANNED), level)
                         self._md_file.new_paragraph()
                         did_write_part = True
         # if we loaded nothing for this control yet then it must need a fresh prompt for the control statement

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -146,6 +146,8 @@ class ControlWriter():
         """Add prompts to the markdown for the control itself, per component."""
         if comp_def_format:
             self._md_file.new_paraline(const.STATUS_PROMPT)
+            self._md_file.new_paraline(const.RULES_WARNING)
+            self._md_file.new_paraline(const.CONTROL_PROSE_PROMPT)
             self._md_file.new_paragraph()
         did_write = False
         level = 3

--- a/trestle/core/generic_oscal.py
+++ b/trestle/core/generic_oscal.py
@@ -212,7 +212,7 @@ class GenericComponent(TrestleBaseModel):
     def generate() -> GenericComponent:
         """Generate instance of GenericComponent."""
         uuid = str(uuid4())
-        status = common.ImplementationStatus(state=const.STATUS_OTHER)
+        status = common.ImplementationStatus(state=const.STATUS_PLANNED)
         return GenericComponent(
             uuid=uuid, type=const.REPLACE_ME, title=const.REPLACE_ME, description=const.REPLACE_ME, status=status
         )


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Put profile title in comp-gen markdown
Removed -profile option from command
Reworked component-generate to conform to new naming conventions
Changed allowed vals for imp_status

closes #1205 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

