### PR TITLE
feat: allow profile-resolve to specify brackets around value

### DIFF
--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -839,16 +839,12 @@ def test_profile_resolve(
     test_utils.execute_command_and_assert(command_profile_resolve, 0, monkeypatch)
     res_cat, _ = ModelUtils.load_top_level_model(tmp_trestle_dir, cat_name, cat.Catalog, FileContentType.JSON)
     ac_1 = res_cat.groups[0].controls[0]
-    if bracket_format:
-        if show_values:
-            expected_prose = 'Designate an [(officer]) to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
-        else:
-            expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
-    else:
-        if show_values:
-            expected_prose = 'Designate an officer to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
-        else:
-            expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+    expected_value = '{{ insert: param, ac-1_prm_3 }}'
+    if show_values:
+        expected_value = 'officer'
+        if bracket_format:
+            expected_value = f'[({expected_value}])'
+    expected_prose = f'Designate an {expected_value} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
     assert ac_1.parts[0].parts[1].prose == expected_prose
 
 

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -823,21 +823,32 @@ def test_adding_removing_sections(tmp_trestle_dir: pathlib.Path, monkeypatch: Mo
     assert not tree.get_node_for_key('## Control this_should_appear_in_parts')
 
 
+@pytest.mark.parametrize('bracket_format', [True, False])
 @pytest.mark.parametrize('show_values', [True, False])
-def test_profile_resolve(tmp_trestle_dir: pathlib.Path, show_values: bool, monkeypatch: MonkeyPatch) -> None:
+def test_profile_resolve(
+    tmp_trestle_dir: pathlib.Path, show_values: bool, bracket_format: bool, monkeypatch: MonkeyPatch
+) -> None:
     """Test profile resolve to create resolved profile catalog."""
     test_utils.setup_for_multi_profile(tmp_trestle_dir, False, False)
     cat_name = 'resolved_catalog'
     command_profile_resolve = f'trestle author profile-resolve -n main_profile -o {cat_name}'
     if show_values:
         command_profile_resolve += ' -sv'
+    if bracket_format:
+        command_profile_resolve += ' -bf [(.])'
     test_utils.execute_command_and_assert(command_profile_resolve, 0, monkeypatch)
     res_cat, _ = ModelUtils.load_top_level_model(tmp_trestle_dir, cat_name, cat.Catalog, FileContentType.JSON)
     ac_1 = res_cat.groups[0].controls[0]
-    if show_values:
-        expected_prose = 'Designate an officer to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+    if bracket_format:
+        if show_values:
+            expected_prose = 'Designate an [(officer]) to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+        else:
+            expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
     else:
-        expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+        if show_values:
+            expected_prose = 'Designate an officer to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
+        else:
+            expected_prose = 'Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and'  # noqa E501
     assert ac_1.parts[0].parts[1].prose == expected_prose
 
 

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -451,7 +451,7 @@ class ProfileResolve(AuthorCommonCommand):
         self.add_argument(
             '-bf',
             '--bracket-format',
-            help='Format to allow brackets around value, e.g. [.] or ((.)), with the dot representing the value',
+            help='With -sv, allows brackets around value, e.g. [.] or ((.)), with the dot representing the value.',
             required=False,
             type=str,
             default=''
@@ -495,7 +495,7 @@ class ProfileResolve(AuthorCommonCommand):
             raise TrestleNotFoundError(f'Cannot resolve profile catalog: profile {profile_path} does not exist.')
         param_rep = ParameterRep.VALUE_OR_LABEL_OR_CHOICES if show_values else ParameterRep.LEAVE_MOUSTACHE
 
-        bracket_format = bracket_format if bracket_format else None
+        bracket_format = none_if_empty(bracket_format)
         catalog = ProfileResolver().get_resolved_profile_catalog(
             trestle_root, profile_path, False, False, bracket_format, param_rep
         )


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
If -sv is specified to output the value during profile-resolve, a new parameter -bf --bracket-format allows specifying brackets around that value

closes #1206 
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)
