### PR TITLE
feat: allow remote profiles to reference catalogs and profiles by relative path in href

### DIFF
--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -435,6 +435,6 @@ def test_profile_resolver_no_params(tmp_trestle_dir: pathlib.Path) -> None:
 
 def test_remote_profile_relative_cat(tmp_trestle_dir: pathlib.Path) -> None:
     """Test profile resolver with remote profile and import of relative catalog path."""
-    profile_path = 'https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json'  # noqa E501
+    profile_path = 'https://raw.githubusercontent.com/usnistgov/oscal-content/feature-basic-end-to-end-example/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json'  # noqa E501
     resolved_cat = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, profile_path)
     assert len(resolved_cat.groups) > 10

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -431,3 +431,10 @@ def test_profile_resolver_no_params(tmp_trestle_dir: pathlib.Path) -> None:
     catalog_str = catalog.oscal_serialize_json()
     # make sure no moustaches remain that would confuse jinja
     assert '{{' not in catalog_str
+
+
+def test_remote_profile_relative_cat(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test profile resolver with remote profile and import of relative catalog path."""
+    profile_path = 'https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json'  # noqa E501
+    resolved_cat = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, profile_path)
+    assert len(resolved_cat.groups) > 10

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -100,7 +100,9 @@ class FetcherBase(ABC):
                 self._do_fetch()
                 return True
             except Exception as e:
-                raise TrestleError(f'Cache update failure for {self._uri}: {e}.') from e
+                raise TrestleError(
+                    f'Cache update failure for {self._uri}.  Please confirm the file is json and not html: {e}.'
+                ) from e  # noqa E501
         return False
 
     def get_raw(self, force_update=False) -> Dict[str, Any]:
@@ -278,6 +280,8 @@ class HTTPSFetcher(FetcherBase):
                     raise TrestleError(f'Cache update failure with bad inputenv var: {err_str}')
         if self._username is not None and self._password is not None:
             auth = HTTPBasicAuth(self._username, self._password)
+
+        # attempt get of the file from url
         try:
             response = requests.get(self._url, auth=auth, verify=verify)
         except Exception as e:

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -281,7 +281,6 @@ class HTTPSFetcher(FetcherBase):
         if self._username is not None and self._password is not None:
             auth = HTTPBasicAuth(self._username, self._password)
 
-        # attempt get of the file from url
         try:
             response = requests.get(self._url, auth=auth, verify=verify)
         except Exception as e:
@@ -396,6 +395,11 @@ class FetcherFactory:
         HTTPS = 3
 
         TRESTLE = 4
+
+    @staticmethod
+    def uri_type_is_not_local(uri_type: UriType) -> bool:
+        """Determine if the uri type is not local."""
+        return uri_type in [FetcherFactory.UriType.SFTP, FetcherFactory.UriType.HTTPS]
 
     @staticmethod
     def get_uri_type(uri: str) -> UriType:

--- a/trestle/core/resolver/_import.py
+++ b/trestle/core/resolver/_import.py
@@ -73,6 +73,7 @@ class Import(Pipeline.Filter):
         if self._import.href[0] == '#':
             # Specification section on internal reference resolution:
             # https://pages.nist.gov/OSCAL/concepts/processing/profile-resolution/#d2e300-head
+            # if href is a local reference, replace it with the actual uri in the resources
             try:
                 resource = [r for r in self._resources if r.uuid == self._import.href[1:]][0]
                 self._import.href = [
@@ -86,11 +87,12 @@ class Import(Pipeline.Filter):
                 raise TrestleError(
                     f'Back matter resource resolution needed for profile import failed with error: {str(e)}'
                 )
+
         uri_type = cache.FetcherFactory.get_uri_type(self._import.href)
         # if this looks like a relative path to remote source, append parent path
         if uri_type == cache.FetcherFactory.UriType.LOCAL_FILE and self._parent_url_root:
             self._import.href = self._parent_url_root + self._import.href
-        # if href is now a remote path, capture its parent path for use with child imports
+        # if href is now a remote path, capture its parent path for possible use with child imports that are relative
         if uri_type not in [cache.FetcherFactory.UriType.LOCAL_FILE, cache.FetcherFactory.UriType.TRESTLE]:
             head_path, _ = os.path.split(self._import.href)
             if head_path and head_path[-1] != '/':

--- a/trestle/core/resolver/_import.py
+++ b/trestle/core/resolver/_import.py
@@ -91,15 +91,12 @@ class Import(Pipeline.Filter):
         uri_type = cache.FetcherFactory.get_uri_type(self._import.href)
         # if this looks like a relative path to remote source, append parent path
         if uri_type == cache.FetcherFactory.UriType.LOCAL_FILE and self._parent_url_root:
-            self._import.href = self._parent_url_root + self._import.href
+            self._import.href = self._parent_url_root + '/' + self._import.href
         # if href is now a remote path, capture its parent path for possible use with child imports that are relative
-        if uri_type not in [cache.FetcherFactory.UriType.LOCAL_FILE, cache.FetcherFactory.UriType.TRESTLE]:
-            head_path, _ = os.path.split(self._import.href)
-            if head_path and head_path[-1] != '/':
-                head_path += '/'
-            self._parent_url_root = head_path
-            logger.info('parent head path %s', head_path)
-        logger.info('import href is %s', self._import.href)
+        if cache.FetcherFactory.uri_type_is_not_local(uri_type):
+            self._parent_url_root = os.path.dirname(self._import.href)
+            logger.debug('parent url root path %s', self._parent_url_root)
+        logger.debug('import href is %s', self._import.href)
 
     def process(self, _=None) -> Iterator[cat.Catalog]:
         """Load href for catalog or profile and yield each import as catalog imported by its distinct pipeline."""


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

If you try to resolve a profile at a remote url, and its href to the catalog is local to its directory - it will fail.  This has now been updated so that it works.

closes #1287 

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
