### PR TITLE
fix: boost test coverage for component generate and assemble

### DIFF
--- a/tests/trestle/core/commands/author/component_test.py
+++ b/tests/trestle/core/commands/author/component_test.py
@@ -87,6 +87,22 @@ def check_at1_contents(at1_path: pathlib.Path) -> None:
 
 def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test component generate."""
+
+    def _assemble_and_check_ac1_contents(assem_name: str, assemble_cmd: str, new_prose: str, add_comp: bool) -> None:
+        test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
+        assem_component, _ = model_utils.ModelUtils.load_model_for_class(
+            tmp_trestle_dir, assem_name, comp.ComponentDefinition
+        )
+        for ii in range(3):
+            assert assem_component.components[0].control_implementations[0].implemented_requirements[0].set_parameters[
+                0].values[ii].__root__ == f'inserted value {ii}'
+
+        statement = assem_component.components[0].control_implementations[0].implemented_requirements[0].statements[0]
+        assert statement.description == new_prose
+        assert ControlInterface.get_status_from_props(statement).state == const.STATUS_IMPLEMENTED
+        if add_comp:
+            assert assem_component.components[2].title == 'comp_new'
+
     comp_name = test_utils.setup_component_generate(tmp_trestle_dir)
     ac1_path = tmp_trestle_dir / 'md_comp/comp_aa/comp_prof_aa/ac/ac-1.md'
 
@@ -133,32 +149,15 @@ def test_component_generate(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPa
         ac1_path, '### Implementation Status: partial', f'### Implementation Status: {const.STATUS_IMPLEMENTED}'
     )
 
-    # edit a prose
+    # edit prose
     new_prose = 'new prose\nmultiline too'
     test_utils.substitute_text_in_file(ac1_path, 'statement prose for part a. from comp aa', new_prose)
 
-    # assemble and confirm new value was captured
-    test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
-
-    assem_component, _ = model_utils.ModelUtils.load_model_for_class(
-        tmp_trestle_dir, assem_name, comp.ComponentDefinition
-    )
-
-    for ii in range(3):
-        assert assem_component.components[0].control_implementations[0].implemented_requirements[0].set_parameters[
-            0].values[ii].__root__ == f'inserted value {ii}'
-
-    statement = assem_component.components[0].control_implementations[0].implemented_requirements[0].statements[0]
-    assert statement.description == new_prose
-    assert ControlInterface.get_status_from_props(statement).state == const.STATUS_IMPLEMENTED
+    _assemble_and_check_ac1_contents(assem_name, assemble_cmd, new_prose, False)
 
     # confirm we can add a new component via markdown
     add_comp(tmp_trestle_dir / 'md_comp', ac1_path)
-    test_utils.execute_command_and_assert(assemble_cmd, CmdReturnCodes.SUCCESS.value, monkeypatch)
-    assem_component, _ = model_utils.ModelUtils.load_model_for_class(
-        tmp_trestle_dir, assem_name, comp.ComponentDefinition
-    )
-    assert assem_component.components[2].title == 'comp_new'
+    _assemble_and_check_ac1_contents(assem_name, assemble_cmd, new_prose, True)
 
 
 def test_generic_oscal() -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Increase coverage for comp generate and assemble and confirm edits work as expected

closes #1277

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
