### PR TITLE
fix: problem in cat assemble with subgroups

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,20 @@ def sample_catalog_rich_controls():
 
 
 @pytest.fixture(scope='function')
+def sample_catalog_subgroups():
+    """Return a catalog with groups of groups."""
+    catalog_obj = gens.generate_sample_model(cat.Catalog)
+    group = cat.Group(id='a', title='The a group')
+    control_c = cat.Control(id='control_c', title='this is control c')
+    sub_sub_group = cat.Group(id='bb', title='The bb sub sub group', controls=[control_c])
+    sub_group = cat.Group(id='b', title='The b sub group', groups=[sub_sub_group])
+    group.groups = [sub_group]
+    catalog_obj.groups = [group]
+
+    return catalog_obj
+
+
+@pytest.fixture(scope='function')
 def sample_component_definition():
     """Return a valid ComponentDefinition object with some contents."""
     # one component has no properties - the other has two

--- a/tests/trestle/core/commands/author/catalog_test.py
+++ b/tests/trestle/core/commands/author/catalog_test.py
@@ -612,3 +612,14 @@ def test_prune_written_controls(tmp_trestle_dir: pathlib.Path, monkeypatch: Monk
     id_subset = control_ids - set(controls_to_delete)
 
     assert CatalogInterface._prune_controls(md_path, id_subset) == controls_to_delete
+
+
+def test_catalog_assemble_subgroups(
+    tmp_trestle_dir: pathlib.Path, sample_catalog_subgroups: cat.Catalog, monkeypatch: MonkeyPatch
+) -> None:
+    """Test assembly of catalog with group having no controls but does contain subgroup."""
+    ModelUtils.save_top_level_model(sample_catalog_subgroups, tmp_trestle_dir, 'my_catalog', FileContentType.JSON)
+    catalog_generate = 'trestle author catalog-generate -n my_catalog -o md_catalog -vv'
+    test_utils.execute_command_and_assert(catalog_generate, 0, monkeypatch)
+    catalog_assemble = 'trestle author catalog-assemble -m md_catalog -o my_catalog -vv'
+    test_utils.execute_command_and_assert(catalog_assemble, 0, monkeypatch)

--- a/trestle/core/catalog/catalog_api.py
+++ b/trestle/core/catalog/catalog_api.py
@@ -42,7 +42,7 @@ class CatalogAPI():
     def __init__(self, catalog: Optional[cat.Catalog], context: Optional[ControlContext] = None):
         """Initialize catalog api."""
         if not catalog:
-            logger.info('No catalog was provided, generating a new one.')
+            logger.debug('No catalog was provided in CatalogAPI init, generating a new one.')
             catalog = gens.generate_sample_model(cat.Catalog)
         self._catalog = catalog
         self._catalog_interface = CatalogInterface(self._catalog)

--- a/trestle/core/catalog/catalog_api.py
+++ b/trestle/core/catalog/catalog_api.py
@@ -42,6 +42,7 @@ class CatalogAPI():
     def __init__(self, catalog: Optional[cat.Catalog], context: Optional[ControlContext] = None):
         """Initialize catalog api."""
         if not catalog:
+            # catalog assemble initializes with no catalog but may merge into an existing one later
             logger.debug('No catalog was provided in CatalogAPI init, generating a new one.')
             catalog = gens.generate_sample_model(cat.Catalog)
         self._catalog = catalog

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -222,8 +222,7 @@ class CatalogInterface():
         if group.controls:
             controls.extend(CatalogInterface._get_all_controls_in_list(group.controls, recurse))
         for sub_group in as_list(group.groups):
-            if sub_group.controls:
-                controls.extend(CatalogInterface._get_all_controls_in_group(sub_group, recurse))
+            controls.extend(CatalogInterface._get_all_controls_in_group(sub_group, recurse))
         return controls
 
     def get_sorted_controls_in_group(self, group_id: str) -> List[cat.Control]:
@@ -767,7 +766,8 @@ class CatalogInterface():
         id_map: Dict[str, pathlib.Path] = {'': md_path}
         for gdir in md_path.rglob('*'):
             if gdir.is_dir():
-                id_map[gdir.stem] = gdir
+                dir_name = gdir.parts[-1]
+                id_map[dir_name] = gdir
         # rebuild the dict by inserting items in manner sorted by key
         sorted_id_map: Dict[str, pathlib.Path] = {}
         for key in sorted(id_map):

--- a/trestle/core/catalog/catalog_reader.py
+++ b/trestle/core/catalog/catalog_reader.py
@@ -113,7 +113,9 @@ class CatalogReader():
             control_list = sorted(control_list_raw, key=lambda control: ControlInterface.get_sort_id(control))
             if group_id:
                 if not group_title:
-                    logger.warning(f'No group title found in controls for group {group_id}')
+                    logger.warning(
+                        f'No group title found in controls for group {group_id}.  The title will be recovered if assembling into an existing catalog with the group title defined.'  # noqa E501
+                    )
                 new_group = cat.Group(id=group_id, title=group_title)
                 new_group.controls = none_if_empty(control_list)
                 groups.append(new_group)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
cat-assemble wasn't capturing sub group names properly

closes #1289 
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
