### PR TITLE
feat: get statement parts to allow easy capture of statement prose

### DIFF
--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -268,6 +268,21 @@ def test_catalog_interface(sample_catalog_rich_controls: cat.Catalog) -> None:
     assert interface._catalog.controls[1].controls[0].title == new_title
 
 
+def test_get_statement_parts(simplified_nist_catalog: cat.Catalog) -> None:
+    """Test the catalog interface with complex controls."""
+    interface = CatalogInterface(simplified_nist_catalog)
+    parts = interface.get_statement_parts('ac-1')
+    assert len(parts) == 9
+    prt = parts[0]
+    assert prt['indent'] == 0
+    assert prt['label'] == 'a.'
+    assert prt['prose'].startswith('Develop, document')
+    prt = parts[3]
+    assert prt['indent'] == 2
+    assert prt['label'] == '(b)'
+    assert prt['prose'].startswith('Is consistent with')
+
+
 def test_catalog_interface_groups() -> None:
     """Test handling of groups of groups in CatalogInterface."""
     catalog: cat.Catalog = cat.Catalog.oscal_read(test_utils.JSON_TEST_DATA_PATH / 'nist_tutorial_catalog.json')

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -281,11 +281,14 @@ class CatalogInterface():
         """Get list of statement parts as dicts with indentation, label and prose."""
         items = []
         control = self.get_control(control_id)
+        # statement may have no parts at all but if statement present it is first part
         if control and control.parts:
-            # statement is first part
             part = control.parts[0]
-            for prt in as_filtered_list(part.parts, lambda p: p.name == 'item'):
-                items.extend(CatalogInterface._get_statement_sub_parts(prt, 0))
+            if part.name == 'statement':
+                for prt in as_filtered_list(part.parts, lambda p: p.name == 'item'):
+                    items.extend(CatalogInterface._get_statement_sub_parts(prt, 0))
+            else:
+                logger.warning(f'Control {control_id} has parts but first part name is {part.name} - not statement')
         return items
 
     def get_control_part_prose(self, control_id: str, part_name: str) -> str:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Per recent feature request - simple routine in catalog_interface to get control statement prose as list of indented items.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
