### PR TITLE
fix: simple fix for statement labels not showing properly

### DIFF
--- a/tests/data/json/test_profile_f.json
+++ b/tests/data/json/test_profile_f.json
@@ -113,11 +113,11 @@
               "by-id": "ac-5_gdn",
               "props": [
                 {
-                  "name": "test_epty",
+                  "name": "test_five",
                   "value": "one"
                 },
                 {
-                  "name": "test_epty_2",
+                  "name": "test_five_2",
                   "value": "two"
                 }
               ]              

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -960,3 +960,7 @@ def test_profile_generate_inherited_props(tmp_trestle_dir: pathlib.Path, monkeyp
     assert inherited_props[1] == {
         'name': 'add_prof_b_prop_by_id', 'value': 'add prof b prop by id value', 'part_name': 'ac-3.3_prm_2'
     }
+
+    ac5_path = tmp_trestle_dir / 'my_md/ac/ac-5.md'
+    assert test_utils.confirm_text_in_file(ac5_path, 'value: one', 'smt-part: a.')
+    assert test_utils.confirm_text_in_file(ac5_path, 'test_five', 'smt-part: ac-5_gdn')

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -443,8 +443,6 @@ NS_HELP = 'Default namespace to use if namespace is not specified for a property
 
 DEFAULT_NS = 'default-namespace'
 
-NO_NS = 'no-ns'
-
 DISPLAY_NAME = 'display-name'
 
 RESOLUTION_SOURCE = 'resolution-source'

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -443,6 +443,8 @@ NS_HELP = 'Default namespace to use if namespace is not specified for a property
 
 DEFAULT_NS = 'default-namespace'
 
+NO_NS = 'no-ns'
+
 DISPLAY_NAME = 'display-name'
 
 RESOLUTION_SOURCE = 'resolution-source'

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -264,7 +264,6 @@ class CatalogInterface():
                         id_dict[sub_part.id] = label
                 if id_dict:
                     id_map[control.id] = id_dict
-                break
         return id_map
 
     def get_control_part_prose(self, control_id: str, part_name: str) -> str:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Bad break statement killed part label lookup needed for smt-part: a. in yaml header added prop

closes #1212
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
