### PR TITLE
feat: made model equivalence check more rigorous

### DIFF
--- a/tests/trestle/core/validator_helper_test.py
+++ b/tests/trestle/core/validator_helper_test.py
@@ -39,7 +39,7 @@ def test_regenerate_uuids_ssp() -> None:
 def test_regenerate_uuids_catalog() -> None:
     """Test regeneration of uuids with updated refs in catalog."""
     orig_cat = catalog.Catalog.oscal_read(catalog_path)
-    new_cat, uuid_lut, n_refs_updated = ModelUtils.regenerate_uuids(orig_cat)
+    _, uuid_lut, n_refs_updated = ModelUtils.regenerate_uuids(orig_cat)
     assert len(uuid_lut.items()) == 2
     assert n_refs_updated == 2
 

--- a/trestle/common/model_utils.py
+++ b/trestle/common/model_utils.py
@@ -18,6 +18,7 @@ import importlib
 import logging
 import pathlib
 import re
+import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -27,7 +28,6 @@ from pydantic import BaseModel, create_model
 
 import trestle.common
 import trestle.common.common_types
-import trestle.oscal.component as comp
 from trestle.common import const, err, str_utils, type_utils as utils
 from trestle.common.common_types import TG, TopLevelOscalModel
 from trestle.common.err import TrestleError, TrestleNotFoundError
@@ -538,11 +538,11 @@ class ModelUtils:
         if isinstance(obj, common.Remarks) or isinstance(obj, common.ParameterValue):
             return obj.__root__
         # it is either a string already or we cast it to string
-        if not hasattr(obj, '__fields_set__'):
+        if not hasattr(obj, '__fields__'):
             return str(obj)
         # it is an oscal object and we need to recurse within its attributes
         res = {}
-        for field in obj.__fields_set__:
+        for field in obj.__fields__:
             if partial and field not in main_fields:
                 continue
             attr = getattr(obj, field)
@@ -663,7 +663,7 @@ class ModelUtils:
             value = getattr(object_of_interest, name_of_interest, None)
             if value is not None:
                 loe.append(value)
-            fields = getattr(object_of_interest, '__fields_set__', None)
+            fields = getattr(object_of_interest, '__fields__', None)
             if fields is not None:
                 for field in fields:
                     loe.extend(
@@ -743,13 +743,15 @@ class ModelUtils:
         if isinstance(object_of_interest, common.Resource):
             pass
         elif isinstance(object_of_interest, BaseModel):
-            # fields_set has names of fields set when model was initialized
-            fields = getattr(object_of_interest, '__fields_set__', None)
+            # fields has names of all fields in model
+            fields = getattr(object_of_interest, '__fields__', None)
             for field in fields:
                 new_object = None
                 if field == uuid_str:
-                    new_object = str(uuid.uuid4())
-                    uuid_lut[object_of_interest.__dict__[field]] = new_object
+                    orig_uuid = getattr(object_of_interest, field)
+                    if orig_uuid:
+                        new_object = str(uuid.uuid4())
+                        uuid_lut[orig_uuid] = new_object
                 else:
                     new_object, uuid_lut = ModelUtils._regenerate_uuids_in_place(
                         object_of_interest.__dict__[field],
@@ -780,7 +782,7 @@ class ModelUtils:
         """Update all refs to uuids that were changed."""
         n_refs_updated = 0
         if isinstance(object_of_interest, BaseModel):
-            fields = getattr(object_of_interest, '__fields_set__', None)
+            fields = getattr(object_of_interest, '__fields__', None)
             for field in fields:
                 new_object, n_new_updates = ModelUtils._update_new_uuid_refs(
                     object_of_interest.__dict__[field],
@@ -837,70 +839,50 @@ class ModelUtils:
         return new_object, uuid_lut, n_refs_updated
 
     @staticmethod
+    def _objects_differ(obj_a: Any, obj_b: Any, ignore_type_list: List[Any], ignore_name_list: List[str]) -> bool:
+        """Compare two objects with option to ignore given types."""
+        obj_a_type = type(obj_a)
+        obj_b_type = type(obj_b)
+        if bool(obj_a) != bool(obj_b) or obj_a_type != obj_b_type:
+            return True
+        if not bool(obj_a):
+            return False
+        if obj_a_type in ignore_type_list:
+            return False
+        # getsizeof is not useful for str
+        if obj_a_type is str:
+            if obj_a != obj_b:
+                return True
+        else:
+            if sys.getsizeof(obj_a) != sys.getsizeof(obj_b):
+                return True
+        if isinstance(obj_a, BaseModel):
+            fields_a = getattr(obj_a, '__fields__', None)
+            fields_b = getattr(obj_b, '__fields__', None)
+            if fields_a != fields_b:
+                return True
+            for field in as_list(fields_a):
+                if field not in ignore_name_list and ModelUtils.objects_differ(
+                        getattr(obj_a, field), getattr(obj_b, field), ignore_type_list, ignore_name_list):
+                    return True
+        elif obj_a_type is list:
+            if len(obj_a) != len(obj_b):
+                return True
+            for item_a, item_b in zip(obj_a, obj_b):
+                if ModelUtils.objects_differ(item_a, item_b, ignore_type_list, ignore_name_list):
+                    return True
+        elif obj_a_type is dict:
+            if obj_a.keys() != obj_b.keys():
+                return True
+            for key, val in obj_a.items():
+                if key not in ignore_name_list and ModelUtils.objects_differ(
+                        val, obj_b[key], ignore_type_list, ignore_name_list):
+                    return True
+        elif obj_a != obj_b:
+            return True
+        return False
+
+    @staticmethod
     def models_are_equivalent(model_a: Optional[TopLevelOscalModel], model_b: Optional[TopLevelOscalModel]) -> bool:
         """Test if models are equivalent except for last modified and uuid."""
-        # set b's extra properties to those of a then later undo so the models are not changed by this routine
-        if not model_a and not model_b:
-            return True
-        if not model_a or not model_b:
-            return False
-        b_last_modified, model_b.metadata.last_modified = model_b.metadata.last_modified, model_a.metadata.last_modified
-        b_uuid, model_b.uuid = model_b.uuid, model_a.uuid
-        equivalent = model_a == model_b
-        model_b.metadata.last_modified, model_b.uuid = b_last_modified, b_uuid
-        return equivalent
-
-    @staticmethod
-    def imp_reqs_are_equivalent(imp_a: comp.ImplementedRequirement, imp_b: comp.ImplementedRequirement) -> bool:
-        """Determine if imp_reqs are equivalent."""
-        if imp_a.description != imp_b.description:
-            return False
-        if imp_a.props != imp_b.props:
-            return False
-        if imp_a.set_parameters != imp_b.set_parameters:
-            return False
-        if imp_a.remarks != imp_b.remarks:
-            return False
-        if len(as_list(imp_a.statements)) != len(as_list(imp_b.statements)):
-            return False
-        for kk, state_a in enumerate(as_list(imp_a.statements)):
-            state_b = imp_b.statements[kk]
-            b_uuid, state_b.uuid = state_b.uuid, state_a.uuid
-            statements_equiv = state_a == state_b
-            state_b.uuid = b_uuid
-            if not statements_equiv:
-                return False
-        return True
-
-    @staticmethod
-    def component_defs_are_equivalent(
-        model_a: Optional[comp.ComponentDefinition], model_b: Optional[comp.ComponentDefinition]
-    ) -> bool:
-        """
-        Determine if two comp defs are equivalent.
-
-        This isn't a comprehensive check but looks for changes that would have happened during component assemble.
-        """
-        if not model_a and not model_b:
-            return True
-        if not model_a or not model_b:
-            return False
-        if len(as_list(model_a.components)) != len(as_list(model_b.components)):
-            return False
-        # confirm all statements are identical except for uuid
-        for ii, c_a in enumerate(as_list(model_a.components)):
-            c_b = model_b.components[ii]
-            if len(as_list(c_a.control_implementations)) != len(as_list(c_b.control_implementations)):
-                return False
-            for jj, cimp_a in enumerate(as_list(c_a.control_implementations)):
-                cimp_b = c_b.control_implementations[jj]
-                if cimp_a.props != cimp_b.props:
-                    return False
-                if cimp_a.set_parameters != cimp_b.set_parameters:
-                    return False
-                if len(as_list(cimp_a.implemented_requirements)) != len(as_list(cimp_b.implemented_requirements)):
-                    return False
-                for kk, imp_a in enumerate(as_list(cimp_a.implemented_requirements)):
-                    if not ModelUtils.imp_reqs_are_equivalent(imp_a, cimp_b.implemented_requirements[kk]):
-                        return False
-        return True
+        return not ModelUtils._objects_differ(model_a, model_b, [common.LastModified], ['last-modified', 'uuid'])

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -200,7 +200,7 @@ class ComponentAssemble(AuthorCommonCommand):
 
         if not version and assem_comp_path.exists():
             _, _, existing_comp = ModelUtils.load_distributed(assem_comp_path, trestle_root)
-            if ModelUtils.component_defs_are_equivalent(existing_comp, parent_comp):
+            if ModelUtils.models_are_equivalent(existing_comp, parent_comp):
                 logger.info('Assembled component is no different from existing version, so no update.')
                 return CmdReturnCodes.SUCCESS.value
 

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -200,7 +200,8 @@ class ComponentAssemble(AuthorCommonCommand):
 
         if not version and assem_comp_path.exists():
             _, _, existing_comp = ModelUtils.load_distributed(assem_comp_path, trestle_root)
-            if ModelUtils.models_are_equivalent(existing_comp, parent_comp):
+            # comp def will change statement uuids so need to ignore them in comparison
+            if ModelUtils.models_are_equivalent(existing_comp, parent_comp, True):
                 logger.info('Assembled component is no different from existing version, so no update.')
                 return CmdReturnCodes.SUCCESS.value
 

--- a/trestle/core/resolver/merge.py
+++ b/trestle/core/resolver/merge.py
@@ -114,7 +114,7 @@ class Merge(Pipeline.Filter):
 
     def _merge_items(self, dest: OBT, src: OBT, merge_method: prof.Method) -> None:
         """Merge two items recursively."""
-        for field in src.__fields__:
+        for field in src.__fields_set__:
             self._merge_attrs(dest, src, field, merge_method)
 
     def _group_contents(self, group: cat.Group) -> Tuple[List[cat.Control], List[common.Parameter]]:

--- a/trestle/core/resolver/merge.py
+++ b/trestle/core/resolver/merge.py
@@ -114,7 +114,7 @@ class Merge(Pipeline.Filter):
 
     def _merge_items(self, dest: OBT, src: OBT, merge_method: prof.Method) -> None:
         """Merge two items recursively."""
-        for field in src.__fields_set__:
+        for field in src.__fields__:
             self._merge_attrs(dest, src, field, merge_method)
 
     def _group_contents(self, group: cat.Group) -> Tuple[List[cat.Control], List[common.Parameter]]:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Improved the check for model equivalence to recurse and check every attribute except specified ones.
Converted references to __field_set__ to __field__ because field_set only pertains to fields set when the obect was first initialized.  other fields could be set later and they would be missed.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
