### PR TITLE
fix: Remove attrs version pinning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 include_package_data = True
 
 install_requires =
-    attrs~=19.3
+    attrs
     ilcli
     cryptography
     paramiko


### PR DESCRIPTION
Removing pinning of `attrs` version, as there seems to be no breaking dependency. 

I have tested this tested this using poetry command. Given below is the output of 
`poetry show attrs` command.

```python
 name         : attrs
 version      : 22.2.0
 description  : Classes Without Boilerplate

required by
 - jsonschema >=17.4.0
 - pytest >=17.4.0
```

I am recommending this change, as pinned version of `attrs` package is causing my dependency conflicts.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.


