### PR TITLE
fix: Fix html markdown blocks in documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -571,7 +571,8 @@ Example input OSCO scan result file contents (snippet):
 
 *ssg-ocp4-ds-cis-111.222.333.444-pod.yaml*
 
-<details>
+<details markdown>
+
 <summary>display sample</summary>
 
 ```yaml
@@ -643,7 +644,8 @@ Example input OSCAL metadata file contents:
 
 *oscal-metadata.yaml*
 
-<details>
+<details markdown>
+
 <summary>display sample</summary>
 
 ```yaml
@@ -741,7 +743,8 @@ Example output OSCAL Observations file contents (snippet):
 
 *ssg-ocp4-ds-cis-111.222.333.444-pod.json*
 
-<details>
+<details markdown>
+
 <summary>display sample</summary>
 
 ```json
@@ -882,7 +885,8 @@ Example input directory contents listing:
 
 *Tanium.comply-nist-results*
 
-<details>
+<details markdown>
+
 <summary>display sample</summary>
 
 ```json
@@ -982,7 +986,8 @@ Example output directory contents listing:
 
 *Tanium.oscal.json*
 
-<details>
+<details markdown>
+
 <summary>display sample</summary>
 
 ```json
@@ -1315,7 +1320,8 @@ Example component-definition.json:
 
 ### spreadsheet to component definition mapping
 
-<details>
+<details markdown>
+
 <summary>display mapping table</summary>
 
 <style>

--- a/docs/python_trestle_setup.md
+++ b/docs/python_trestle_setup.md
@@ -66,7 +66,8 @@ usage: trestle [-h]
                ...
 ```
 
-<details>
+<details markdown>
+
 <summary>Full help text</summary>
 
 ```bash

--- a/docs/trestle_author.md
+++ b/docs/trestle_author.md
@@ -6,8 +6,9 @@ to learn more about Trestle authoring capabilities.
 
 ## Contents
 
-<details>
-  <summary><b>1. Overview</b></summary>
+<details markdown>
+
+<summary><b>1. Overview</b></summary>
 
 ## Overview
 
@@ -29,8 +30,9 @@ The markdown centric workflows allow transition path where capability is [being 
 
 </details>
 
-<details>
-  <summary><b>2. Setting up the Trestle workspace</b></summary>
+<details markdown>
+
+<summary><b>2. Setting up the Trestle workspace</b></summary>
 
 ## Setting up the Trestle workspace
 
@@ -50,500 +52,514 @@ The templates will be located in the `/my_workspace/.trestle/author/`. Please no
 
 </details>
 
-<details>
-  <summary><b>3. Authoring of Documents</b></summary>
-
-- <details>
-  <summary><b>Documents Structural Enforcement</b></summary>
-
-  ## Markdown structural enforcement
-
-  Trestle templating enforces the documents to follow a specific structure. There are two ways in which structure is enforced in a document against template:
-
-  1. Enforcing a YAML header (metadata) structure at the top of the markdown document.
-  1. Enforcing a heading structure within the markdown document.
-
-  Each document is validated against a specific template, see CLI section below on information on how to specify which template the document should be validated against.
-
-  ### Enforcing YAML header (metadata) structure
-
-  Each template and document contains metadata in form of a YAML header that is placed on top.
-  When the document is created (i.e. `trestle docs setup`) the metadata is copied from the template to the newly created document.
-
-  Below is an example of a markdown file that contains YAML header:
-
-  ```markdown
-  ---
-  groceries:
-      grocery1:
-          name: apple
-          type: fruit
-          bought-in: Local market
-      grocery2:
-          name: potato
-          type: vegetable
-          bought-in: Local market
-  date: 01-01-2022
-  not-important-field: not important
-  x-trestle-version: 1.0.0
-  x-trestle-ignore: not-important-field, bought-in
-  ---
-  # The rest of my document
-  ```
-
-  Each field in the YAML header follows the `key: value` format.
-  For YAML header we validate the structure and the presence of the "keys" and not the "values".
-
-  The document YAML header(metadata) is said to be **_valid_** against the template, if and only if:
-
-  1. It contains **all** keys from the template EXCEPT the keys that either:
-     1. Start with `x-trestle`
-     1. Are listed under the `x-trestle-ignore` key (i.e. `x-trestle-ignore: not-important-field, bought-in`)
-  1. The version under `x-trestle-template-version: ` key is matching the template.
-  1. No new keys were added to the document.
-
-  For example, this change to the YAML header above is acceptable:
-
-  ```markdown
-  ---
-  groceries:
-      grocery1:
-          name: pear
-          type: fruit
-          bought-in: Superstore
-      grocery2:
-          name: potato
-          type: vegetable
-          bought-in: Local market
-  date: 10-10-2023
-  not-important-field: not important
-  x-trestle-version: 1.0.0
-  x-trestle-ignore: not-important-field, bought-in
-  ---
-  # The rest of my document
-  ```
-
-  ### Enforcing heading structure
-
-  Markdown headings are considered to be nested based on the heading level (i.e. number of `#`). For example, `## 1.1 Lower level heading` is below `# 1. top level heading`.
-
-  The document body is said to be **_valid_** against the template, if and only if,
-
-  1. It contains **_all_** the headings provided in the template.
-  1. No new headings were added at the top level (i.e. `# New heading` is not allowed).
-  1. All original headings are in the same order as in the template.
-  1. All headings must be in the hierarchical order (i.e. `# Heading` then `### Heading` then `## Heading` is invalid).
-  1. If the `--governed-heading` option is provided, then document is valid if no keys has changed in the specified governed section.
-
-  For example, consider this template as our starting point:
-
-  ```markdown
-  # Template heading 1
-  Some text
-  # Template heading 2
-  ## Template sub heading
-  ```
-
-  Now we added new sections and ended up with the following document:
-  (note: this document will be valid against the template above)
-
-  ```markdown
-  # Template heading 1
-  Content for heading one
-  ## Non-required sub header
-  Content for non-required sub header
-  # Template heading 2
-  Content for heading two
-  ## Template sub heading
-  Content for template sub heading
-  ### non required sub-sub heading
-  This sub-sub heading is okay
-  ```
-
-  However, violations such as adding or removing a heading at the top level are not acceptable:
-
-  ```markdown
-  # Template heading 1
-  Content for heading one
-  ## Non-required sub header
-  Content for non-required sub header
-  # Template heading 2
-  Content for heading two
-  ## Template sub heading
-  Content for template sub heading
-  # Top level heading that is not okay <<< NOT OKAY
-  ```
-
-  For each of the headings - the text of the heading is enforced with one caveat:
-
-  - If the template heading text is wrapped in curly brackets `{}` then the name is not measured e.g. `# {Insert title here}`.
-
-  ## Drawio enforcement mechanisms
-
-  Drawio or [diagrams.net](https://app.diagrams.net/) is a diagramming platform which has significant use for architecture diagrams. In the context of governance of content, trestle is supporting enforcement of metadata.
-
-  Drawio (or `mxgraph`) files have a set of data fields. In a drawio file this is available in the edit menu as *edit data*. The diagram below shows how to access the (meta)data.
-
-  ![Accessing the drawio data editor](assets/drawio_data_menu.png "Accessing the drawio data editor")
-
-  The data presents as a set of key-value pairs which can be edited (see below). The data is bound to each tab in a drawio file. The trestle CLI currently expects that metadata (whether from the template or file to be measured) is in the first tab when editing the draw io file.
-
-  ![Editing drawio data](assets/drawio_editing_data.png "Editing drawio data")
-
-  </details>
-
-- <details>
-  <summary><b>Setting Up Templates and Documents Via CLI</b></summary>
-  Trestle allows the setup of templates and governed documents in a several different ways based on the nature of the needed governance.
-
-  Definitions used in this section:
-
-  - _**document**_ - a markdown or drawio file that needs to be validated against some template.
-  - _**template**_ - an individual markdown or drawio file containing metadata and/or headings against which the documents will be validated.
-  - _**task**_ - a name of the folders containing documents and their respective templates.
-  - _**template folder**_ - an individual folder containing the templates that documents needs to be validated against.
-
-  You can set up multiple different tasks and types of validations in the same workspace.
-
-  Setup Trestle for:
-
-  - <details>
-      <summary><b>docs - Validating documents against one specific template (one template per task)</b></summary>
-
-    ## Validating documents against one specific template
-
-    In this section we describe the functionality of `trestle author docs` command.
-
-    `author docs` is designed to support enforcing and generating templating markdown files within a single folder based on a task name. Currently `author docs` supports markdown files only.
-
-    ### Creating new task/template
-
-    To create a new task with the necessary directory structures for running governed docs validation, run:
-
-    > trestle author docs setup -tn my_task_name
-
-    This will create a template folder and a single template: `TRESTLE_ROOT/.trestle/author/my_task_name/0.0.1/template.md`.
-    As well as an empty document folder: `TRESTLE_ROOT/my_task_name/`
-    The template will be applied to **all** markdown files in the task i.e.: `TRESTLE_ROOT/my_task_name/*.md`.
-
-    #### Extra options
-
-    - You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
-      By default if no version is provided `0.0.1` will be used.
-
-    ### Creating new document for the task
-
-    To create a new document that confirms to a template run:
-
-    > trestle author docs create-sample -tn my_task_name
-
-    This will create a sample document in: `TRESTLE_ROOT/my_task_name/my_task_name_000.md`.
-    Once created this document will be a complete copy of the template, however you can modify this file with your own content.
-
-    #### Extra options
-
-    - This command has no extra options
-
-    ### Validating the template
-
-    To ensure that the markdown in the template is parseable run:
-
-    > trestle author docs template-validate -tn my_task_name
-
-    #### Extra options
-
-    - If `--governed-heading 'heading name'` (`-gh`) is passed it ensures that the required heading exists.
-    - If `--header-validate` (`-hv`) is passed the header will be validated as well.
-    - If `--header-only-validate` (`-hov`) only the header and NOT the body will be validated
-
-    ### Validating the documents against the template
-
-    To validate the documents against a template run:
-
-    > trestle author docs validate -tn my_task_name
-
-    This will take the `TRESTLE_ROOT/.trestle/author/my_task_name/template.md` template and validate all markdown files here: `TRESTLE_ROOT/my_task_name/*.md`.
-
-    Running the command will validate that markdown body in the document is valid against the template. Please note that by default the header will **not** be validated.
-    See extra options for more validation options. To learn more on what exactly is validated please refer to `Documents Structural Enforcement` section in this document.
-
-    #### Extra options
-
-    - If `--governed-heading` (`-gh`) is passed it will ensure that the governed content was not modified. Governed content comes in the **key:** value format:
-      ```markdown
-         # Governed section
-         **Content Type:**  Foo
-         **Author(s):**  Bah
-         **Executive Owner:**  Stuff
-         **Technical Approver:**   John Doe (approved)
-         **Version:** 1.0.1
-      ```
-      Running `trestle author docs validate -tn docs_task -gh="Governed section"` will ensure this content is present in the document.
-    - If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
-    - If `--header-validate` (`-hv`) is passed the header will be validated as well.
-    - If `--header-only-validate` (`-hov`) is passed only the header and NOT the body will be validated.
-    - If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
-    - If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
-    - If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
-      Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
-
-    </details>
-
-  - <details>
-      <summary><b>folders - Validating documents against multiple templates and ensuring folder structure (multiple individual templates per task) </b></summary>
-
-    ## Validating against multiple templates
-
-    In this section we describe the functionality of `trestle author folders` command.
-
-    `author folders` is designed to allow the assembly of groups of templates where each folder contains unique content.
-    This command will validate that both: structure (i.e. all template documents are present) and content is preserved in the folder. Trestle author folders supports validation of both markdown and drawio files. Note that headers / metadata must be specified in each applicable template.
-
-    ### Creating new task folder
-
-    To create a new task folder run:
-
-    > trestle author folders setup -tn my_task_2
-
-    This will create a template folder with the following structure:
-
-    ```text
-    trestle_root
-     ┣ .trestle
-     ┃ ┣ author
-     ┃ ┃ ┣ my_task_2
-     ┃ ┃ ┃ ┣ 0.0.1
-     ┃ ┃ ┃ ┃ ┣ a_template.md
-     ┃ ┃ ┃ ┃ ┣ another_template.md
-     ┃ ┃ ┃ ┃ ┗ arhitecture.drawio
-     ┃ ┗ config.ini
-    ```
-
-    Each task folder is required to meet template requirements for all: `a_template.md`, `another_template.md`, and `template.drawio`. The names, numbers, and nesting of folders is user specifiable, however, unlike `docs` the names must be carried over to each instances.
-
-    #### Extra options
-
-    - You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
-      By default if no version is provided `0.0.1` will be used.
-
-    ### Creating new documents for the task
-
-    Following the similar structure of `docs`, measurement occurs in the `my_task_2` where this structure is enforced for every directory.
-
-    To create a new folder with documents for the task run:
-
-    > trestle author folders create-sample -tn my_task_2
-
-    This will create a subfolder in the `my_task_2` with the same content as in template folder. Running it twice will result in:
-
-    ```text
-    trestle_root
-     ┣ .trestle
-     ┣ my_task_2
-     ┃ ┣ sample_folder_0
-     ┃ ┃ ┣ a_template.md
-     ┃ ┃ ┣ arhitecture.drawio
-     ┃ ┃ ┗ another_template.md
-
-     ┃ ┗ sample_folder_1
-     ┃ ┃ ┣ a_template.md
-     ┃ ┃ ┣ arhitecture.drawio
-     ┃ ┃ ┗ another_template.md
-    ```
-
-    #### Extra options
-
-    - This command has no extra options
-
-    ### Validating the templates
-
-    To validate the documents against the template run:
-
-    > trestle author folders template-validate -tn my_task_2
-
-    This will ensure that the respective template files are parseable.
-
-    #### Extra options
-
-    - This command has no extra options
-
-    ### Validating the documents against templates
-
-    The validation in `trestle author folder` runs similarly as in `docs` but now each document will be validated against the template with the same name as in the template folder.
-
-    To validate the documents against their respective templates, run:
-
-    > trestle author folders validate -tn my_task_name
-
-    This will validate all files. Please note that all files from the template folder must be present in the individual document folders.
-
-    #### Extra options
-
-    - If `--governed-heading` (`-gh`) is passed it will ensure that the governed content was not modified. Governed content comes in the **key:** value format:
-      ```markdown
-         # Governed section
-         **Content Type:**  Foo
-         **Author(s):**  Bah
-         **Executive Owner:**  Stuff
-         **Technical Approver:**   John Doe (approved)
-         **Version:** 1.0.1
-      ```
-      Running `trestle author docs validate -tn docs_task -gh="Governed section"` will ensure this content is present in the document.
-    - If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
-    - If `--header-validate` (`-hv`) is passed the header will be validated as well.
-    - If `--header-only-validate` (`-hov`) is passed only the header and NOT the body will be validated.
-    - If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
-    - If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
-    - If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
-      Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
-
-    </details>
-
-  - <details>
-      <summary><b>headers - Validate only the headers against a global or a specific template </b></summary>
-
-    ## Validate only the headers against a global or a specific template.
-
-    In this section we describe the functionality of `trestle author headers` command.
-
-    Trestle author headers supports a slightly different usecase than that of `docs` and `folders` above as only the YAML headers will be validated.
-    This command can be useful when one does not care about the markdown structure and might want to use global templates (templates that are shared across multiple tasks).
-
-    With `headers` template folder can contain both .md and .drawio files and each file will be validated against the template that matches the extension.
-    Also `headers` allow user to have `global` templates that can be shared across multiple tasks.
-
-    ### Creating new task/template
-
-    To create a new task run:
-
-    > trestle author headers setup -tn my_task_3
-
-    This will create a template folder with the following format:
-
-    ```text
-    trestle_root
-    ┣ .trestle
-    ┃ ┣ author
-    ┃ ┃ ┣ my_task_3
-    ┃ ┃ ┃ ┣ 0.0.1
-    ┃ ┃ ┃ ┃ ┣ template.md
-    ┃ ┃ ┃ ┃ ┗ template.drawio
-    ┃ ┗ config.ini
-    ```
-
-    #### Extra options
-
-    - If `--global` (`-g`) is passed then `__global__` then it will create `trestle_root/.trestle/author/__global__` folder. Use this when you would like to use same template for multiple tasks.
-      ```text
-      trestle_root
-      ┣ .trestle
-      ┃ ┣ author
-      ┃ ┃ ┣ __global__
-      ┃ ┃ ┃ ┣ 0.0.1
-      ┃ ┃ ┃ ┃ ┣ template.md
-      ┃ ┃ ┃ ┃ ┗ template.drawio
-      ┃ ┗ config.ini
-      ```
-    - You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
-      By default if no version is provided `0.0.1` will be used.
-
-    ### Creating new documents
-
-    As of now this command does not support the automatic creation of the sample documents.
-
-    ### Validating the templates
-
-    To validate the documents against the template run:
-
-    > trestle author headers template-validate -tn my_task_3
-
-    This will ensure that the respective template files are parseable.
-
-    #### Extra options
-
-    - This command has no extra options
-
-    ### Validating the documents
-
-    To validate the documents against the template run:
-
-    > trestle author headers validate -tn my_task_3
-
-    This will validate all files within the directory against the templates (of the matching task name) by matching the extensions.
-    Please note that **only** headers will be validated. There is no option to validate the body.
-
-    ### Extra options
-
-    - If `--global` (`-g`) is passed it will create `trestle_root/.trestle/author/__global__` folder. Use this when you would like to use same template for multiple tasks.
-    - If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
-    - If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
-    - If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
-    - If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
-      Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
-
-    </details>
-
-  </details>
-
-- <details>
-  <summary><b>Template Versioning</b></summary>
-
-  ## Template versioning
-
-  ### Prerequisite:
-
-  This section assumes that you have an existing Trestle workspace initialized, with existing template and governed documents.
-  Please follow steps in the section `Setting up the Trestle Workspace` if you don't have one.
-
-  Trestle provides the capability to version the templates and the documents via `x-trestle-template-version` field in the header.
-
-  Consider an example where we have a governed document called `Decision 1` that we now need to update to contain a new header field `approved-status` and a new required heading `Heading n` at the end, as demonstrated in the Figure below:
-  ![Decision document update](assets/template_versioning.png)
-
-  The intended workflow in this scenario is to:
-
-  1.Create a new version of the `decisions` template:
-
-  ```bash
-  cd my_workspace 
-  trestle author docs setup -tn decisions -tv 0.1.1
-  >>> Set template version to 0.1.1.
-  >>> Template file setup for task decisions at .trestle/author/decisions/0.1.1/template.md
-  >>> Task directory is decisions
-  ```
-
-  Add the new required content to the newly created template. In our example simply copy-paste all content from the `.trestle/author/decisions/0.1.0/template.md` and add the newly required fields.
-
-  2.Create a new instance of that template.
-
-  ```bash
-  trestle author docs create-sample -tn decisions -tv 0.1.1
-  >>> Set template version to 0.1.1.
-  ```
-
-  This step will create a copy of the template of version 0.1.1.
-
-  Now you will need to fill the documents with the updated information and new fields.
-
-  3.(Optional) Delete the old document.
-
-  Now that you have a new version of the document, you can delete the old one if you no longer need it. You can also keep it if you would like to maintain a history of updates.
-
-  4.Run validation.
-
-  After filling the contents to the new version of the template, you can run the validation to ensure that everything works as expected.
-
-  ```bash
-  trestle author docs validate -tn decisions
-  >>> Instances will be validated against template version specified in their headers.
-  >>> VALID: decisions/decision_000.md
-  ```
-
-  </details>
+<details markdown>
+
+<summary><b>3. Authoring of Documents</b></summary>
+
+<details markdown>
+
+<summary><b>Documents Structural Enforcement</b></summary>
+
+## Markdown structural enforcement
+
+Trestle templating enforces the documents to follow a specific structure. There are two ways in which structure is enforced in a document against template:
+
+1. Enforcing a YAML header (metadata) structure at the top of the markdown document.
+1. Enforcing a heading structure within the markdown document.
+
+Each document is validated against a specific template, see CLI section below on information on how to specify which template the document should be validated against.
+
+### Enforcing YAML header (metadata) structure
+
+Each template and document contains metadata in form of a YAML header that is placed on top.
+When the document is created (i.e. `trestle docs setup`) the metadata is copied from the template to the newly created document.
+
+Below is an example of a markdown file that contains YAML header:
+
+```markdown
+---
+groceries:
+grocery1:
+  name: apple
+  type: fruit
+  bought-in: Local market
+grocery2:
+  name: potato
+  type: vegetable
+  bought-in: Local market
+date: 01-01-2022
+not-important-field: not important
+x-trestle-version: 1.0.0
+x-trestle-ignore: not-important-field, bought-in
+---
+# The rest of my document
+```
+
+Each field in the YAML header follows the `key: value` format.
+For YAML header we validate the structure and the presence of the "keys" and not the "values".
+
+The document YAML header(metadata) is said to be **_valid_** against the template, if and only if:
+
+1. It contains **all** keys from the template EXCEPT the keys that either:
+   1. Start with `x-trestle`
+   1. Are listed under the `x-trestle-ignore` key (i.e. `x-trestle-ignore: not-important-field, bought-in`)
+1. The version under `x-trestle-template-version: ` key is matching the template.
+1. No new keys were added to the document.
+
+For example, this change to the YAML header above is acceptable:
+
+```markdown
+---
+groceries:
+  grocery1:
+      name: pear
+      type: fruit
+      bought-in: Superstore
+  grocery2:
+      name: potato
+      type: vegetable
+      bought-in: Local market
+date: 10-10-2023
+not-important-field: not important
+x-trestle-version: 1.0.0
+x-trestle-ignore: not-important-field, bought-in
+---
+# The rest of my document
+```
+
+### Enforcing heading structure
+
+Markdown headings are considered to be nested based on the heading level (i.e. number of `#`). For example, `## 1.1 Lower level heading` is below `# 1. top level heading`.
+
+The document body is said to be **_valid_** against the template, if and only if,
+
+1. It contains **_all_** the headings provided in the template.
+1. No new headings were added at the top level (i.e. `# New heading` is not allowed).
+1. All original headings are in the same order as in the template.
+1. All headings must be in the hierarchical order (i.e. `# Heading` then `### Heading` then `## Heading` is invalid).
+1. If the `--governed-heading` option is provided, then document is valid if no keys has changed in the specified governed section.
+
+For example, consider this template as our starting point:
+
+```markdown
+# Template heading 1
+Some text
+# Template heading 2
+## Template sub heading
+```
+
+Now we added new sections and ended up with the following document:
+(note: this document will be valid against the template above)
+
+```markdown
+# Template heading 1
+Content for heading one
+## Non-required sub header
+Content for non-required sub header
+# Template heading 2
+Content for heading two
+## Template sub heading
+Content for template sub heading
+### non required sub-sub heading
+This sub-sub heading is okay
+```
+
+However, violations such as adding or removing a heading at the top level are not acceptable:
+
+```markdown
+# Template heading 1
+Content for heading one
+## Non-required sub header
+Content for non-required sub header
+# Template heading 2
+Content for heading two
+## Template sub heading
+Content for template sub heading
+# Top level heading that is not okay <<< NOT OKAY
+```
+
+For each of the headings - the text of the heading is enforced with one caveat:
+
+- If the template heading text is wrapped in curly brackets `{}` then the name is not measured e.g. `# {Insert title here}`.
+
+## Drawio enforcement mechanisms
+
+Drawio or [diagrams.net](https://app.diagrams.net/) is a diagramming platform which has significant use for architecture diagrams. In the context of governance of content, trestle is supporting enforcement of metadata.
+
+Drawio (or `mxgraph`) files have a set of data fields. In a drawio file this is available in the edit menu as *edit data*. The diagram below shows how to access the (meta)data.
+
+![Accessing the drawio data editor](assets/drawio_data_menu.png "Accessing the drawio data editor")
+
+The data presents as a set of key-value pairs which can be edited (see below). The data is bound to each tab in a drawio file. The trestle CLI currently expects that metadata (whether from the template or file to be measured) is in the first tab when editing the draw io file.
+
+![Editing drawio data](assets/drawio_editing_data.png "Editing drawio data")
 
 </details>
-<details>
-  <summary><b>4. Authoring of OSCAL Models</b></summary>
+
+<details markdown>
+
+<summary><b>Setting Up Templates and Documents Via CLI</b></summary>
+Trestle allows the setup of templates and governed documents in a several different ways based on the nature of the needed governance.
+
+Definitions used in this section:
+
+- _**document**_ - a markdown or drawio file that needs to be validated against some template.
+- _**template**_ - an individual markdown or drawio file containing metadata and/or headings against which the documents will be validated.
+- _**task**_ - a name of the folders containing documents and their respective templates.
+- _**template folder**_ - an individual folder containing the templates that documents needs to be validated against.
+
+You can set up multiple different tasks and types of validations in the same workspace.
+
+Setup Trestle for:
+
+<details markdown>
+
+<summary><b>docs - Validating documents against one specific template (one template per task)</b></summary>
+
+## Validating documents against one specific template
+
+In this section we describe the functionality of `trestle author docs` command.
+
+`author docs` is designed to support enforcing and generating templating markdown files within a single folder based on a task name. Currently `author docs` supports markdown files only.
+
+### Creating new task/template
+
+To create a new task with the necessary directory structures for running governed docs validation, run:
+
+> trestle author docs setup -tn my_task_name
+
+This will create a template folder and a single template: `TRESTLE_ROOT/.trestle/author/my_task_name/0.0.1/template.md`.
+As well as an empty document folder: `TRESTLE_ROOT/my_task_name/`
+The template will be applied to **all** markdown files in the task i.e.: `TRESTLE_ROOT/my_task_name/*.md`.
+
+#### Extra options
+
+- You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
+  By default if no version is provided `0.0.1` will be used.
+
+### Creating new document for the task
+
+To create a new document that confirms to a template run:
+
+> trestle author docs create-sample -tn my_task_name
+
+This will create a sample document in: `TRESTLE_ROOT/my_task_name/my_task_name_000.md`.
+Once created this document will be a complete copy of the template, however you can modify this file with your own content.
+
+#### Extra options
+
+- This command has no extra options
+
+### Validating the template
+
+To ensure that the markdown in the template is parseable run:
+
+> trestle author docs template-validate -tn my_task_name
+
+#### Extra options
+
+- If `--governed-heading 'heading name'` (`-gh`) is passed it ensures that the required heading exists.
+- If `--header-validate` (`-hv`) is passed the header will be validated as well.
+- If `--header-only-validate` (`-hov`) only the header and NOT the body will be validated
+
+### Validating the documents against the template
+
+To validate the documents against a template run:
+
+> trestle author docs validate -tn my_task_name
+
+This will take the `TRESTLE_ROOT/.trestle/author/my_task_name/template.md` template and validate all markdown files here: `TRESTLE_ROOT/my_task_name/*.md`.
+
+Running the command will validate that markdown body in the document is valid against the template. Please note that by default the header will **not** be validated.
+See extra options for more validation options. To learn more on what exactly is validated please refer to `Documents Structural Enforcement` section in this document.
+
+#### Extra options
+
+- If `--governed-heading` (`-gh`) is passed it will ensure that the governed content was not modified. Governed content comes in the **key:** value format:
+
+```markdown
+     # Governed section
+     **Content Type:**  Foo
+     **Author(s):**  Bah
+     **Executive Owner:**  Stuff
+     **Technical Approver:**   John Doe (approved)
+     **Version:** 1.0.1
+```
+
+Running `trestle author docs validate -tn docs_task -gh="Governed section"` will ensure this content is present in the document.
+
+- If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
+- If `--header-validate` (`-hv`) is passed the header will be validated as well.
+- If `--header-only-validate` (`-hov`) is passed only the header and NOT the body will be validated.
+- If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
+- If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
+- If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
+  Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
+
+</details>
+
+<details markdown>
+
+<summary><b>folders - Validating documents against multiple templates and ensuring folder structure (multiple individual templates per task) </b></summary>
+
+## Validating against multiple templates
+
+In this section we describe the functionality of `trestle author folders` command.
+
+`author folders` is designed to allow the assembly of groups of templates where each folder contains unique content.
+This command will validate that both: structure (i.e. all template documents are present) and content is preserved in the folder. Trestle author folders supports validation of both markdown and drawio files. Note that headers / metadata must be specified in each applicable template.
+
+### Creating new task folder
+
+To create a new task folder run:
+
+> trestle author folders setup -tn my_task_2
+
+This will create a template folder with the following structure:
+
+```text
+trestle_root
+┣ .trestle
+┃ ┣ author
+┃ ┃ ┣ my_task_2
+┃ ┃ ┃ ┣ 0.0.1
+┃ ┃ ┃ ┃ ┣ a_template.md
+┃ ┃ ┃ ┃ ┣ another_template.md
+┃ ┃ ┃ ┃ ┗ arhitecture.drawio
+┃ ┗ config.ini
+```
+
+Each task folder is required to meet template requirements for all: `a_template.md`, `another_template.md`, and `template.drawio`. The names, numbers, and nesting of folders is user specifiable, however, unlike `docs` the names must be carried over to each instances.
+
+#### Extra options
+
+- You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
+  By default if no version is provided `0.0.1` will be used.
+
+### Creating new documents for the task
+
+Following the similar structure of `docs`, measurement occurs in the `my_task_2` where this structure is enforced for every directory.
+
+To create a new folder with documents for the task run:
+
+> trestle author folders create-sample -tn my_task_2
+
+This will create a subfolder in the `my_task_2` with the same content as in template folder. Running it twice will result in:
+
+```text
+trestle_root
+ ┣ .trestle
+ ┣ my_task_2
+ ┃ ┣ sample_folder_0
+ ┃ ┃ ┣ a_template.md
+ ┃ ┃ ┣ arhitecture.drawio
+ ┃ ┃ ┗ another_template.md
+
+ ┃ ┗ sample_folder_1
+ ┃ ┃ ┣ a_template.md
+ ┃ ┃ ┣ arhitecture.drawio
+ ┃ ┃ ┗ another_template.md
+```
+
+#### Extra options
+
+- This command has no extra options
+
+### Validating the templates
+
+To validate the documents against the template run:
+
+> trestle author folders template-validate -tn my_task_2
+
+This will ensure that the respective template files are parseable.
+
+#### Extra options
+
+- This command has no extra options
+
+### Validating the documents against templates
+
+The validation in `trestle author folder` runs similarly as in `docs` but now each document will be validated against the template with the same name as in the template folder.
+
+To validate the documents against their respective templates, run:
+
+> trestle author folders validate -tn my_task_name
+
+This will validate all files. Please note that all files from the template folder must be present in the individual document folders.
+
+#### Extra options
+
+- If `--governed-heading` (`-gh`) is passed it will ensure that the governed content was not modified. Governed content comes in the **key:** value format:
+  ```markdown
+     # Governed section
+     **Content Type:**  Foo
+     **Author(s):**  Bah
+     **Executive Owner:**  Stuff
+     **Technical Approver:**   John Doe (approved)
+     **Version:** 1.0.1
+  ```
+
+Running `trestle author docs validate -tn docs_task -gh="Governed section"` will ensure this content is present in the document.
+
+- If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
+- If `--header-validate` (`-hv`) is passed the header will be validated as well.
+- If `--header-only-validate` (`-hov`) is passed only the header and NOT the body will be validated.
+- If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
+- If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
+- If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
+  Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
+
+</details>
+
+<details markdown>
+
+<summary><b>headers - Validate only the headers against a global or a specific template </b></summary>
+
+## Validate only the headers against a global or a specific template.
+
+In this section we describe the functionality of `trestle author headers` command.
+
+Trestle author headers supports a slightly different usecase than that of `docs` and `folders` above as only the YAML headers will be validated.
+This command can be useful when one does not care about the markdown structure and might want to use global templates (templates that are shared across multiple tasks).
+
+With `headers` template folder can contain both .md and .drawio files and each file will be validated against the template that matches the extension.
+Also `headers` allow user to have `global` templates that can be shared across multiple tasks.
+
+### Creating new task/template
+
+To create a new task run:
+
+> trestle author headers setup -tn my_task_3
+
+This will create a template folder with the following format:
+
+```text
+trestle_root
+┣ .trestle
+┃ ┣ author
+┃ ┃ ┣ my_task_3
+┃ ┃ ┃ ┣ 0.0.1
+┃ ┃ ┃ ┃ ┣ template.md
+┃ ┃ ┃ ┃ ┗ template.drawio
+┃ ┗ config.ini
+```
+
+#### Extra options
+
+- If `--global` (`-g`) is passed then `__global__` then it will create `trestle_root/.trestle/author/__global__` folder. Use this when you would like to use same template for multiple tasks.
+  ```text
+  trestle_root
+  ┣ .trestle
+  ┃ ┣ author
+  ┃ ┃ ┣ __global__
+  ┃ ┃ ┃ ┣ 0.0.1
+  ┃ ┃ ┃ ┃ ┣ template.md
+  ┃ ┃ ┃ ┃ ┗ template.drawio
+  ┃ ┗ config.ini
+  ```
+- You can create different versions of the template by specifying the version via `--template-version` flag. See `Template Versioning` section for more information.
+  By default if no version is provided `0.0.1` will be used.
+
+### Creating new documents
+
+As of now this command does not support the automatic creation of the sample documents.
+
+### Validating the templates
+
+To validate the documents against the template run:
+
+> trestle author headers template-validate -tn my_task_3
+
+This will ensure that the respective template files are parseable.
+
+#### Extra options
+
+- This command has no extra options
+
+### Validating the documents
+
+To validate the documents against the template run:
+
+> trestle author headers validate -tn my_task_3
+
+This will validate all files within the directory against the templates (of the matching task name) by matching the extensions.
+Please note that **only** headers will be validated. There is no option to validate the body.
+
+### Extra options
+
+- If `--global` (`-g`) is passed it will create `trestle_root/.trestle/author/__global__` folder. Use this when you would like to use same template for multiple tasks.
+- If `--ignore ^_.*` (`-ig`) is passed it will validate all files except folders and files that start with underscore `_`. Use this option when you would like to ignore any folders or files that match given regular expression.
+- If `--readme-validate` (`-rv`) is passed README.md will be validated as well, otherwise it is ignored.
+- If `--recurse` (`-r`) is passed the documents in the subfolders will also be validated. By default `author docs` only indexes a flat directory.
+- If `--template-version 1.0.0` (`-tv`) is passed the header field `x-trestle-template-version` will be ignored and document will be forcefully validated against template of version `1.0.0`.
+  Use this for testing purposes _only_ when you need to validate the document against a specific template. By default the template version will be determined based on `x-trestle-template-version` in the document.
+
+</details>
+
+</details>
+
+<details markdown>
+
+<summary><b>Template Versioning</b></summary>
+
+## Template versioning
+
+### Prerequisite:
+
+This section assumes that you have an existing Trestle workspace initialized, with existing template and governed documents.
+Please follow steps in the section `Setting up the Trestle Workspace` if you don't have one.
+
+Trestle provides the capability to version the templates and the documents via `x-trestle-template-version` field in the header.
+
+Consider an example where we have a governed document called `Decision 1` that we now need to update to contain a new header field `approved-status` and a new required heading `Heading n` at the end, as demonstrated in the Figure below:
+![Decision document update](assets/template_versioning.png)
+
+The intended workflow in this scenario is to:
+
+1.Create a new version of the `decisions` template:
+
+```bash
+cd my_workspace 
+trestle author docs setup -tn decisions -tv 0.1.1
+>>> Set template version to 0.1.1.
+>>> Template file setup for task decisions at .trestle/author/decisions/0.1.1/template.md
+>>> Task directory is decisions
+```
+
+Add the new required content to the newly created template. In our example simply copy-paste all content from the `.trestle/author/decisions/0.1.0/template.md` and add the newly required fields.
+
+2.Create a new instance of that template.
+
+```bash
+trestle author docs create-sample -tn decisions -tv 0.1.1
+>>> Set template version to 0.1.1.
+```
+
+This step will create a copy of the template of version 0.1.1.
+
+Now you will need to fill the documents with the updated information and new fields.
+
+3.(Optional) Delete the old document.
+
+Now that you have a new version of the document, you can delete the old one if you no longer need it. You can also keep it if you would like to maintain a history of updates.
+
+4.Run validation.
+
+After filling the contents to the new version of the template, you can run the validation to ensure that everything works as expected.
+
+```bash
+trestle author docs validate -tn decisions
+>>> Instances will be validated against template version specified in their headers.
+>>> VALID: decisions/decision_000.md
+```
+
+</details>
+
+</details>
+</details>
+<details markdown>
+
+<summary><b>4. Authoring of OSCAL Models</b></summary>
 
 ## OSCAL Authoring
 

--- a/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
+++ b/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
@@ -8,14 +8,17 @@ The key modes of authoring are *-generate* and *-assemble*.  During *-generate* 
 
 A third mode of authoring is *-filter*, where parts of a document are removed.  This allows one large master document to be represented in simpler ways with, e.g. proprietary prose culled in form intended for consumption outside a company.
 
-<details><summary>Integration with git and CI/CD</summary>
+<details markdown>
+
+<summary>Integration with git and CI/CD</summary>
 The command line interface in Trestle makes a powerful combination with git and CI/CD environments (Continuous Integration, Continuous Delivery or Deployment) when the trestle commands are performed via github actions or equivalent.  This allows different classes of users based on 1) their access to the repository 2) the changes to documents they are allowed to commit, and 3) the changes they can make to actions that are triggered by a commit.  As an example, a command line option may limit the type of content added to a profile, and if disallowed changes are detected during commit - the commit will be rejected.  This, in combination with having all controls as individual markdown files organized by groups in directories, makes management and tracking of author edits robust and automatically controlled by the built-in features of the respository.
 
 For an example of actions triggered by a commit, a change to a control in a catalog could generate a pull request that is approved by someone with appropriate authority, and when it is later merged it triggers notification downstream to authors of profiles that import that catalog.
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>The author commands</summary>
 
 The author commands are:
@@ -33,7 +36,8 @@ Note that version 1.x of trestle creates SSP's by adding prose directly to the S
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>Some details of the author commands</summary>
 
 The markdown files for controls usually have a YAML header at the top containing metadata about the control.  Sometimes that information is read-only and intended as additional information useful during markdown editing, but in other cases the content may be edited and incorporated as new values for the control after `-assemble`.  In addition, most `-generate` commands allow specifying a separate YAML header file containing information either needed by the command, or intended to be incorporated into the header of each control markdown file.  When generating markdown a YAML header may be optionally provided, and if so, the option `--overwrite-header-values` will cause the values in the provided YAML header to overwrite the value in the markdown file's header for any items that are common.  Otherwise the provided YAML header will simply insert any values not already in the markdown header. By default, Trestle will preserve the history of the changes in generated markdowns, however `--force-overwrite` option can be used to overwrite markdowns with content from JSON. Note that this option will completely delete all existing markdowns (in the given `output` folder) without saving any changes. To save the changes, run assemble first.
@@ -45,7 +49,8 @@ For a complete standalone demonstration of the SSP generation process with trest
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>Background on underlying concepts</summary>
 
 In order to understand the specific operations handled by these commands, it is helpful to clarify some of the underlying OSCAL structures and how they can be edited in markdown form.  This tutorial should be viewed in the context of the extensive documentation provided by [OSCAL](https://pages.nist.gov/OSCAL).
@@ -78,7 +83,8 @@ NOTE: We use `json` format for specifying OSCAL files in this tutorial, but it i
 
 ## The author commands for markdown generation and assembly (to JSON)
 
-<details>
+<details markdown>
+
 <summary>`trestle author catalog-generate` and `trestle author catalog-assemble`</summary>
 
 `catalog-generate` takes an existing json catalog and writes it out as markdown files for each control in a user-specified directory.  That directory will contain subdirectories for each group in the catalog, and those directories may contain subdirectories for groups within groups.  But controls containing controls are always split out into a series of controls in the same directory - and each control markdown file corresponds to a single control.
@@ -87,7 +93,8 @@ We now look at the contents of a typical control markdown file.
 
 A Control may contain many parts, but only one of them is a Statement, which describes the function of the control.  The statement itself is broken down into separate items, each of which may contain parameter id's in "moustache" (`{{}}`) brackets.  Below is an example of a control as generated in markdown form by the `catalog-generate` command.
 
-<details>
+<details markdown>
+
 <summary>Control example</summary>
 
 ```markdown
@@ -182,12 +189,14 @@ Note that `catalog-assemble` can instantiate a catalog anew from a manually crea
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>`trestle author profile-generate` and `trestle author profile-assemble`</summary>
 
 The background text above conveys how a profile pulls controls from catalogs and makes modifications to them, and the `trestle profile` tools let you change the way those modifications are made.  In addition to selecting controls and setting parameters, a profile may add new parts to a control that provide additional guidance specific to a certain use case.  `profile-generate` is run with the command, `trestle author profile-generate --name profile_name --output markdown_dir`.  It will load the specified profile name from the trestle workspace (it must have been imported into the trestle workspace prior) and create its corresponding resolved profile catalog - but *without* applying any of its `Adds` of additonal guidance content or `SetParameters`.  It will make all other modifications, but the `Adds` and `SetParameters` are kept separate, as shown below:
 
-<details>
+<details markdown>
+
 <summary>Example of control markdown after `profile-generate`</summary>
 
 ```markdown
@@ -356,7 +365,8 @@ Keep in mind that the header in the `profile-` tools corresponds to the `SetPara
 
 As with `catalog-assemble` described above, a new file is written out only if there are changes to the model relative to an existing output file.
 
-<details>
+<details markdown>
+
 <summary>Use of Sections in `profile-generate` and `profile-assemble`</summary>
 
 The addition of guidance sections in the `profile` tools requires special handling because the corresponding parts have both a name and a title, where the name is a short form used as an id in the json schema, while the title is the readable form intended for final presentation.  An example is `ImplGuidance` vs. `Implementation Guidance`.  The trestle authoring tools strive to make the markdown as readable as possible, therefore the headings for sections use the title - which means somehow there is a need for a mapping from the short name to the long title for each section.  This mapping is provided in several ways:  During `profile-generate` you may provide a `--sections "ImplGuidance:Implementation Guidance,ExpEvidence:Expected Evidence"` option that would provide title values for `ImplGuidance` and `ExpEvidence`.  This dictionary mapping is then inserted into the yaml header of each control's markdown.  You may also add this mapping directly to a yaml file that is passed in during `profile-generate`, which is preferable if the list of sections is long.  The sections should be entered in the yaml header in a section titled, `x-trestle-sections`.
@@ -371,7 +381,8 @@ Note that these section options are all optional and there isn't a need to provi
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>Markdown Specifications for Editable Content.</summary>
 
 For the ease of editing markdown in Github, Trestle's markdown parser follows [Github Flavoured Markdown (GFM) specifications](https://github.github.com/gfm/) and therefore only certain Control headers will be parsed and added to the control.
@@ -415,7 +426,8 @@ In all cases above Trestle markdown parser will skip such headers and it will be
 </details>
 </details>
 
-<details>
+<details markdown>
+
 <summary>`trestle author ssp-generate` and `trestle author ssp-assemble`</summary>
 
 The `ssp-generate` sub-command creates a partial SSP (System Security Plan) from a profile and optional yaml header file.  `ssp-assemble` (described below) can later assemble the markdown files into a single json SSP file.  The profile contains a list of imports that are either a direct reference to a catalog, or an indirect reference via a profile.
@@ -441,7 +453,8 @@ Similar to `catalog-generate`, the `--yaml` and `--overwrite-header-values` flag
 
 The resulting files look like this:
 
-<details>
+<details markdown>
+
 <summary>Example of control markdown after `ssp-generate`</summary>
 
 ```markdown
@@ -570,7 +583,8 @@ As with all the `assemble` tools, you may optionally specify a `--name` for a co
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>`trestle author ssp-filter`</summary>
 
 Once you have an SSP in the trestle directory you can filter its contents with a profile by using the command `trestle author ssp-filter`.  The SSP is assumed to contain a superset of the controls needed by the profile, and the filter operation will generate a new SSP with only those controls needed by the profile.  The filter command is invoked as:
@@ -581,7 +595,8 @@ Both the SSP and profile must be present in the trestle directory.  This command
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>`trestle author component-generate`</summary>
 
 The `trestle author component-generate` command takes a JSON ComponentDefinition file and creates markdown for its controls in separate directories for each of the DefinedComponents in the file.  This allows specifying the implementation response and status for each component separately in separate markdown files for a control.  In addition, the markdown captures Rules in the control that specify descriptions and parameter values that apply to the expected responses.
@@ -590,7 +605,8 @@ The command has few options compared to other author commands and only requires 
 
 Here is an example of the generated markdown for the component `OSCO` in the ComponentDefinition file.  Note that this file will be under the subdirectory `OSCO/source_name` of the specified output directory - and any other DefinedComponents will have corresponding subdirectories level with the `OSCO` one.  Here `source_name` refers to the name of the profile or catalog in the ComponentDefinition that is the source for this control.  The control markdown files are written into directories split by both component name and source name.  If the source refers to a general uri and not a named profile or catalog in the trestle directory, then names such as `source_001` and `source_002` are assigned.  The actual source title can be found in the yaml header of any of the control markdown files.
 
-<details>
+<details markdown>
+
 <summary>Example of control markdown after `component-generate`</summary>
 
 ```markdown
@@ -685,7 +701,8 @@ Implement as needed for OSCO
 
 There is no direct way to specify rules in the ComponentDefinition, so they are specified via properties as shown here:
 
-<details>
+<details markdown>
+
 <summary>Representation of rules in the `props` of a `ComponentDefinition`</summary>
 ```json
 [
@@ -731,7 +748,8 @@ In this scheme the rules have a `Rule_Id` (`XCCDF` in this example) and an assoc
 
 The markdown header lists all the rules that apply to this control, along with their descriptions, and for each implementation response, the rules that apply to it are shown.  The association of an ImplementedRequirement with a rule is again done with properties as shown here:
 
-<details>
+<details markdown>
+
 <summary>Linking of `ImplementedRequirement` to a rule</summary>
 ```json
 {
@@ -772,7 +790,8 @@ As mentioned above, trestle version 1.x allows generation and assembly of markdo
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>Summary of options used by the `catalog`, `profile`, `component` and `ssp` authoring tools.</summary>
 
 The provided options for the generation and assembly of documents in the ssp workflow is rich and powerful, but can also be confusing.  To help see how they all relate please consult the following diagram showing the required and optional command line arguments for each command.  The checkboxes indicate required and the open circles represent optional.

--- a/docs/tutorials/task.ocp4-cis-profile-to-oscal-catalog/transformation.md
+++ b/docs/tutorials/task.ocp4-cis-profile-to-oscal-catalog/transformation.md
@@ -18,7 +18,8 @@ Follow the instructions [here](https://ibm.github.io/compliance-trestle/python_t
 
 Linux, Mac
 
-<details>
+<details markdown>
+
 <summary>Windows</summary>
 
 Make these changes:
@@ -73,7 +74,8 @@ Configuration flags sit under [task.ocp4-cis-profile-to-oscal-catalog]:
 (venv.trestle)$ curl 'https://raw.githubusercontent.com/IBM/compliance-trestle/main/docs/tutorials/task.ocp4-cis-profile-to-oscal-catalog/demo-ocp4-cis-profile-to-oscal-catalog.config' > adjunct-data/task-files/demo-ocp4-cis-profile-to-oscal-catalog.config
 ```
 
-<details>
+<details markdown>
+
 <summary>demo-ocp4-cis-profile-to-oscal-catalog.config</summary>
 
 ```
@@ -103,7 +105,8 @@ VALID: Model /home/<user>/trestle.workspace/catalogs/ocp4-cis/catalog.json passe
 (venv.trestle)$ cat catlogs/ocp4-cis/catalog.json
 ```
 
-<details>
+<details markdown>
+
 <summary>catalog.json</summary>
 
 ```

--- a/docs/tutorials/task.ocp4-cis-profile-to-oscal-cd/transformation.md
+++ b/docs/tutorials/task.ocp4-cis-profile-to-oscal-cd/transformation.md
@@ -18,7 +18,8 @@ Follow the instructions [here](https://ibm.github.io/compliance-trestle/python_t
 
 Linux, Mac
 
-<details>
+<details markdown>
+
 <summary>Windows</summary>
 
 Make these changes:
@@ -98,7 +99,8 @@ Notes:
 (venv.trestle)$ curl 'https://raw.githubusercontent.com/IBM/compliance-trestle/main/docs/tutorials/task.ocp4-cis-profile-to-oscal-cd/enabled_rules.json' > adjunct-data/task-files/enabled_rules.json
 ```
 
-<details>
+<details markdown>
+
 <summary>demo-ocp4-cis-profile-to-oscal-cd.config</summary>
 
 ```shell
@@ -136,7 +138,8 @@ enabled-rules  = adjunct-data/task-files/enabled_rules.json
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>selected_rules.json</summary>
 
 ```json
@@ -149,7 +152,8 @@ enabled-rules  = adjunct-data/task-files/enabled_rules.json
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>enabled_rules.json</summary>
 
 ```json
@@ -207,7 +211,8 @@ VALID: Model /home/<user>/trestle.workspace/component-definitions/ocp4-cis/compo
 (venv.trestle)$ cat component-definitions/ocp4-cis/component-definition.json
 ```
 
-<details>
+<details markdown>
+
 <summary>component-definition.json</summary>
 
 ```json

--- a/docs/tutorials/task.tanium-result-to-oscal-ar/transformation.md
+++ b/docs/tutorials/task.tanium-result-to-oscal-ar/transformation.md
@@ -14,7 +14,8 @@ The second is a one-command transformation from `Tanium.results` to `OSCAL.json`
 
 Linux, Mac
 
-<details>
+<details markdown>
+
 <summary>Windows</summary>
 
 Make these changes:
@@ -90,7 +91,8 @@ Initialized trestle project successfully in /home/<user>/trestle.workspace
 (venv.trestle)$ curl 'https://raw.githubusercontent.com/IBM/compliance-trestle/develop/tests/data/tasks/tanium/input-doc/Tanium.comply-nist-results' > tanium/tests/data/tasks/tanium/input/Tanium.doc-json
 ```
 
-<details>
+<details markdown>
+
 <summary>sample: Tanium.doc-json</summary>
 
 ```json
@@ -161,7 +163,8 @@ Initialized trestle project successfully in /home/<user>/trestle.workspace
 (venv.trestle)$ curl 'https://raw.githubusercontent.com/IBM/compliance-trestle/develop/tests/data/tasks/tanium/demo-tanium-result-to-oscal-ar.config' > tanium/demo-tanium-result-to-oscal-ar.config
 ```
 
-<details>
+<details markdown>
+
 <summary>sample: demo-tanium-result-to-oscal-ar.config</summary>
 
 ```conf
@@ -192,7 +195,8 @@ Task: tanium-result-to-oscal-ar executed successfully.
 (venv.trestle)$ cat tests/data/tasks/tanium/runtime/Tanium.oscal.json
 ```
 
-<details>
+<details markdown>
+
 <summary>sample:  Tanium.oscal.json</summary>
 
 ```json

--- a/docs/tutorials/task.transformer-construction/transformer-construction.md
+++ b/docs/tutorials/task.transformer-construction/transformer-construction.md
@@ -74,7 +74,8 @@ For example, if each instance of source data includes not much more than:
 
 then the best mapping would be to an Observations only.
 
-<details>
+<details markdown>
+
 <summary>example snippet: instance suitable for mapping to Observation</summary>
 
 ```yaml
@@ -87,7 +88,8 @@ metadata:
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>example snippet: instance OSCAL Observation</summary>
 
 ```json
@@ -179,7 +181,8 @@ If each instance of source data includes:
 
 then the best mapping wound be to Findings with Observations.
 
-<details>
+<details markdown>
+
 <summary>example snippet: xml instance suitable for mapping to Finding with Observation</summary>
 
 ```json
@@ -204,7 +207,8 @@ then the best mapping wound be to Findings with Observations.
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>example snippet: instance OSCAL Finding</summary>
 
 ```json
@@ -253,7 +257,8 @@ then the best mapping wound be to Findings with Observations.
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>example snippet: instance OSCAL Observation</summary>
 
 ```json
@@ -304,7 +309,8 @@ then the best mapping wound be to Findings with Observations.
 
 </details>
 
-<details>
+<details markdown>
+
 <summary>example snippet: local definitions</summary>
 
 ```json

--- a/docs/tutorials/trestle_sample_workflow.md
+++ b/docs/tutorials/trestle_sample_workflow.md
@@ -24,7 +24,8 @@ Be sure to include the quotes (' ') as shown in the examples, e.g. `merge -e 'ca
 In this tutorial you will see sections that contain dropdown that is revealed when you click on them.  Below is an example ("Like this").  Be sure to click on those sections to see their contents - and then close them if you like.
 
 <br>
-<details>
+<details markdown>
+
 <summary>Like this</summary>
 
 ```text
@@ -68,7 +69,8 @@ please be sure it conforms with the current OSCAL schema (OSCAL version 1.0.2) a
 If there are any errors the Import will fail and the file must be corrected.
 
 <br>
-<details>
+<details markdown>
+
 <summary>Your initial workspace will look like this</summary>
 
 ```text
@@ -136,7 +138,8 @@ trestle split -f ./catalog.json -e 'catalog.metadata,catalog.groups,catalog.back
 Here the `-f` refers to the filename of the json catalog file, and `-e` refers to the comma-separated list of `elements` you would like to split from the file.  This list does not represent the full file contents of the source `catalog.json` file, so some contents will be left behind in a much smaller `catalog.json` file after the split.  The elements that were split off will be placed in separate json files next to the new and smaller `catalog.json` file.
 
 <br>
-<details>
+<details markdown>
+
 <summary>Your new catalogs directory with json files split out</summary>
 
 ```text
@@ -176,7 +179,8 @@ trestle split -f ./metadata.json -e 'metadata.roles,metadata.parties,metadata.re
 ```
 
 <br>
-<details>
+<details markdown>
+
 <summary>The directory will now look like this, with metadata split into files</summary>
 
 ```text
@@ -221,7 +225,8 @@ trestle split -f ./responsible-parties.json -e 'responsible-parties.*'
 ```
 
 <br>
-<details>
+<details markdown>
+
 <summary>The directory now looks like this, with new subdirectories containing multiple roles and responsible-parties</summary>
 
 ```text
@@ -265,7 +270,8 @@ trestle split -f ./groups.json -e 'groups.*.controls.*'
 ```
 
 <br>
-<details>
+<details markdown>
+
 <summary>Your directory is now very large with that one command!</summary>
 
 ```text
@@ -691,7 +697,8 @@ trestle merge -e 'catalog.*'
 ```
 
 <br>
-<details>
+<details markdown>
+
 <summary>After all that splitting and merging you are back to this directory structure</summary>
 
 ```text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ extra:
 markdown_extensions:
 - admonition
 - markdown_include.include
+- md_in_html
 - pymdownx.emoji
 - pymdownx.magiclink
 - pymdownx.superfences
@@ -17,20 +18,22 @@ markdown_extensions:
 - toc:
     permalink: ¤
 nav:
-- Trestle overview: index.md
+- Overview: index.md
 - Installation: python_trestle_setup.md
 - Tutorials:
   - Intro to trestle workflow: tutorials/trestle_sample_workflow.md
   - Compliance posture: tutorials/continuous-compliance/continuous-compliance.md
-  - SSP, Catalog, and Profile Authoring: tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
-  - Transformer construction: tutorials/task.transformer-construction/transformer-construction.md
-  - Task - ocp4-cis-profile-to-oscal-catalog: tutorials/task.ocp4-cis-profile-to-oscal-catalog/transformation.md
-  - Task - ocp4-cis-profile-to-oscal-cd: tutorials/task.ocp4-cis-profile-to-oscal-cd/transformation.md
-  - Task - tanium-result-to-oscal-ar: tutorials/task.tanium-result-to-oscal-ar/transformation.md
-- Trestle command-line interface (CLI):
-  - CLI for OSCAL documents: cli.md
-  - Trestle CLI for Governance of Authored Documents: trestle_author.md
-  - CLI for jinja template processing: trestle_author_jinja.md
+  - Trestle Authoring:
+    - Governance of Authored Documents: trestle_author.md
+    - SSP, Catalog, and Profile Authoring: tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
+  - Trestle Transformers and Tasks:
+    - Transformer construction: tutorials/task.transformer-construction/transformer-construction.md
+    - Task - ocp4-cis-profile-to-oscal-catalog: tutorials/task.ocp4-cis-profile-to-oscal-catalog/transformation.md
+    - Task - ocp4-cis-profile-to-oscal-cd: tutorials/task.ocp4-cis-profile-to-oscal-cd/transformation.md
+    - Task - tanium-result-to-oscal-ar: tutorials/task.tanium-result-to-oscal-ar/transformation.md
+  - Trestle command-line interface (CLI):
+    - CLI for OSCAL documents: cli.md
+    - CLI for Jinja Template processing: trestle_author_jinja.md
 - Contributing:
   - Code of Conduct: mkdocs_code_of_conduct.md
   - Contributing overview: contributing/mkdocs_contributing.md
@@ -195,6 +198,7 @@ site_url: https://ibm.github.io/compliance-trestle
 theme:
   features:
   - content.code.annotate
+  - navigation.tabs
   name: material
   palette:
     accent: purple


### PR DESCRIPTION
Signed-off-by: Ekaterina Nikonova <enikonovad@gmail.com>

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Fixed html markdown in the documentation.
Rearranged the documentation and added tabs.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
