### PR TITLE
fix: Fix docs template validate flags

### DIFF
--- a/tests/trestle/core/commands/author/docs_test.py
+++ b/tests/trestle/core/commands/author/docs_test.py
@@ -685,3 +685,39 @@ def test_instance_validate_with_governed_heading(
     # Validate non existing governed section
     command_string_validate_content = 'trestle author docs validate -tn test_task -gh=NonExisting'
     execute_command_and_assert(command_string_validate_content, 1, monkeypatch)
+
+
+def test_template_validate_flags_invalid_body(
+    testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Test behaviour of flags when validating template with invalid body."""
+    task_template = tmp_trestle_dir / '.trestle/author/test_task/0.0.1/template.md'
+    test_template = testdata_dir / 'author/0.0.1/test_1_md_format/template.md'
+
+    (tmp_trestle_dir / '.trestle/author/test_task/0.0.1').mkdir(parents=True)
+    task_template.touch()
+    shutil.copy(test_template, task_template)
+
+    command_validate = 'trestle author docs template-validate -tn test_task'
+    execute_command_and_assert(command_validate, 0, monkeypatch)
+
+    command_validate = 'trestle author docs template-validate -tn test_task -hv'
+    execute_command_and_assert(command_validate, 0, monkeypatch)
+
+    # Make invalid change in the body
+    md_api = MarkdownAPI()
+    header, tree = md_api.processor.process_markdown(task_template)
+    a_node = tree.get_node_for_key('# Required header 1', True)
+
+    assert a_node
+    tree.content.raw_text = tree.content.raw_text.replace('# Required header 1', '<unclosed_html>')
+    md_api.write_markdown_with_header(task_template, header, tree.content.raw_text)
+
+    command_validate = 'trestle author docs template-validate -tn test_task'
+    execute_command_and_assert(command_validate, 1, monkeypatch)
+
+    command_validate = 'trestle author docs template-validate -tn test_task -hov'
+    execute_command_and_assert(command_validate, 0, monkeypatch)
+
+    command_validate = 'trestle author docs template-validate -tn test_task -hv'
+    execute_command_and_assert(command_validate, 1, monkeypatch)

--- a/trestle/core/commands/author/docs.py
+++ b/trestle/core/commands/author/docs.py
@@ -162,16 +162,19 @@ class Docs(AuthorCommonCommand):
                 break
         return CmdReturnCodes.SUCCESS.value
 
-    def template_validate(self, heading: str, validate_header: bool, validate_only_header: bool) -> int:
+    def template_validate(self, heading: Optional[str], validate_header: bool, validate_only_header: bool) -> int:
         """Validate that the template is acceptable markdown."""
         template_file = self.template_dir / self.template_name
         if not self._validate_template_dir():
-            raise TrestleError('Aborting setup')
+            raise TrestleError(f'Aborting setup, template directory {self.template_dir} is invalid.')
         if not template_file.is_file():
             raise TrestleError(f'Required template file: {self.rel_dir(template_file)} does not exist. Exiting.')
         try:
             md_api = MarkdownAPI()
-            md_api.load_validator_with_template(template_file, validate_header, validate_only_header, heading)
+            validate_body = False if validate_only_header else True
+            md_api.load_validator_with_template(
+                template_file, validate_header or validate_only_header, validate_body, heading, True
+            )
         except Exception as ex:
             raise TrestleError(f'Template for task {self.task_name} failed to validate due to {ex}')
 

--- a/trestle/core/markdown/markdown_api.py
+++ b/trestle/core/markdown/markdown_api.py
@@ -41,12 +41,18 @@ class MarkdownAPI:
         md_template_path: pathlib.Path,
         validate_yaml_header: bool,
         validate_md_body: bool,
-        md_header_to_validate: Optional[str] = None
+        governed_section: Optional[str] = None,
+        validate_template: bool = False
     ) -> None:
-        """Load and initialize markdown validator."""
+        """Load and initialize markdown validator. By default the template won't be validated."""
         try:
-            self.processor.governed_header = md_header_to_validate
-            template_header, template_tree = self.processor.process_markdown(md_template_path)
+            self.processor.governed_header = governed_section
+            if validate_template:
+                template_header, template_tree = self.processor.process_markdown(md_template_path, validate_yaml_header,
+                                                                                 validate_md_body or governed_section is
+                                                                                 not None)
+            else:
+                template_header, template_tree = self.processor.process_markdown(md_template_path)
 
             if len(template_header) == 0 and validate_yaml_header:
                 raise TrestleError(f'Expected yaml header for markdown template where none exists {md_template_path}')
@@ -57,7 +63,7 @@ class MarkdownAPI:
                 template_tree,
                 validate_yaml_header,
                 validate_md_body,
-                md_header_to_validate
+                governed_section
             )
         except TrestleError as e:
             raise TrestleError(f'Error while loading markdown template {md_template_path}: {e}.')

--- a/trestle/core/markdown/markdown_api.py
+++ b/trestle/core/markdown/markdown_api.py
@@ -44,7 +44,7 @@ class MarkdownAPI:
         governed_section: Optional[str] = None,
         validate_template: bool = False
     ) -> None:
-        """Load and initialize markdown validator. By default the template won't be validated."""
+        """Load and initialize markdown validator."""
         try:
             self.processor.governed_header = governed_section
             if validate_template:
@@ -54,7 +54,7 @@ class MarkdownAPI:
             else:
                 template_header, template_tree = self.processor.process_markdown(md_template_path)
 
-            if len(template_header) == 0 and validate_yaml_header:
+            if not template_header and validate_yaml_header:
                 raise TrestleError(f'Expected yaml header for markdown template where none exists {md_template_path}')
 
             self.validator = MarkdownValidator(

--- a/trestle/core/markdown/markdown_processor.py
+++ b/trestle/core/markdown/markdown_processor.py
@@ -47,9 +47,12 @@ class MarkdownProcessor:
         except ValueError as e:
             raise TrestleError(f'Not a valid Github Flavored markdown: {e}.')
 
-    def process_markdown(self, md_path: pathlib.Path) -> Tuple[Dict, MarkdownNode]:
+    def process_markdown(self,
+                         md_path: pathlib.Path,
+                         read_header: bool = True,
+                         read_body: bool = True) -> Tuple[Dict, MarkdownNode]:
         """Parse the markdown and builds the tree to operate over it."""
-        header, markdown_wo_header = self.read_markdown_wo_processing(md_path)
+        header, markdown_wo_header = self.read_markdown_wo_processing(md_path, read_header, read_body)
 
         _ = self.render_gfm_to_html(markdown_wo_header)
 
@@ -57,12 +60,19 @@ class MarkdownProcessor:
         tree = MarkdownNode.build_tree_from_markdown(lines, self.governed_header)
         return header, tree
 
-    def read_markdown_wo_processing(self, md_path: pathlib.Path) -> Tuple[Dict, str]:
+    def read_markdown_wo_processing(self,
+                                    md_path: pathlib.Path,
+                                    read_header: bool = True,
+                                    read_body: bool = True) -> Tuple[Dict, str]:
         """Read markdown header to dictionary and body to string."""
         try:
             contents = frontmatter.loads(md_path.open('r', encoding=const.FILE_ENCODING).read())
-            header = contents.metadata
-            markdown_wo_header = contents.content
+            header = {}
+            markdown_wo_header = ''
+            if read_header:
+                header = contents.metadata
+            if read_body:
+                markdown_wo_header = contents.content
 
             return header, markdown_wo_header
         except UnicodeDecodeError as e:

--- a/trestle/core/markdown/markdown_validator.py
+++ b/trestle/core/markdown/markdown_validator.py
@@ -37,12 +37,12 @@ class MarkdownValidator:
         template_tree: MarkdownNode,
         validate_yaml_header: bool,
         validate_md_body: bool,
-        md_header_to_validate: Optional[str] = None
+        governed_section: Optional[str] = None
     ):
         """Initialize markdown validator."""
         self._validate_yaml_header = validate_yaml_header
         self._validate_md_body = validate_md_body
-        self.md_header_to_validate = md_header_to_validate.strip(' ') if md_header_to_validate is not None else None
+        self.governed_section = governed_section.strip(' ') if governed_section is not None else None
         self.template_header = template_header
         self.template_tree = template_tree
         self.template_path = tmp_path
@@ -98,18 +98,16 @@ class MarkdownValidator:
             elif headers_match and not self._validate_md_body:
                 return True
 
-        if self.md_header_to_validate is not None:
-            instance_gov_nodes = instance_tree.get_all_nodes_for_keys([self.md_header_to_validate], False)
-            template_gov_nodes = self.template_tree.get_all_nodes_for_keys([self.md_header_to_validate], False)
+        if self.governed_section is not None:
+            instance_gov_nodes = instance_tree.get_all_nodes_for_keys([self.governed_section], False)
+            template_gov_nodes = self.template_tree.get_all_nodes_for_keys([self.governed_section], False)
 
             if not instance_gov_nodes:
-                logger.info(f'Governed section {self.md_header_to_validate} not found in instance: {instance}')
+                logger.info(f'Governed section {self.governed_section} not found in instance: {instance}')
                 return False
 
             if not template_gov_nodes:
-                logger.info(
-                    f'Governed section {self.md_header_to_validate} not found in template: {self.template_path}'
-                )
+                logger.info(f'Governed section {self.governed_section} not found in template: {self.template_path}')
                 return False
 
             if [node.key for node in instance_gov_nodes] != [node.key for node in template_gov_nodes]:


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Currently `docs template-validate` would validate header and body by default, however only the body should be validated if no flags are provided. Header should be validated only when `-hv` or `-hov` are provided.

This PR fixes the issue.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
