### PR TITLE
fix: add top level to parts output by get_statement_parts

### DIFF
--- a/tests/data/json/simplified_nist_catalog.json
+++ b/tests/data/json/simplified_nist_catalog.json
@@ -220,6 +220,7 @@
               {
                 "id": "ac-1_smt",
                 "name": "statement",
+                "prose": "The organization:",
                 "parts": [
                   {
                     "id": "ac-1_smt.a",

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -272,13 +272,13 @@ def test_get_statement_parts(simplified_nist_catalog: cat.Catalog) -> None:
     """Test the catalog interface with complex controls."""
     interface = CatalogInterface(simplified_nist_catalog)
     parts = interface.get_statement_parts('ac-1')
-    assert len(parts) == 9
+    assert len(parts) == 10
     prt = parts[0]
     assert prt['indent'] == 0
-    assert prt['label'] == 'a.'
-    assert prt['prose'].startswith('Develop, document')
-    prt = parts[3]
-    assert prt['indent'] == 2
+    assert prt['label'] == ''
+    assert prt['prose'] == 'The organization:'
+    prt = parts[4]
+    assert prt['indent'] == 3
     assert prt['label'] == '(b)'
     assert prt['prose'].startswith('Is consistent with')
 

--- a/tests/trestle/core/utils_test.py
+++ b/tests/trestle/core/utils_test.py
@@ -273,7 +273,7 @@ def test_find_all_prose(simplified_nist_catalog: catalog.Catalog) -> None:
     """Test get all prose from catalog."""
     prose_list = ModelUtils.find_values_by_name(simplified_nist_catalog, 'prose')
     n_lines = len(prose_list)
-    assert n_lines == 224
+    assert n_lines == 225
 
 
 def test_strip_lower_equals() -> None:

--- a/trestle/core/catalog_interface.py
+++ b/trestle/core/catalog_interface.py
@@ -289,8 +289,8 @@ class CatalogInterface():
     @staticmethod
     def _get_statement_sub_parts(part: common.Part, indent: int) -> List[Dict[str, str]]:
         items = []
+        # this may be '' if no label
         label = ControlInterface.get_label(part)
-        label = 'no_label' if not label else label
         prose = '' if part.prose is None else part.prose
         items.append({'indent': indent, 'label': label, 'prose': prose})
         for prt in as_filtered_list(part.parts, lambda p: p.name == 'item'):
@@ -301,12 +301,15 @@ class CatalogInterface():
         """Get list of statement parts as dicts with indentation, label and prose."""
         items = []
         control = self.get_control(control_id)
-        # statement may have no parts at all but if statement present it is first part
-        if control and control.parts:
+
+        # control may have no statement or parts
+        # but if statement present it is first part
+        if control is None:
+            logger.warning(f'No control found for id {control_id}')
+        elif control.parts:
             part = control.parts[0]
             if part.name == 'statement':
-                for prt in as_filtered_list(part.parts, lambda p: p.name == 'item'):
-                    items.extend(CatalogInterface._get_statement_sub_parts(prt, 0))
+                items.extend(CatalogInterface._get_statement_sub_parts(part, 0))
             else:
                 logger.warning(f'Control {control_id} has parts but first part name is {part.name} - not statement')
         return items


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Small change so that get_statement_parts provides the top level prose for the statement
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
