### PR TITLE
fix: adding multiple value set to rule param values during component …

### DIFF
--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -124,11 +124,8 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
     assert creation_time == assem_comp_path.stat().st_mtime
 
     # edit a rule param value
-    new_text = '      component-values:\n        - inserted value\n'
-
-    # testing multiple values setting
-    for _n in range(3):
-        file_utils.insert_text_in_file(ac1_path, '- shared_param_1_aa_opt_1', new_text)
+    new_text = '      component-values:\n        - inserted value 0\n        - inserted value 1\n        - inserted value 2\n'  # noqa E501
+    file_utils.insert_text_in_file(ac1_path, '- shared_param_1_aa_opt_1', new_text)
 
     # assemble and confirm new value was captured
     test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
@@ -137,8 +134,9 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
         tmp_trestle_dir, assem_name, comp.ComponentDefinition
     )
 
-    assert assem_component.components[0].control_implementations[0].implemented_requirements[0].set_parameters[
-        0].values[0].__root__ == 'inserted value'
+    for ii in range(3):
+        assert assem_component.components[0].control_implementations[0].implemented_requirements[0].set_parameters[
+            0].values[ii].__root__ == f'inserted value {ii}'
 
     # confirm we can add a new component via markdown
     add_comp(tmp_trestle_dir / 'md_comp', ac1_path)

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -125,7 +125,10 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
 
     # edit a rule param value
     new_text = '      component-values:\n        - inserted value\n'
-    file_utils.insert_text_in_file(ac1_path, '- shared_param_1_aa_opt_1', new_text)
+
+    # testing multiple values setting
+    for _n in range(3):
+        file_utils.insert_text_in_file(ac1_path, '- shared_param_1_aa_opt_1', new_text)
 
     # assemble and confirm new value was captured
     test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)

--- a/trestle/core/commands/author/catalog.py
+++ b/trestle/core/commands/author/catalog.py
@@ -72,7 +72,7 @@ class CatalogGenerate(AuthorCommonCommand):
 
             if args.force_overwrite:
                 try:
-                    logger.debug(f'Overwriting the content in {args.output} folder.')
+                    logger.info(f'Overwriting the content in {args.output} folder.')
                     clear_folder(pathlib.Path(args.output))
                 except TrestleError as e:  # pragma: no cover
                     raise TrestleError(f'Unable to overwrite contents in {args.output} folder: {e}')

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -63,7 +63,7 @@ class ComponentGenerate(AuthorCommonCommand):
 
             if args.force_overwrite:
                 try:
-                    logger.debug(f'Overwriting the content in {args.output} folder.')
+                    logger.info(f'Overwriting the content in {args.output} folder.')
                     clear_folder(pathlib.Path(args.output))
                 except TrestleError as e:  # pragma: no cover
                     raise TrestleError(f'Unable to overwrite contents in {args.output} folder: {e}')
@@ -104,7 +104,7 @@ class ComponentGenerate(AuthorCommonCommand):
         self, context: ControlContext, component: comp.DefinedComponent, markdown_dir_path: pathlib.Path
     ) -> int:
         """Create markdown for the component using its source profiles."""
-        logger.debug(f'Creating markdown for component {component.title}.')
+        logger.info(f'Generating markdown for component {component.title}')
         context.comp_name = component.title
         context.component = component
         context.uri_name_map = {}
@@ -284,7 +284,7 @@ class ComponentAssemble(AuthorCommonCommand):
             context.comp_name = component.title
             context.comp_def = parent_comp
             context.component = component
-            logger.info(f'reading markdown for component {component.title}')
+            logger.info(f'Assembling markdown for component {component.title}')
             ComponentAssemble._update_component_with_markdown(md_dir, component, context)
 
     @staticmethod

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -284,6 +284,7 @@ class ComponentAssemble(AuthorCommonCommand):
             context.comp_name = component.title
             context.comp_def = parent_comp
             context.component = component
+            logger.info(f'reading markdown for component {component.title}')
             ComponentAssemble._update_component_with_markdown(md_dir, component, context)
 
     @staticmethod

--- a/trestle/core/commands/author/component.py
+++ b/trestle/core/commands/author/component.py
@@ -240,7 +240,7 @@ class ComponentAssemble(AuthorCommonCommand):
             _, _, existing_comp = ModelUtils.load_distributed(assem_comp_path, trestle_root)
             # comp def will change statement uuids so need to ignore them in comparison
             if ModelUtils.models_are_equivalent(existing_comp, parent_comp, True):
-                logger.info('Assembled component is no different from existing version, so no update.')
+                logger.info('Assembled component definition is no different from existing version, so no update.')
                 return CmdReturnCodes.SUCCESS.value
 
         if regenerate:
@@ -248,7 +248,9 @@ class ComponentAssemble(AuthorCommonCommand):
         ModelUtils.update_last_modified(parent_comp)
 
         if assem_comp_path.parent.exists():
-            logger.info('Creating component from markdown and destination component exists, so updating.')
+            logger.info(
+                'Creating component definition from markdown and destination component definition exists, so updating.'
+            )  # noqa E501
             shutil.rmtree(str(assem_comp_path.parent))
 
         assem_comp_path.parent.mkdir(parents=True, exist_ok=True)

--- a/trestle/core/commands/author/profile.py
+++ b/trestle/core/commands/author/profile.py
@@ -86,7 +86,7 @@ class ProfileGenerate(AuthorCommonCommand):
 
             if args.force_overwrite:
                 try:
-                    logger.debug(f'Overwriting the content of {args.output}.')
+                    logger.info(f'Overwriting the content in {args.output}.')
                     clear_folder(pathlib.Path(args.output))
                 except TrestleError as e:  # pragma: no cover
                     raise TrestleError(f'Unable to overwrite contents of {args.output}: {e}')

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -135,7 +135,7 @@ class SSPGenerate(AuthorCommonCommand):
         """
         if force_overwrite:
             try:
-                logger.debug(f'Overwriting the content of {md_path}.')
+                logger.info(f'Overwriting the content in {md_path}.')
                 clear_folder(pathlib.Path(md_path))
             except TrestleError as e:  # pragma: no cover
                 raise TrestleError(f'Unable to overwrite contents of {md_path}: {e}')

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -1096,36 +1096,40 @@ class ControlInterface:
             if profile_title != ModelUtils.get_title_from_model_uri(trestle_root, control_imp.source):
                 continue
             for imp_req in as_list(control_imp.implemented_requirements):
-                if imp_req.control_id == new_imp_req.control_id:
-                    _, imp_req_param_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(imp_req)
-                    imp_req_rule_param_ids = [d['name'] for d in imp_req_param_dict]
-                    status = ControlInterface.get_status_from_props(new_imp_req)
-                    ControlInterface.insert_status_in_props(imp_req, status)
-                    imp_req.description = new_imp_req.description
-                    statement_dict = {stat.statement_id: stat for stat in as_list(imp_req.statements)}
-                    # update set parameter values with values from markdown - but only for rule param vals
-                    for set_param in as_list(new_imp_req.set_parameters):
-                        if set_param.param_id in (control_imp_rule_param_ids + imp_req_rule_param_ids):
-                            found = False
-                            for dest_param in imp_req.set_parameters:
-                                if dest_param.param_id == set_param.param_id:
-                                    dest_param.values = set_param.values
-                                    found = True
-                                    break
-                            # if rule parameter val was not already set by a set_param, make new set_param for it
-                            if not found:
-                                imp_req.set_parameters = as_list(imp_req.set_parameters)
-                                imp_req.set_parameters.append(
-                                    comp.SetParameter(param_id=set_param.param_id, values=set_param.values)
-                                )
-                    new_statements: List[comp.Statement] = []
-                    for statement in as_list(new_imp_req.statements):
-                        # get the original version of the statement if available, or use new one
-                        stat = statement_dict.get(statement.statement_id, statement)
-                        # update the description and status from markdown
-                        stat.description = statement.description
-                        ControlInterface._copy_status_in_props(stat, statement)
-                        new_statements.append(stat)
-                    imp_req.statements = none_if_empty(new_statements)
-                    return
+                if imp_req.control_id != new_imp_req.control_id:
+                    continue
+                _, imp_req_param_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(imp_req)
+                imp_req_rule_param_ids = [d['name'] for d in imp_req_param_dict]
+                status = ControlInterface.get_status_from_props(new_imp_req)
+                ControlInterface.insert_status_in_props(imp_req, status)
+                imp_req.description = new_imp_req.description
+                statement_dict = {stat.statement_id: stat for stat in as_list(imp_req.statements)}
+                # update set parameter values with values from markdown - but only for rule param vals
+                for set_param in as_list(new_imp_req.set_parameters):
+                    if set_param.param_id not in (control_imp_rule_param_ids + imp_req_rule_param_ids):
+                        continue
+                    found = False
+                    for dest_param in imp_req.set_parameters:
+                        if dest_param.param_id != set_param.param_id:
+                            continue
+                        dest_param.values = set_param.values
+                        found = True
+                        break
+                    # if rule parameter val was not already set by a set_param, make new set_param for it
+                    if found:
+                        continue
+                    imp_req.set_parameters = as_list(imp_req.set_parameters)
+                    imp_req.set_parameters.append(
+                        comp.SetParameter(param_id=set_param.param_id, values=set_param.values)
+                    )
+                new_statements: List[comp.Statement] = []
+                for statement in as_list(new_imp_req.statements):
+                    # get the original version of the statement if available, or use new one
+                    stat = statement_dict.get(statement.statement_id, statement)
+                    # update the description and status from markdown
+                    stat.description = statement.description
+                    ControlInterface._copy_status_in_props(stat, statement)
+                    new_statements.append(stat)
+                imp_req.statements = none_if_empty(new_statements)
+                return
         logger.warning(f'Unable to add imp req for control {new_imp_req.control_id} and source: {profile_title}')

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -1132,4 +1132,6 @@ class ControlInterface:
                     new_statements.append(stat)
                 imp_req.statements = none_if_empty(new_statements)
                 return
-        logger.warning(f'Unable to add imp req for control {new_imp_req.control_id} and source: {profile_title}')
+        logger.warning(
+            f'Unable to add imp req for component {component.title} control {new_imp_req.control_id} and source: {profile_title}'  # noqa E501
+        )

--- a/trestle/core/resolver/merge.py
+++ b/trestle/core/resolver/merge.py
@@ -183,12 +183,12 @@ class Merge(Pipeline.Filter):
             if self._profile.merge.as_is is not None:
                 as_is = self._profile.merge.as_is
             if self._profile.merge.combine is None:
-                logger.warning('Profile has merge but no combine so defaulting to combine/merge.')
+                logger.debug('Profile has merge but no combine so defaulting to combine/merge.')
                 merge_method = prof.Method.merge
             else:
                 merge_combine = self._profile.merge.combine
                 if merge_combine.method is None:
-                    logger.warning('Profile has merge combine but no method.  Defaulting to merge.')
+                    logger.debug('Profile has merge combine but no method.  Defaulting to merge.')
                     merge_method = prof.Method.merge
                 else:
                     merge_method = merge_combine.method


### PR DESCRIPTION
…assemble

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

Extended work for [PR#1299](https://github.com/IBM/compliance-trestle/pull/1299) on setting multiple values multiple value set to rule param values during component assemble.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
