### PR TITLE
fix: Bump flake8 in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
         files: "^(trestle|tests|scripts)"
         stages: [commit]
         additional_dependencies: [toml]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         args: [--extend-ignore, "P1,C812,C813,C814,C815,C816,W503,W605", "--illegal-import-packages=filecmp"]

--- a/trestle/core/models/elements.py
+++ b/trestle/core/models/elements.py
@@ -138,7 +138,7 @@ class ElementPath:
     def get_obm_wrapped_type(self,
                              root_model: Optional[Type[Any]] = None,
                              use_parent: bool = False) -> Type[OscalBaseModel]:
-        """Get the type of the element. If the type is a collection wrap the type in an OscalBaseModel as a __root__ element.
+        """Get the type of the element. Wraps the collection type in an OscalBaseModel as a __root__ element.
 
         This should principally be used for validating content.
 


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Gitlab repo of flake8 has been removed and project is now hosted on Github. 
Updated a version of flake8 used in pre-commit to Github repo

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
