### PR TITLE
feat: Allow trestle init to specify the purpose of initialisation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,7 +139,18 @@ Trestle provides utilities for converting from element path to trestle's python 
 
 ## `trestle init`
 
-This command will create (initialize) a trestle workspace in the current directory with the necessary directory structure and trestle artefacts. For example, if we run `trestle init` in a directory, it will create the directory structure below for different artefacts:
+This command will create (initialize) a trestle workspace in the current directory with the necessary directory structure and trestle artefacts.
+This command has multiple modes that it can run in:
+
+- `--full`
+- `--local`
+- `--govdocs`
+
+By default `trestle init` will run in the `--full` mode.
+
+`--full` mode is meant to be used when full functionality of Trestle is used i.e. managing OSCAL models locally, govern documents or using Trestle for API purposes.
+`dist` repository will be used when `trestle assemble` command is used.
+Running `trestle init --full` will create the directory structure below for different artefacts:
 
 ```text
 .
@@ -159,6 +170,27 @@ This command will create (initialize) a trestle workspace in the current directo
 ├── assessment-plans
 ├── assessment-results
 └── plan-of-action-and-milestones
+```
+
+`--local` mode is meant to be used when Trestle is used to only manage OSCAL models locally. Running `trestle init --local` will create the directory structure below for different artefacts:
+
+```text
+.
+├── .trestle
+├── catalogs
+├── profiles
+├── component-definitions
+├── system-security-plans
+├── assessment-plans
+├── assessment-results
+└── plan-of-action-and-milestones
+```
+
+`--govdocs` mode is meant to be used when Trestle is only used to govern documents. Running `trestle init --govdocs` will create the directory structure below:
+
+```text
+.
+├── .trestle
 ```
 
 `.trestle` directory is a special directory containing various trestle artefacts to help run various other commands.

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -27,7 +27,7 @@ import trestle.common.const as const
 from trestle.common import file_utils
 
 
-def test_init(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init happy path and no flags."""
     os.chdir(tmp_path)
     command = 'trestle init -v'
@@ -41,7 +41,7 @@ def test_init(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_directory_creation_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_directory_creation_error(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test error during init when a directory cannot be created."""
     # Windows read-only on dir does not prevent file creation in dir
     if file_utils.is_windows():
@@ -70,7 +70,7 @@ def test_directory_creation_error(tmp_path: pathlib.Path, keep_cwd: bool, monkey
     assert not config_exists
 
 
-def test_config_copy_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_config_copy_error(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test error during init when a contents of .trestle cannot be created."""
     os.chdir(tmp_path)
     config_dir = pathlib.Path(const.TRESTLE_CONFIG_DIR)
@@ -90,7 +90,7 @@ def test_config_copy_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: 
     assert os.stat(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE)).st_size == 0
 
 
-def test_init_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init_local(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init for local usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --local'
@@ -104,7 +104,7 @@ def test_init_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyP
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init_govdocs(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init for governed document usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs'
@@ -118,7 +118,7 @@ def test_init_govdocs(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: Monke
     assert not os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_full(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init_full(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init for full usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --full'
@@ -132,7 +132,7 @@ def test_init_full(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPa
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs_n_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init_govdocs_n_local(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init with multiple flags behave like mode of the highest hierarchy."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs --local'
@@ -146,7 +146,7 @@ def test_init_govdocs_n_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatc
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs_n_full(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+def test_init_govdocs_n_full(tmp_path: pathlib.Path, keep_cwd: pathlib.Path, monkeypatch: MonkeyPatch):
     """Test init with multiple flags behave like mode of the highest hierarchy."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs --full'

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -90,7 +90,7 @@ def test_config_copy_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: 
     assert os.stat(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE)).st_size == 0
 
 
-def test_init_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+def test_init_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test init for local usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --local'
@@ -104,7 +104,7 @@ def test_init_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+def test_init_govdocs(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test init for governed document usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs'
@@ -118,7 +118,7 @@ def test_init_govdocs(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     assert not os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_full(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+def test_init_full(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test init for full usage only."""
     os.chdir(tmp_path)
     command = 'trestle init --full'
@@ -132,7 +132,7 @@ def test_init_full(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs_n_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+def test_init_govdocs_n_local(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test init with multiple flags behave like mode of the highest hierarchy."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs --local'
@@ -146,7 +146,7 @@ def test_init_govdocs_n_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_init_govdocs_n_full(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+def test_init_govdocs_n_full(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test init with multiple flags behave like mode of the highest hierarchy."""
     os.chdir(tmp_path)
     command = 'trestle init --govdocs --full'

--- a/tests/trestle/core/commands/init_test.py
+++ b/tests/trestle/core/commands/init_test.py
@@ -18,26 +18,21 @@
 import os
 import pathlib
 import stat
-import sys
 
 from _pytest.monkeypatch import MonkeyPatch
 
-import pytest
+from tests.test_utils import execute_command_and_assert
 
 import trestle.common.const as const
-from trestle import cli
 from trestle.common import file_utils
 
 
-def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
-    """Test init happy path."""
+def test_init(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
+    """Test init happy path and no flags."""
     os.chdir(tmp_path)
-    testargs = ['trestle', 'init', '-v']
-    monkeypatch.setattr(sys, 'argv', testargs)
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        cli.run()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 0
+    command = 'trestle init -v'
+    execute_command_and_assert(command, 0, monkeypatch)
+
     for directory in const.MODEL_DIR_LIST:
         assert os.path.isdir(directory)
         assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
@@ -46,7 +41,7 @@ def test_init(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
 
 
-def test_directory_creation_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
+def test_directory_creation_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test error during init when a directory cannot be created."""
     # Windows read-only on dir does not prevent file creation in dir
     if file_utils.is_windows():
@@ -56,12 +51,10 @@ def test_directory_creation_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     config_dir.mkdir()
     config_dir.chmod(stat.S_IREAD)
     config_file = config_dir / const.TRESTLE_CONFIG_FILE
-    testargs = ['trestle', 'init']
-    monkeypatch.setattr(sys, 'argv', testargs)
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        cli.run()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 1
+
+    command = 'trestle init -v'
+    execute_command_and_assert(command, 1, monkeypatch)
+
     for directory in const.MODEL_DIR_LIST:
         dir_path = pathlib.Path(directory)
         assert not dir_path.exists()
@@ -77,7 +70,7 @@ def test_directory_creation_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     assert not config_exists
 
 
-def test_config_copy_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
+def test_config_copy_error(tmp_path: pathlib.Path, keep_cwd: bool, monkeypatch: MonkeyPatch):
     """Test error during init when a contents of .trestle cannot be created."""
     os.chdir(tmp_path)
     config_dir = pathlib.Path(const.TRESTLE_CONFIG_DIR)
@@ -85,15 +78,83 @@ def test_config_copy_error(tmp_path, keep_cwd, monkeypatch: MonkeyPatch):
     config_file = config_dir / const.TRESTLE_CONFIG_FILE
     config_file.touch()
     config_file.chmod(stat.S_IREAD)
-    testargs = ['trestle', 'init']
-    monkeypatch.setattr(sys, 'argv', testargs)
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        cli.run()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 1
+
+    command = 'trestle init'
+    execute_command_and_assert(command, 1, monkeypatch)
+
     for directory in const.MODEL_DIR_LIST:
         assert os.path.isdir(directory)
         assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
     assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
     assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
     assert os.stat(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE)).st_size == 0
+
+
+def test_init_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Test init for local usage only."""
+    os.chdir(tmp_path)
+    command = 'trestle init --local'
+    execute_command_and_assert(command, 0, monkeypatch)
+
+    for directory in const.MODEL_DIR_LIST:
+        assert os.path.isdir(directory)
+        assert not os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
+        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+    assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
+    assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
+
+
+def test_init_govdocs(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Test init for governed document usage only."""
+    os.chdir(tmp_path)
+    command = 'trestle init --govdocs'
+    execute_command_and_assert(command, 0, monkeypatch)
+
+    for directory in const.MODEL_DIR_LIST:
+        assert not os.path.isdir(directory)
+        assert not os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
+        assert not os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+    assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
+    assert not os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
+
+
+def test_init_full(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Test init for full usage only."""
+    os.chdir(tmp_path)
+    command = 'trestle init --full'
+    execute_command_and_assert(command, 0, monkeypatch)
+
+    for directory in const.MODEL_DIR_LIST:
+        assert os.path.isdir(directory)
+        assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
+        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+    assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
+    assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
+
+
+def test_init_govdocs_n_local(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Test init with multiple flags behave like mode of the highest hierarchy."""
+    os.chdir(tmp_path)
+    command = 'trestle init --govdocs --local'
+    execute_command_and_assert(command, 0, monkeypatch)
+
+    for directory in const.MODEL_DIR_LIST:
+        assert os.path.isdir(directory)
+        assert not os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
+        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+    assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
+    assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))
+
+
+def test_init_govdocs_n_full(tmp_path: pathlib.Path, monkeypatch: MonkeyPatch):
+    """Test init with multiple flags behave like mode of the highest hierarchy."""
+    os.chdir(tmp_path)
+    command = 'trestle init --govdocs --full'
+    execute_command_and_assert(command, 0, monkeypatch)
+
+    for directory in const.MODEL_DIR_LIST:
+        assert os.path.isdir(directory)
+        assert os.path.isdir(os.path.join(const.TRESTLE_DIST_DIR, directory))
+        assert os.path.isfile(os.path.join(directory, const.TRESTLE_KEEP_FILE))
+    assert os.path.isdir(const.TRESTLE_CONFIG_DIR)
+    assert os.path.isfile(os.path.join(const.TRESTLE_CONFIG_DIR, const.TRESTLE_CONFIG_FILE))

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -180,6 +180,18 @@ IOF_SHORT = '-iof'
 IOF_LONG = '--include-optional-fields'
 IOF_HELP = 'Include fields that are optional in the OSCAL model when generating the new object.'
 
+INIT_FULL_SHORT = '-fl'
+INIT_FULL_LONG = '--full'
+INIT_FULL_HELP = 'Initializes Trestle workspace for local, API and governed documents usage.'
+
+INIT_GOVDOCS_SHORT = '-gd'
+INIT_GOVDOCS_LONG = '--govdocs'
+INIT_GOVDOCS_HELP = 'Initializes Trestle workspace for governed documents usage only.'
+
+INIT_LOCAL_SHORT = '-loc'
+INIT_LOCAL_LONG = '--local'
+INIT_LOCAL_HELP = 'Initializes Trestle workspace for local management of OSCAL models.'
+
 FILE_ENCODING = 'utf8'
 
 # Trestle documentation


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Added new modes to `trestle init`. Now it can be run in three different modes: full, local and govdocs.
Full mode is identical to current Trestle init
Local mode will not create dist folder
Govdocs mode will only create .trestle folder

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.

#Closes #1218
