### PR TITLE
fix: allow edit of rule param values during component assemble

### DIFF
--- a/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
+++ b/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
@@ -551,6 +551,16 @@ x-trestle-rules-params:
       options: '["shared_param_1_aa_opt_1", "shared_param_1_aa_opt_2"]'
       rule-id: top_shared_rule_1
 x-trestle-comp-def-rules-param-vals:
+  # You may set new values for rule parameters by adding
+  #
+  # component-values:
+  #   - value 1
+  #   - value 2
+  #
+  # below a section of values:
+  # The values list refers to the values as set by the components, and the component-values are the new values
+  # to be placed in SetParameters of the component definition.
+  #
   comp_aa:
     - name: shared_param_1
       values:
@@ -740,11 +750,12 @@ The values for rule parameters are specified using the normal `SetParameter` mec
 Note that markdown for a control is only created if there are rules associated with the control, and within the markdown the only parts written out that
 prompt for responses are parts that have rules assigned.  Thus the output markdown directory may be highly pruned of both controls and groups of controls if only some controls have rules associated.
 
-In addition, the rules should be regarded as read-only from the editing perspective, and you cannot change the rules associated with a control or its parts.
+In addition, the rules should be regarded as read-only from the editing perspective, and you cannot change the rules associated with a control or its parts.  But you may edit the rule parameter values as described in the comments of the markdown file under
+`x-trestle-comp-def-rules-param-vals`.  You may also edit the prose and implementation status associated with a statement part at the bottom of the markdown file.
 
 `trestle author component-assemble`
 
-The `component-assemble` command will assemble the markdown into a ComponentDefinition file containing all the DefinedComponents in the markdown, and as usual it can either overwrite the original JSON file or create a new one.  Edits made to the prose, status and values in the markdown and header will be captured in the assembled file, but the list of rules attached to each ImplementedRequirement may is *readonly* and new rule associations cannot be made via markdown.
+The `component-assemble` command will assemble the markdown into a ComponentDefinition file containing all the DefinedComponents in the markdown, and as usual it can either overwrite the original JSON file or create a new one.  Edits made to the prose, status and rule parameter values in the markdown and header will be captured in the assembled file, but the list of rules attached with each ImplementedRequirement is *readonly* and new rule associations cannot be made via markdown.
 
 </details>
 

--- a/scripts/gen_oscal.py
+++ b/scripts/gen_oscal.py
@@ -78,7 +78,14 @@ def generate_model(full_name, out_full_name):
 
 
 def generate_models():
-    """Generate all models including 3rd party."""
+    """
+    Generate all models including 3rd party.
+
+    IMPORTANT NOTE: This script will leave the temporary classes in oscal/tmp for reference, but they should be deleted
+    when no longer needed because some of the operations in the build will seek all .py files, and will try to act
+    on these temporary files - giving an error.  So be sure to delete the oscal/tmp directory when done generating
+    new classes.
+    """
     logger.info('generating models')
     out_dir = Path('trestle/oscal')
     out_dir.mkdir(exist_ok=True, parents=True)

--- a/tests/data/json/comp_def_a.json
+++ b/tests/data/json/comp_def_a.json
@@ -174,6 +174,21 @@
                     "value": "implemented"
                   }
                 ],
+                "set-parameters": [
+                  {
+                    "param-id": "shared_param_1",
+                    "values": [
+                      "shared_param_1_aa_opt_1"
+                    ],
+                    "remarks": "set shared param aa 1"
+                  },
+                  {
+                    "param-id": "ac-1_prm_3",
+                    "values": [
+                      "set by comp aa imp req"
+                    ]
+                  }
+                ],    
                 "responsible-roles": [
                   {
                     "role-id": "prepared-by",
@@ -195,21 +210,6 @@
                     ]
                   }
                 ],
-                "set-parameters": [
-                  {
-                    "param-id": "shared_param_1",
-                    "values": [
-                      "shared_param_1_aa_opt_1"
-                    ],
-                    "remarks": "set shared param aa 1"
-                  },
-                  {
-                    "param-id": "ac-1_prm_3",
-                    "values": [
-                      "set by comp aa imp req"
-                    ]
-                  }
-                ],    
                 "statements": [
                   {
                     "statement-id": "ac-1_smt.a",

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -23,7 +23,7 @@ from tests import test_utils
 
 import trestle.core.generic_oscal as generic
 import trestle.oscal.component as comp
-from trestle.common import const, model_utils
+from trestle.common import const, file_utils, model_utils
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.markdown.markdown_processor import MarkdownProcessor
 
@@ -101,8 +101,8 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
 
     file_checker = test_utils.FileChecker(tmp_trestle_dir / md_path)
 
-    generate_cmd = f'trestle author component-generate -n {comp_name} -o {md_path}'
     # confirm it overwrites existing md identically
+    generate_cmd = f'trestle author component-generate -n {comp_name} -o {md_path}'
     test_utils.execute_command_and_assert(generate_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
 
     # all files should be the same
@@ -119,10 +119,23 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
     creation_time = assem_comp_path.stat().st_mtime
     assert model_utils.ModelUtils.models_are_equivalent(orig_component, assem_component, True)
 
+    # assemble again and confirm it is not written out since no change
     test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
     assert creation_time == assem_comp_path.stat().st_mtime
 
-    ac1_path = tmp_trestle_dir / 'md_comp/comp_aa/comp_prof_aa/ac/ac-1.md'
+    # edit a rule param value
+    new_text = '      component-values:\n        - inserted value\n'
+    file_utils.insert_text_in_file(ac1_path, '- shared_param_1_aa_opt_1', new_text)
+
+    # assemble and confirm new value was captured
+    test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
+
+    assem_component, _ = model_utils.ModelUtils.load_model_for_class(
+        tmp_trestle_dir, assem_name, comp.ComponentDefinition
+    )
+
+    assert assem_component.components[0].control_implementations[0].implemented_requirements[0].set_parameters[
+        0].values[0].__root__ == 'inserted value'
 
     # confirm we can add a new component via markdown
     add_comp(tmp_trestle_dir / 'md_comp', ac1_path)

--- a/trestle/common/const.py
+++ b/trestle/common/const.py
@@ -437,7 +437,7 @@ COMP_DEF_RULES_TAG = TRESTLE_TAG + 'comp-def-rules'
 
 PROFILE_VALUES = 'profile-values'
 
-COMP_DEF_VALUES = 'comp-def-values'
+COMPONENT_VALUES = 'component-values'
 
 VALUES = 'values'
 
@@ -496,7 +496,7 @@ YAML_PROFILE_VALUES_COMMENT = """  # You may set values for parameters in the as
   #
 """
 
-YAML_RULE_PARAM_VALUES_COMMENT = """  # You may set new values for rule parameters by adding
+YAML_RULE_PARAM_VALUES_SSP_COMMENT = """  # You may set new values for rule parameters by adding
   #
   # ssp-values:
   #   - value 1
@@ -505,6 +505,18 @@ YAML_RULE_PARAM_VALUES_COMMENT = """  # You may set new values for rule paramete
   # below a section of values:
   # The values list refers to the values as set by the components, and the ssp-values are the new values
   # to be placed in SetParameters of the SSP.
+  #
+"""
+
+YAML_RULE_PARAM_VALUES_COMPONENT_COMMENT = """  # You may set new values for rule parameters by adding
+  #
+  # component-values:
+  #   - value 1
+  #   - value 2
+  #
+  # below a section of values:
+  # The values list refers to the values as set by the components, and the component-values are the new values
+  # to be placed in SetParameters of the component definition.
   #
 """
 

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -1091,14 +1091,33 @@ class ControlInterface:
             have the same source and specify the same control
         """
         for control_imp in as_list(component.control_implementations):
+            _, control_imp_param_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(control_imp)
+            control_imp_rule_param_ids = [d['name'] for d in control_imp_param_dict.values()]
             if profile_title != ModelUtils.get_title_from_model_uri(trestle_root, control_imp.source):
                 continue
             for imp_req in as_list(control_imp.implemented_requirements):
                 if imp_req.control_id == new_imp_req.control_id:
+                    _, imp_req_param_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(imp_req)
+                    imp_req_rule_param_ids = [d['name'] for d in imp_req_param_dict]
                     status = ControlInterface.get_status_from_props(new_imp_req)
                     ControlInterface.insert_status_in_props(imp_req, status)
                     imp_req.description = new_imp_req.description
                     statement_dict = {stat.statement_id: stat for stat in as_list(imp_req.statements)}
+                    # update set parameter values with values from markdown - but only for rule param vals
+                    for set_param in as_list(new_imp_req.set_parameters):
+                        if set_param.param_id in (control_imp_rule_param_ids + imp_req_rule_param_ids):
+                            found = False
+                            for dest_param in imp_req.set_parameters:
+                                if dest_param.param_id == set_param.param_id:
+                                    dest_param.values = set_param.values
+                                    found = True
+                                    break
+                            # if rule parameter val was not already set by a set_param, make new set_param for it
+                            if not found:
+                                imp_req.set_parameters = as_list(imp_req.set_parameters)
+                                imp_req.set_parameters.append(
+                                    comp.SetParameter(param_id=set_param.param_id, values=set_param.values)
+                                )
                     new_statements: List[comp.Statement] = []
                     for statement in as_list(new_imp_req.statements):
                         # get the original version of the statement if available, or use new one

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -563,15 +563,7 @@ class ControlReader():
         imp_req = gens.generate_sample_model(comp.ImplementedRequirement)
         imp_req.control_id = control_id
 
-        imp_req.set_parameters = []
         imp_req.statements = []
-        # add normal user setparams
-        for param_id, param_dict in md_header.get(const.SET_PARAMS_TAG, {}).items():
-            if const.SSP_VALUES in param_dict:
-                values = [common.Value(__root__=value) for value in param_dict[const.SSP_VALUES]]
-                set_param = ossp.SetParameter(param_id=param_id, values=values)
-                imp_req.set_parameters.append(set_param)
-
         comp_dict = md_comp_dict[comp_name]
         for label, comp_info in comp_dict.items():
             # only assemble responses with associated rules
@@ -599,10 +591,13 @@ class ControlReader():
             ControlInterface.insert_status_in_props(statement, comp_info.status)
 
         imp_req.statements = list(statement_map.values())
+        imp_req.set_parameters = []
 
         for _, param_dict_list in md_header.get(const.COMP_DEF_RULES_PARAM_VALS_TAG, {}).items():
             for param_dict in param_dict_list:
                 values = [common.Value(__root__=value) for value in param_dict.get(const.VALUES, [])]
+                comp_values = [common.Value(__root__=value) for value in param_dict.get(const.COMPONENT_VALUES, [])]
+                values = comp_values if comp_values else values
                 set_param = ossp.SetParameter(param_id=param_dict['name'], values=values)
                 imp_req.set_parameters.append(set_param)
         imp_req.statements = none_if_empty(list(statement_map.values()))

--- a/trestle/core/control_writer.py
+++ b/trestle/core/control_writer.py
@@ -485,7 +485,10 @@ class ControlWriter():
                 header_comment_dict[const.SET_PARAMS_TAG] = const.YAML_PROFILE_VALUES_COMMENT
             elif context.purpose == ContextPurpose.SSP:
                 header_comment_dict[const.SET_PARAMS_TAG] = const.YAML_SSP_VALUES_COMMENT
-                header_comment_dict[const.COMP_DEF_RULES_PARAM_VALS_TAG] = const.YAML_RULE_PARAM_VALUES_COMMENT
+                header_comment_dict[const.COMP_DEF_RULES_PARAM_VALS_TAG] = const.YAML_RULE_PARAM_VALUES_SSP_COMMENT
+            elif context.purpose == ContextPurpose.COMPONENT:
+                header_comment_dict[const.COMP_DEF_RULES_PARAM_VALS_TAG
+                                    ] = const.YAML_RULE_PARAM_VALUES_COMPONENT_COMMENT
 
         # begin adding info to the md file
         self._md_file = MDWriter(control_file, header_comment_dict)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
The code was not allowing edit of rule parameter values during component-generate and component-assemble.  This is now working properly and has a corresponding test.

closes #1297
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
