### PR TITLE
fix: Give warnings when component references control not loaded by profile for comp-gen and ssp-gen

### DIFF
--- a/tests/data/json/comp_prof_ab.json
+++ b/tests/data/json/comp_prof_ab.json
@@ -13,6 +13,7 @@
         "include-controls": [
           {
             "with-ids": [
+              "ac-1",
               "ac-2.1",
               "at-1"
             ]

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for the component author module."""
 
-import logging
 import pathlib
 import shutil
 from typing import Any, Dict
@@ -29,8 +28,6 @@ import trestle.oscal.component as comp
 from trestle.common import const, file_utils, model_utils
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.markdown.markdown_processor import MarkdownProcessor
-
-logger = logging.getLogger(__name__)
 
 md_path = 'md_comp'
 

--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -19,8 +19,6 @@ from typing import Any, Dict
 
 from _pytest.monkeypatch import MonkeyPatch
 
-import pytest
-
 from tests import test_utils
 
 import trestle.core.generic_oscal as generic
@@ -176,9 +174,7 @@ def test_generic_oscal() -> None:
     assert cont_imp.description == ''
 
 
-def test_component_generate_missing_control(
-    tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_component_generate_missing_control(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch, capsys) -> None:
     """Test component generate succeeds when profile missing control."""
     comp_name = test_utils.setup_component_generate(tmp_trestle_dir)
 
@@ -189,4 +185,5 @@ def test_component_generate_missing_control(
 
     # confirm success when profile is missing a needed control
     test_utils.execute_command_and_assert(generate_cmd, 0, monkeypatch)
-    assert "Component comp_aa references controls {'ac-1'} not in profile." in caplog.text
+    _, err = capsys.readouterr()
+    assert "Component comp_aa references controls {'ac-1'} not in profile." in err

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -626,6 +626,7 @@ def test_ssp_failure_missing_control(tmp_trestle_dir: pathlib.Path) -> None:
     """Test ssp failure when profile missing control."""
     gen_args, _ = setup_for_ssp(tmp_trestle_dir, prof_name, ssp_name)
     prof_path = tmp_trestle_dir / 'profiles/comp_prof/profile.json'
+    # remove the reference to control ac-1
     test_utils.delete_line_in_file(prof_path, 'ac-1')
     ssp_gen = SSPGenerate()
     assert ssp_gen._run(gen_args) == 1

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -620,3 +620,12 @@ def test_merge_imp_req() -> None:
     imp_req_b.statements = [statement]
     SSPAssemble._merge_imp_req_into_imp_req(imp_req_a, imp_req_b, [])
     assert imp_req_a.statements[0].by_components[0].description == prose
+
+
+def test_ssp_failure_missing_control(tmp_trestle_dir: pathlib.Path) -> None:
+    """Test ssp failure when profile missing control."""
+    gen_args, _ = setup_for_ssp(tmp_trestle_dir, prof_name, ssp_name)
+    prof_path = tmp_trestle_dir / 'profiles/comp_prof/profile.json'
+    test_utils.delete_line_in_file(prof_path, 'ac-1')
+    ssp_gen = SSPGenerate()
+    assert ssp_gen._run(gen_args) == 1

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -18,8 +18,6 @@ import pathlib
 
 from _pytest.monkeypatch import MonkeyPatch
 
-import pytest
-
 from tests import test_utils
 from tests.test_utils import FileChecker, setup_for_ssp
 
@@ -624,7 +622,7 @@ def test_merge_imp_req() -> None:
     assert imp_req_a.statements[0].by_components[0].description == prose
 
 
-def test_ssp_warning_missing_control(tmp_trestle_dir: pathlib.Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_ssp_warning_missing_control(tmp_trestle_dir: pathlib.Path, capsys) -> None:
     """Test ssp success when profile missing control."""
     gen_args, _ = setup_for_ssp(tmp_trestle_dir, prof_name, ssp_name)
     prof_path = tmp_trestle_dir / 'profiles/comp_prof/profile.json'
@@ -632,4 +630,5 @@ def test_ssp_warning_missing_control(tmp_trestle_dir: pathlib.Path, caplog: pyte
     test_utils.delete_line_in_file(prof_path, 'ac-1')
     ssp_gen = SSPGenerate()
     assert ssp_gen._run(gen_args) == 0
-    assert 'Component comp_aa references control ac-1 not in profile.' in caplog.text
+    _, err = capsys.readouterr()
+    assert 'Component comp_aa references control ac-1 not in profile.' in err

--- a/tests/trestle/core/commands/author/ssp_test.py
+++ b/tests/trestle/core/commands/author/ssp_test.py
@@ -18,6 +18,8 @@ import pathlib
 
 from _pytest.monkeypatch import MonkeyPatch
 
+import pytest
+
 from tests import test_utils
 from tests.test_utils import FileChecker, setup_for_ssp
 
@@ -622,11 +624,12 @@ def test_merge_imp_req() -> None:
     assert imp_req_a.statements[0].by_components[0].description == prose
 
 
-def test_ssp_failure_missing_control(tmp_trestle_dir: pathlib.Path) -> None:
-    """Test ssp failure when profile missing control."""
+def test_ssp_warning_missing_control(tmp_trestle_dir: pathlib.Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test ssp success when profile missing control."""
     gen_args, _ = setup_for_ssp(tmp_trestle_dir, prof_name, ssp_name)
     prof_path = tmp_trestle_dir / 'profiles/comp_prof/profile.json'
     # remove the reference to control ac-1
     test_utils.delete_line_in_file(prof_path, 'ac-1')
     ssp_gen = SSPGenerate()
-    assert ssp_gen._run(gen_args) == 1
+    assert ssp_gen._run(gen_args) == 0
+    assert 'Component comp_aa references control ac-1 not in profile.' in caplog.text

--- a/trestle/common/log.py
+++ b/trestle/common/log.py
@@ -50,8 +50,7 @@ def set_global_logging_levels(level: int = logging.INFO) -> None:
     """
     # This line stops default root loggers setup for a python context from logging extra messages.
     # DO NOT USE THIS COMMAND directly from an SDK. Handle logs levels based on your own application
-    # set propagate to True in order to capture warning messages in tests via caplog
-    _logger.propagate = True
+    _logger.propagate = False
     # Remove handlers
     _logger.handlers.clear()
     # set global level

--- a/trestle/common/log.py
+++ b/trestle/common/log.py
@@ -50,7 +50,8 @@ def set_global_logging_levels(level: int = logging.INFO) -> None:
     """
     # This line stops default root loggers setup for a python context from logging extra messages.
     # DO NOT USE THIS COMMAND directly from an SDK. Handle logs levels based on your own application
-    _logger.propagate = False
+    # set propagate to True in order to capture warning messages in tests via caplog
+    _logger.propagate = True
     # Remove handlers
     _logger.handlers.clear()
     # set global level

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -807,7 +807,12 @@ class CatalogInterface():
         comp_rules_params_dict.update(control_imp_rules_params_dict)
         context.rules_params_dict[context.comp_name] = comp_rules_params_dict
         ci_set_params = ControlInterface.get_set_params_from_item(context.control_implementation)
+        catalog_control_ids = self.get_control_ids()
         for imp_req in as_list(context.control_implementation.implemented_requirements):
+            if imp_req.control_id not in catalog_control_ids:
+                raise TrestleError(
+                    f'Component {context.component.title} references control {imp_req.control_id} not in profile.'
+                )
             control_part_id_map = part_id_map.get(imp_req.control_id, {})
             # find if any rules apply to this control, including in statements
             control_rules, statement_rules, ir_props = ControlInterface.get_rule_list_for_imp_req(imp_req)

--- a/trestle/core/catalog/catalog_interface.py
+++ b/trestle/core/catalog/catalog_interface.py
@@ -810,7 +810,7 @@ class CatalogInterface():
         catalog_control_ids = self.get_control_ids()
         for imp_req in as_list(context.control_implementation.implemented_requirements):
             if imp_req.control_id not in catalog_control_ids:
-                raise TrestleError(
+                logger.warning(
                     f'Component {context.component.title} references control {imp_req.control_id} not in profile.'
                 )
             control_part_id_map = part_id_map.get(imp_req.control_id, {})

--- a/trestle/core/catalog/catalog_writer.py
+++ b/trestle/core/catalog/catalog_writer.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List
 
 import trestle.common.const as const
 import trestle.oscal.catalog as cat
+from trestle.common.err import TrestleError
 from trestle.common.list_utils import as_list, deep_get, none_if_empty
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog.catalog_interface import CatalogInterface
@@ -228,9 +229,6 @@ class CatalogWriter():
             control_id = control.id
             context.comp_dict = self._catalog_interface._control_comp_dicts.get(control_id, {})
             control_file_path = self._catalog_interface.get_control_file_path(context.md_root, control_id)
-            if not control_file_path:
-                logger.warning(f'Control {control_id} referenced by component is not in the resolved catalog.')
-                continue
             control_file_path.parent.mkdir(exist_ok=True, parents=True)
             # the catalog interface is from the resolved profile catalog
             control = self._catalog_interface.get_control(control_id)
@@ -279,6 +277,10 @@ class CatalogWriter():
         control_ids_in_comp_imp = [
             imp_req.control_id for imp_req in as_list(context.control_implementation.implemented_requirements)
         ]
+
+        missing_controls = set(control_ids_in_comp_imp).difference(self._catalog_interface.get_control_ids())
+        if missing_controls:
+            raise TrestleError(f'Component {context.comp_name} references controls {missing_controls} not in profile.')
 
         # get top level rule info applying to all controls
         comp_rules_dict, comp_rules_params_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(context.component)  # noqa E501

--- a/trestle/core/catalog/catalog_writer.py
+++ b/trestle/core/catalog/catalog_writer.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, List
 
 import trestle.common.const as const
 import trestle.oscal.catalog as cat
-from trestle.common.err import TrestleError
 from trestle.common.list_utils import as_list, deep_get, none_if_empty
 from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog.catalog_interface import CatalogInterface
@@ -280,7 +279,7 @@ class CatalogWriter():
 
         missing_controls = set(control_ids_in_comp_imp).difference(self._catalog_interface.get_control_ids())
         if missing_controls:
-            raise TrestleError(f'Component {context.comp_name} references controls {missing_controls} not in profile.')
+            logger.warning(f'Component {context.comp_name} references controls {missing_controls} not in profile.')
 
         # get top level rule info applying to all controls
         comp_rules_dict, comp_rules_params_dict, _ = ControlInterface.get_rules_and_params_dict_from_item(context.component)  # noqa E501

--- a/trestle/core/control_interface.py
+++ b/trestle/core/control_interface.py
@@ -1109,13 +1109,23 @@ class ControlInterface:
                     if set_param.param_id not in (control_imp_rule_param_ids + imp_req_rule_param_ids):
                         continue
                     found = False
-                    for dest_param in imp_req.set_parameters:
+                    for dest_param in as_list(imp_req.set_parameters):
                         if dest_param.param_id != set_param.param_id:
                             continue
                         dest_param.values = set_param.values
                         found = True
                         break
                     # if rule parameter val was not already set by a set_param, make new set_param for it
+                    if found:
+                        continue
+                    # but first check if the parameter was already set with the same value in the control_imp
+                    # if so we don't need to insert a new set_param in imp_req
+                    for dest_param in as_list(control_imp.set_parameters):
+                        if dest_param.param_id != set_param.param_id:
+                            continue
+                        if dest_param.values == set_param.values:
+                            found = True
+                            break
                     if found:
                         continue
                     imp_req.set_parameters = as_list(imp_req.set_parameters)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Now give warnings if component references control not loaded by profile during ssp-gen and comp-gen
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
