### PR TITLE
chore: Refactoring of control reader to a new type of markdown node (Part 1)

### DIFF
--- a/docs/api_reference/trestle.core.markdown.base_markdown_node.md
+++ b/docs/api_reference/trestle.core.markdown.base_markdown_node.md
@@ -1,0 +1,2 @@
+::: trestle.core.markdown.base_markdown_node
+handler: python

--- a/docs/api_reference/trestle.core.markdown.control_markdown_node.md
+++ b/docs/api_reference/trestle.core.markdown.control_markdown_node.md
@@ -1,0 +1,2 @@
+::: trestle.core.markdown.control_markdown_node
+handler: python

--- a/docs/api_reference/trestle.core.markdown.docs_markdown_node.md
+++ b/docs/api_reference/trestle.core.markdown.docs_markdown_node.md
@@ -1,0 +1,2 @@
+::: trestle.core.markdown.docs_markdown_node
+handler: python

--- a/docs/api_reference/trestle.core.markdown.markdown_node.md
+++ b/docs/api_reference/trestle.core.markdown.markdown_node.md
@@ -1,2 +1,0 @@
-::: trestle.core.markdown.markdown_node
-handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,9 +121,11 @@ nav:
       - jinja: api_reference/trestle.core.jinja.md
       - links_validator: api_reference/trestle.core.links_validator.md
       - markdown:
+        - base_markdown_node: api_reference/trestle.core.markdown.base_markdown_node.md
+        - control_markdown_node: api_reference/trestle.core.markdown.control_markdown_node.md
+        - docs_markdown_node: api_reference/trestle.core.markdown.docs_markdown_node.md
         - markdown_api: api_reference/trestle.core.markdown.markdown_api.md
         - markdown_const: api_reference/trestle.core.markdown.markdown_const.md
-        - markdown_node: api_reference/trestle.core.markdown.markdown_node.md
         - markdown_processor: api_reference/trestle.core.markdown.markdown_processor.md
         - markdown_validator: api_reference/trestle.core.markdown.markdown_validator.md
         - md_writer: api_reference/trestle.core.markdown.md_writer.md

--- a/tests/trestle/core/commands/author/jinja_cmd_test.py
+++ b/tests/trestle/core/commands/author/jinja_cmd_test.py
@@ -22,7 +22,7 @@ from tests.test_utils import execute_command_and_assert, setup_for_ssp
 
 from trestle.core.commands.author.jinja import _number_captions
 from trestle.core.commands.author.ssp import SSPGenerate
-from trestle.core.markdown.markdown_node import MarkdownNode
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 
 
 def setup_ssp(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch):
@@ -49,7 +49,7 @@ def test_jinja_ssp_output(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.P
 
     with open('output_file.md') as test_output:
         output = test_output.read()
-        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
         assert tree
         node1 = tree.get_node_for_key('# A')
         node2 = tree.get_node_for_key('# C')
@@ -70,7 +70,7 @@ def test_jinja_lookup_table(
 
     with open('output_file.md') as test_output:
         output = test_output.read()
-        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
         assert tree
         node1 = tree.get_node_for_key('### Substitutions')
         node2 = tree.get_node_for_key('# B')
@@ -101,7 +101,7 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
 
     with open('output.md') as test_output:
         output = test_output.read()
-        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
         assert tree
         parent = tree.get_node_for_key('### AC-1 - Policy and Procedures')
         child1 = parent.get_node_for_key('#### AC-1 Summary information')
@@ -114,7 +114,7 @@ def test_params_formatting(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.
 
     with open('output.md') as test_output:
         output = test_output.read()
-        tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
         assert tree
         parent = tree.get_node_for_key('### AC-1 - Policy and Procedures')
         child1 = parent.get_node_for_key('#### AC-1 Summary information')
@@ -137,7 +137,7 @@ def test_jinja_profile_docs(
     for md_control in (tmp_trestle_dir / 'controls' / 'ac').iterdir():
         with open(md_control) as md_file:
             contents = md_file.read()
-            tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))
+            tree = DocsMarkdownNode.build_tree_from_markdown(contents.split('\n'))
             assert tree
             node1 = tree.get_node_for_key('# Control Page')
             assert node1
@@ -165,7 +165,7 @@ def test_jinja_profile_docs_with_group_title(
     md_control = tmp_trestle_dir / 'controls' / 'ac' / 'ac-1.md'
     with open(md_control) as md_file:
         contents = md_file.read()
-        tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(contents.split('\n'))
         assert tree
         node1 = tree.get_node_for_key('# Control Page')
         assert node1
@@ -195,7 +195,7 @@ def test_jinja_profile_docs_with_selected_sections(
     md_control = tmp_trestle_dir / 'controls' / 'ac' / 'ac-1.md'
     with open(md_control) as md_file:
         contents = md_file.read()
-        tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(contents.split('\n'))
         assert tree
         node1 = tree.get_node_for_key('# Control Page')
         assert node1
@@ -223,7 +223,7 @@ def test_jinja_profile_docs_with_selected_sections_and_multiple_parts(
     md_control = tmp_trestle_dir / 'controls' / 'ac' / 'ac-1.md'
     with open(md_control) as md_file:
         contents = md_file.read()
-        tree = MarkdownNode.build_tree_from_markdown(contents.split('\n'))
+        tree = DocsMarkdownNode.build_tree_from_markdown(contents.split('\n'))
         assert tree
         node1 = tree.get_node_for_key('## The above the line guidance')
         assert node1

--- a/tests/trestle/core/commands/author/profile_test.py
+++ b/tests/trestle/core/commands/author/profile_test.py
@@ -39,8 +39,8 @@ from trestle.common.model_utils import ModelUtils
 from trestle.core.catalog.catalog_interface import CatalogInterface
 from trestle.core.commands.author.profile import ProfileAssemble, ProfileGenerate
 from trestle.core.control_interface import ControlInterface
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 from trestle.core.markdown.markdown_api import MarkdownAPI
-from trestle.core.markdown.markdown_node import MarkdownNode
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.profile_resolver import ProfileResolver
 
@@ -736,7 +736,7 @@ More evidence
 def test_adding_removing_sections(tmp_trestle_dir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     """Test the profile generate and assemble in cycles, with incremental changes."""
 
-    def generate_assemble(md_path: pathlib.Path) -> MarkdownNode:
+    def generate_assemble(md_path: pathlib.Path) -> DocsMarkdownNode:
         prof_assemble = f'trestle author profile-assemble -n main_profile -m {md_name} -o main_profile'
         test_utils.execute_command_and_assert(prof_assemble, 0, monkeypatch)
 

--- a/tests/trestle/core/markdown/markdown_node_test.py
+++ b/tests/trestle/core/markdown/markdown_node_test.py
@@ -21,8 +21,8 @@ import frontmatter
 import pytest
 
 import trestle.common.const as const
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode, DocsSectionContent
 from trestle.core.markdown.markdown_api import MarkdownAPI
-from trestle.core.markdown.markdown_node import MarkdownNode, SectionContent
 
 
 @pytest.mark.parametrize('md_path', [(pathlib.Path('tests/data/markdown/valid_complex_md.md'))])
@@ -32,7 +32,7 @@ def test_tree_text_equal_to_md(md_path: pathlib.Path) -> None:
     markdown_wo_header = contents.content
     lines = markdown_wo_header.split('\n')
 
-    tree: MarkdownNode = MarkdownNode.build_tree_from_markdown(lines)
+    tree: DocsMarkdownNode = DocsMarkdownNode.build_tree_from_markdown(lines)
     assert markdown_wo_header == tree.content.raw_text
 
 
@@ -43,10 +43,10 @@ def test_md_get_node_for_key(md_path: pathlib.Path) -> None:
     markdown_wo_header = contents.content
     lines = markdown_wo_header.split('\n')
 
-    tree: MarkdownNode = MarkdownNode.build_tree_from_markdown(lines)
+    tree: DocsMarkdownNode = DocsMarkdownNode.build_tree_from_markdown(lines)
     assert tree.get_node_for_key('header1') is None
     assert tree.get_node_for_key('nonexisting header') is None
-    node: MarkdownNode = tree.get_node_for_key('# 2. MD Header 2 Blockquotes')
+    node: DocsMarkdownNode = tree.get_node_for_key('# 2. MD Header 2 Blockquotes')
     assert node is not None
     # Assert returned node has content
     assert node.key == '# 2. MD Header 2 Blockquotes'
@@ -71,7 +71,7 @@ def test_md_content_is_correct(md_path: pathlib.Path) -> None:
     markdown_wo_header = contents.content
     lines = markdown_wo_header.split('\n')
 
-    tree: MarkdownNode = MarkdownNode.build_tree_from_markdown(lines)
+    tree: DocsMarkdownNode = DocsMarkdownNode.build_tree_from_markdown(lines)
     assert tree is not None
     assert len(tree.content.subnodes_keys) == 28
     assert tree.content.raw_text == markdown_wo_header
@@ -90,7 +90,7 @@ def test_md_headers_in_html_blocks_are_ignored(md_path: pathlib.Path) -> None:
     markdown_wo_header = contents.content
     lines = markdown_wo_header.split('\n')
 
-    tree: MarkdownNode = MarkdownNode.build_tree_from_markdown(lines)
+    tree: DocsMarkdownNode = DocsMarkdownNode.build_tree_from_markdown(lines)
     assert tree is not None
     tricky_node = tree.get_node_for_key('1.3', strict_matching=False)
     assert tricky_node.key == '## 1.3 MD Subheader 1.3 HTML'
@@ -191,7 +191,7 @@ def test_modify_subtree(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Pat
 
 def test_get_header_level() -> None:
     """Test get header level."""
-    node = MarkdownNode('foo', SectionContent(), 0)
+    node = DocsMarkdownNode('foo', DocsSectionContent(), 0)
     assert node._get_header_level_if_valid('') is None
     assert node._get_header_level_if_valid('# ') == 1
     assert node._get_header_level_if_valid(' # ## ') is None

--- a/tests/trestle/core/ssp_io_test.py
+++ b/tests/trestle/core/ssp_io_test.py
@@ -25,7 +25,7 @@ from trestle.core import profile_resolver
 from trestle.core.commands.author.ssp import SSPGenerate
 from trestle.core.control_context import ContextPurpose, ControlContext
 from trestle.core.control_reader import ControlReader
-from trestle.core.markdown.markdown_node import MarkdownNode
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 from trestle.core.models.file_content_type import FileContentType
 from trestle.core.remote import cache
 from trestle.core.ssp_io import SSPMarkdownWriter
@@ -117,7 +117,7 @@ def test_ssp_get_control_response(tmp_trestle_dir: pathlib.Path, monkeypatch: Mo
 
     md_text = ssp_io.get_control_response('ac-1', 1, True)
     assert md_text
-    tree = MarkdownNode.build_tree_from_markdown(md_text.split('\n'))
+    tree = DocsMarkdownNode.build_tree_from_markdown(md_text.split('\n'))
 
     assert tree.get_node_for_key('## Implementation for part a.')
     assert len(list(tree.get_all_headers_for_level(2))) == 1
@@ -156,7 +156,7 @@ def test_writers(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monk
     assert not output
 
     output = ssp_io._write_list_with_header('Sample list', ['1', '2', '3'], 2)
-    tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+    tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
     node = tree.get_node_for_key('### Sample list')
     assert node
     assert node.content.text == ['', '- 1', '', '- 2', '', '- 3']
@@ -165,7 +165,7 @@ def test_writers(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monk
     assert not output
 
     output = ssp_io._write_table_with_header('Sample table', [['1', '2', '3'], ['4', '5', '6']], ['c1', 'c2', 'c3'], 0)
-    tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+    tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
     node = tree.get_node_for_key('# Sample table')
     assert node
     assert node.content.tables[0] == '| c1 | c2 | c3 |'
@@ -175,7 +175,7 @@ def test_writers(testdata_dir: pathlib.Path, tmp_trestle_dir: pathlib.Path, monk
     assert not output
 
     output = ssp_io._write_str_with_header('Some text', 'this is a text.', 5)
-    tree = MarkdownNode.build_tree_from_markdown(output.split('\n'))
+    tree = DocsMarkdownNode.build_tree_from_markdown(output.split('\n'))
     node = tree.get_node_for_key('###### Some text')
     assert node
     assert node.content.raw_text == '###### Some text\n\nthis is a text.'

--- a/trestle/core/control_reader.py
+++ b/trestle/core/control_reader.py
@@ -15,7 +15,6 @@
 import logging
 import pathlib
 import re
-import string
 from typing import Any, Dict, List, Optional, Tuple
 
 import trestle.core.generic_oscal as generic
@@ -29,8 +28,8 @@ from trestle.common.str_utils import spaces_and_caps_to_snake
 from trestle.core import generators as gens
 from trestle.core.control_context import ContextPurpose, ControlContext
 from trestle.core.control_interface import CompDict, ComponentImpInfo, ControlInterface
+from trestle.core.markdown.control_markdown_node import ControlMarkdownNode
 from trestle.core.markdown.markdown_api import MarkdownAPI
-from trestle.core.markdown.markdown_processor import MarkdownNode
 from trestle.oscal import common
 from trestle.oscal import component as comp
 from trestle.oscal import profile as prof
@@ -39,269 +38,8 @@ from trestle.oscal import ssp as ossp
 logger = logging.getLogger(__name__)
 
 
-class ControlReader():
+class ControlReader:
     """Class to read controls from markdown."""
-
-    @staticmethod
-    def _parse_control_title_line(line: str) -> Tuple[int, str, str]:
-        """Process the title line and extract the control id, group title (in brackets) and control title."""
-        if line.count('-') == 0:
-            raise TrestleError(f'Markdown control title format error, missing - after control id: {line}')
-        split_line = line.split()
-        if len(split_line) < 3 or split_line[2] != '-':
-            raise TrestleError(f'Cannot parse control markdown title for control_id group and title: {line}')
-        # first token after the #
-        control_id = split_line[1]
-        group_title_start = line.find('\[')
-        group_title_end = line.find('\]')
-        if group_title_start < 0 or group_title_end < 0 or group_title_start > group_title_end:
-            raise TrestleError(f'unable to read group title for control {control_id}')
-        group_title = line[group_title_start + 2:group_title_end].strip()
-        control_title = line[group_title_end + 2:].strip()
-        return control_id, group_title, control_title
-
-    @staticmethod
-    def _indent(line: str) -> int:
-        """Measure indent of non-empty line."""
-        if not line:
-            raise TrestleError('Empty line queried for indent.')
-        if line[0] not in [' ', '-']:
-            return -1
-        for ii in range(len(line)):
-            if line[ii] == '-':
-                return ii
-            # if line is indented it must start with -
-            if line[ii] != ' ':
-                return ii
-
-    @staticmethod
-    def _get_next_line(ii: int, lines: List[str]) -> Tuple[int, str]:
-        while ii < len(lines):
-            line = lines[ii]
-            if line:
-                return ii, line
-            ii += 1
-        return -1, ''
-
-    @staticmethod
-    def _get_next_indent(ii: int, lines: List[str], skip_empty_lines: bool = True) -> Tuple[int, int, str]:
-        """Seek to next content line.  ii remains at line read."""
-        while 0 <= ii < len(lines):
-            line = lines[ii]
-            if line and not line.isspace():
-                if line[0] == '#':
-                    return ii, -1, line
-                indent = ControlReader._indent(line)
-                if indent >= 0:
-                    # extract text after -
-                    start = indent + 1
-                    while start < len(line) and line[start] == ' ':
-                        start += 1
-                    if start >= len(line):
-                        raise TrestleError(f'Invalid line {line}')
-                    return ii, indent, line[start:]
-                return ii, indent, line
-            elif not skip_empty_lines:
-                return ii, -1, line
-            ii += 1
-        return ii, -1, ''
-
-    @staticmethod
-    def _read_part_id_prose(line: str) -> Tuple[str, str]:
-        """Extract the part id letter or number and prose from line."""
-        start = line.find('\\[')
-        end = line.find('\\]')
-        prose = line.strip() if start < 0 else line[end + 2:].strip()
-        id_ = '' if start < 0 or end < 0 else line[start + 2:end]
-        return id_, prose
-
-    @staticmethod
-    def _bump_label(label: str) -> str:
-        """
-        Find next label given a string of 1 or more pure letters or digits.
-
-        The input must be either a string of digits or a string of ascii letters - or empty string.
-        """
-        if not label:
-            return 'a'
-        if label[0] in string.digits:
-            return str(int(label) + 1)
-        if len(label) == 1 and label[0].lower() < 'z':
-            return chr(ord(label[0]) + 1)
-        # if this happens to be a string of letters, force it lowercase and bump
-        label = label.lower()
-        factor = 1
-        value = 0
-        # delta is needed because a counts as 0 when first value on right, but 1 for all others
-        delta = 0
-        for letter in label[::-1]:
-            value += (ord(letter) - ord('a') + delta) * factor
-            factor *= 26
-            delta = 1
-
-        value += 1
-
-        new_label = ''
-        delta = 0
-        while value > 0:
-            new_label += chr(ord('a') + value % 26 - delta)
-            value = value // 26
-            delta = 1
-        return new_label[::-1]
-
-    @staticmethod
-    def _create_next_label(prev_label: str, indent: int) -> str:
-        """
-        Create new label at indent level based on previous label if available.
-
-        If previous label is available, make this the next one in the sequence.
-        Otherwise start with a or 1 on alternate levels of indentation.
-        If alphabetic label reaches z, next one is aa.
-        Numeric ranges from 1 to 9, then 10 etc.
-        """
-        if not prev_label:
-            # assume indent goes in steps of 2
-            return ['a', '1'][(indent // 2) % 2]
-        label_prefix = ''
-        label_suffix = prev_label
-        is_char = prev_label[-1] in string.ascii_letters
-        # if it isn't ending in letter or digit just append 'a' to end
-        if not is_char and prev_label[-1] not in string.digits:
-            return prev_label + 'a'
-        # break in middle of string if mixed types
-        if len(prev_label) > 1:
-            ii = len(prev_label) - 1
-            while ii >= 0:
-                if prev_label[ii] not in string.ascii_letters + string.digits:
-                    break
-                if (prev_label[ii] in string.ascii_letters) != is_char:
-                    break
-                ii -= 1
-            if ii >= 0:
-                label_prefix = prev_label[:(ii + 1)]
-                label_suffix = prev_label[(ii + 1):]
-
-        return label_prefix + ControlReader._bump_label(label_suffix)
-
-    @staticmethod
-    def _read_parts(indent: int, ii: int, lines: List[str], parent_id: str,
-                    parts: List[common.Part]) -> Tuple[int, List[common.Part]]:
-        """If indentation level goes up or down, create new list or close current one."""
-        while True:
-            ii, new_indent, line = ControlReader._get_next_indent(ii, lines)
-            if new_indent < 0:
-                # we are done reading control statement
-                return ii, parts
-            if new_indent == indent:
-                # create new item part and add to current list of parts
-                id_text, prose = ControlReader._read_part_id_prose(line)
-                # id_text is the part id and needs to be as a label property value
-                # if none is there then create one from previous part, or use default
-                if not id_text:
-                    prev_label = ControlInterface.get_label(parts[-1]) if parts else ''
-                    id_text = ControlReader._create_next_label(prev_label, indent)
-                id_ = ControlInterface.strip_to_make_ncname(parent_id.rstrip('.') + '.' + id_text.strip('.'))
-                name = 'objective' if id_.find('_obj') > 0 else 'item'
-                prop = common.Property(name='label', value=id_text)
-                part = common.Part(name=name, id=id_, prose=prose, props=[prop])
-                parts.append(part)
-                ii += 1
-            elif new_indent > indent:
-                # add new list of parts to last part and continue
-                if len(parts) == 0:
-                    raise TrestleError(f'Improper indentation structure: {line}')
-                ii, new_parts = ControlReader._read_parts(new_indent, ii, lines, parts[-1].id, [])
-                if new_parts:
-                    parts[-1].parts = new_parts
-            else:
-                # return list of sub-parts
-                return ii, parts
-
-    @staticmethod
-    def _read_control_statement_or_objective(key: str, lines: List[str], control_id: str) -> common.Part:
-        """Read control statement or objective, raise an error if not found."""
-        matching_idx = [i for i, line in enumerate(lines) if line.lower().startswith(key.lower())]
-        if len(matching_idx) == 0:
-            raise TrestleError(f'Heading {key} was not found in control {control_id}.')
-        if len(matching_idx) > 1:
-            raise TrestleError(f'Multiple headings {key} are found in control {control_id}. Only one allowed.')
-
-        starting_line = matching_idx[0] + 1
-        prose = []
-
-        if key == const.CONTROL_STATEMENT_HEADER:
-            statement_id = ControlInterface.create_statement_id(control_id)
-            a_part = common.Part(name=const.STATEMENT, id=statement_id)
-        elif key == const.CONTROL_OBJECTIVE_HEADER:
-            a_part = common.Part(name='objective', id=f'{control_id}_obj')
-        else:
-            raise TrestleError(f'Reading control with heading {key} is not supported.')
-
-        for i in range(starting_line, len(lines)):
-            line = lines[i]
-            if not line:
-                prose.append(line)
-                continue
-
-            indent = ControlReader._indent(line)
-            if indent < 0:
-                prose.append(line)
-            else:
-                if line.lstrip()[0] != '-':
-                    # Prose that appears indented but has no - : treat it as the normal statement prose
-                    prose.append(line)
-                    continue
-
-                # Read parts
-                _, parts = ControlReader._read_parts(0, i, lines, a_part.id, [])
-                a_part.parts = none_if_empty(parts)
-
-                break
-        if prose:
-            # Delete all leading and trailing new lines before and after the text
-            str_prose = '\n'.join(prose)
-            str_prose = str_prose.strip()
-            if str_prose:
-                a_part.prose = str_prose
-
-        return a_part
-
-    @staticmethod
-    def _read_sections(ii: int, lines: List[str], control_id: str,
-                       control_parts: List[common.Part]) -> Tuple[int, Optional[List[common.Part]]]:
-        """Read all sections following the section separated by ## Control."""
-        new_parts = []
-        prefix = const.CONTROL_HEADER + ' '
-        while 0 <= ii < len(lines):
-            line = lines[ii]
-            if line.startswith('## What is the solution') or line.startswith(f'# {const.EDITABLE_CONTENT}'):
-                ii += 1
-                continue
-            if not line:
-                ii += 1
-                continue
-            if line and not line.startswith(prefix):
-                # the control has no sections to read, so exit the loop
-                break
-            label = line[len(prefix):].strip()
-            prose = ''
-            ii += 1
-            while 0 <= ii < len(lines) and not lines[ii].startswith(prefix) and not lines[ii].startswith(
-                    f'# {const.EDITABLE_CONTENT}'):
-                prose = '\n'.join([prose, lines[ii]])
-                ii += 1
-            if prose:
-                if label.lower() == 'guidance':
-                    id_ = ControlInterface.strip_to_make_ncname(control_id + '_gdn')
-                else:
-                    id_ = ControlInterface.strip_to_make_ncname(control_id + '_' + label)
-                label = ControlInterface.strip_to_make_ncname(label)
-                new_parts.append(common.Part(id=id_, name=label, prose=prose.strip('\n')))
-        if new_parts:
-            control_parts = [] if not control_parts else control_parts
-            control_parts.extend(new_parts)
-        control_parts = none_if_empty(control_parts)
-        return ii, control_parts
 
     @staticmethod
     def _clean_prose(prose: List[str]) -> List[str]:
@@ -336,7 +74,7 @@ class ControlReader():
         comp_name: Optional[str],
         label: str,
         comp_dict: CompDict,
-        node: MarkdownNode,
+        node: ControlMarkdownNode,
         control_id: str,
         comp_list: List[str],
         context: ControlContext
@@ -591,7 +329,7 @@ class ControlReader():
     @staticmethod
     def _add_control_part(
         control_id: str,
-        subnode: MarkdownNode,
+        subnode: ControlMarkdownNode,
         required_sections_list: List[str],
         sections_dict: Dict[str, str],
         snake_dict: Dict[str, str],
@@ -627,7 +365,7 @@ class ControlReader():
 
     @staticmethod
     def _add_sub_parts(part_id: str,
-                       node: MarkdownNode,
+                       node: ControlMarkdownNode,
                        fixed_part_name: Optional[str] = None) -> Optional[List[common.Part]]:
         if not node.subnodes:
             return None
@@ -651,7 +389,7 @@ class ControlReader():
     @staticmethod
     def _add_sub_part(
         control_id: str,
-        subnode: MarkdownNode,
+        subnode: ControlMarkdownNode,
         label_map: Dict[str, str],
         by_id_parts: Dict[str, List[common.Part]],
         sections_dict: Dict[str, str]
@@ -800,39 +538,49 @@ class ControlReader():
         """Read the control and group title from the markdown file."""
         control = gens.generate_sample_model(cat.Control)
         md_api = MarkdownAPI()
-        yaml_header, control_tree = md_api.processor.process_markdown(control_path)
+        yaml_header, control_tree = md_api.processor.process_control_markdown(control_path)
         control_titles = list(control_tree.get_all_headers_for_level(1))
         if len(control_titles) == 0:
             raise TrestleError(f'Control markdown: {control_path} contains no control title.')
+        if len(control_titles) > 1:
+            raise TrestleError(f'Control markdown: {control_path} contains multiple control titles {control_titles}.')
 
-        control.id, group_title, control.title = ControlReader._parse_control_title_line(control_titles[0])
+        control.id = control_tree.subnodes[0].content.control_id
+        group_title = control_tree.subnodes[0].content.control_group
+        control.title = control_tree.subnodes[0].content.control_title
 
-        control_headers = list(control_tree.get_all_headers_for_level(2))
-        if len(control_headers) == 0:
-            raise TrestleError(f'Control markdown: {control_path} contains no control statements.')
-
-        control_statement = control_tree.get_node_for_key(control_headers[0])
-        statement_part = ControlReader._read_control_statement_or_objective(
-            const.CONTROL_STATEMENT_HEADER, control_statement.content.raw_text.split('\n'), control.id
-        )
+        control_statement = control_tree.get_control_statement()
+        statement_part = control_statement.content.statement_part
 
         control.parts = [statement_part] if statement_part else None
-        control_objective = control_tree.get_node_for_key(const.CONTROL_OBJECTIVE_HEADER)
+        control_objective = control_tree.get_control_objective()
         if control_objective is not None:
-            objective_part = ControlReader._read_control_statement_or_objective(
-                const.CONTROL_OBJECTIVE_HEADER, control_objective.content.raw_text.split('\n'), control.id
-            )
+            objective_part = control_objective.content.objective_part
             if objective_part:
                 if control.parts:
                     control.parts.append(objective_part)
                 else:
                     control.parts = [objective_part]
-        for header_key in control_tree.get_all_headers_for_key(const.CONTROL_HEADER, False):
-            if header_key not in {control_headers[0], const.CONTROL_OBJECTIVE_HEADER, control_titles[0]}:
-                section_node = control_tree.get_node_for_key(header_key)
-                _, control.parts = ControlReader._read_sections(
-                    0, section_node.content.raw_text.split('\n'), control.id, control.parts
-                )
+
+        control_guidance = control_tree.get_control_guidance()
+        if control_guidance is not None:
+            guidance_part = control_guidance.content.guidance_part
+            if guidance_part:
+                if control.parts:
+                    control.parts.append(guidance_part)
+                else:
+                    control.parts = [guidance_part]
+
+        all_other_parts = []
+        for section_node in control_tree.get_other_control_parts():
+            parts = section_node.content.other_parts
+            all_other_parts.extend(parts)
+        if all_other_parts:
+            if control.parts:
+                control.parts.extend(all_other_parts)
+            else:
+                control.parts = all_other_parts
+
         if set_parameters_flag:
             params: Dict[str, str] = yaml_header.get(const.SET_PARAMS_TAG, [])
             if params:

--- a/trestle/core/jinja.py
+++ b/trestle/core/jinja.py
@@ -25,8 +25,7 @@ from jinja2.ext import Extension
 from jinja2.parser import Parser
 
 from trestle.common import err
-from trestle.core.markdown import markdown_const
-from trestle.core.markdown import markdown_node
+from trestle.core.markdown import docs_markdown_node, markdown_const
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ logger = logging.getLogger(__name__)
 def adjust_heading_level(input_md: str, expected: int) -> str:
     """Adjust the header level of a markdown string such that the most significant header matches the expected #'s."""
     output_md = input_md
-    mdn = markdown_node.MarkdownNode.build_tree_from_markdown(input_md.split('\n'))
+    mdn = docs_markdown_node.DocsMarkdownNode.build_tree_from_markdown(input_md.split('\n'))
     if mdn.subnodes:
         mdn_top_heading = mdn.subnodes[0].get_node_header_lvl()
         delta = int(expected) - mdn_top_heading
@@ -113,7 +112,7 @@ class MDSectionInclude(TrestleJinjaExtension):
         fm = frontmatter.loads(md_content)
         if not fm.metadata == {}:
             logger.warning('Non zero metadata on MD section include - ignoring')
-        full_md = markdown_node.MarkdownNode.build_tree_from_markdown(fm.content.split('\n'))
+        full_md = docs_markdown_node.DocsMarkdownNode.build_tree_from_markdown(fm.content.split('\n'))
         md_section = full_md.get_node_for_key(section_title.value, strict_matching=True)
         # adjust
         if kwargs is not None:

--- a/trestle/core/markdown/base_markdown_node.py
+++ b/trestle/core/markdown/base_markdown_node.py
@@ -137,14 +137,6 @@ class BaseMarkdownNode:
         # go through all contents and modify headers
         self._rec_traverse_header_update(self, header_map)
 
-    def get_count_of_subnodes(self, recurse=True) -> int:
-        """Get count of subnodes with optional recursion."""
-        count = len(self.subnodes)
-        if recurse:
-            for subnode in self.subnodes:
-                count += subnode.get_count_of_subnodes(True)
-        return count
-
     def delete_nodes_text(self, keys: List[str], strict_matching: bool = True) -> List[str]:
         """Remove text from this node that is found in matching subnodes."""
         text_lines = self.content.raw_text.split('\n')
@@ -164,37 +156,10 @@ class BaseMarkdownNode:
         level: int,
         governed_header: Optional[str] = None
     ) -> Tuple[BaseMarkdownNode, int]:
-        """
-        Build a tree from the markdown recursively.
-
-        The tree is contructed with valid headers as node's keys
-        and node's content contains everything that is under that header.
-        The subsections are placed into node's children with the same structure.
-
-        A header is valid iff the line starts with # and it is not:
-          1. Inside of the html blocks
-          2. Inside single lined in the <> tags
-          3. Inside the html comment
-          4. Inside any table, code block or blockquotes
-        """
+        """Build a tree from the markdown recursively."""
         content = BaseSectionContent()
         node_children = []
         i = starting_line
-
-        while True:
-            if i >= len(lines):
-                break
-            line = lines[i].strip(' ')
-            header_lvl = self._get_header_level_if_valid(line)
-
-            if header_lvl is not None:
-                if header_lvl >= level + 1:
-                    # build subtree
-                    subtree, i = self._build_tree(lines, line, i + 1, level + 1, governed_header)
-                    node_children.append(subtree)
-                    content.union(subtree)
-                else:
-                    break  # level of the header is above or equal to the current level, subtree is over
 
         first_line_to_grab = starting_line - 1 if starting_line else 0
         content.raw_text = '\n'.join(lines[first_line_to_grab:i])

--- a/trestle/core/markdown/base_markdown_node.py
+++ b/trestle/core/markdown/base_markdown_node.py
@@ -1,6 +1,6 @@
 # -*- mode:python; coding:utf-8 -*-
 
-# Copyright (c) 2021 IBM Corp. All rights reserved.
+# Copyright (c) 2023 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A markdown node."""
+"""A base markdown node."""
 from __future__ import annotations
 
 import logging
@@ -28,36 +28,26 @@ from trestle.common.list_utils import as_filtered_list, delete_list_from_list
 logger = logging.getLogger(__name__)
 
 
-class SectionContent:
+class BaseSectionContent:
     """A content of the node."""
 
     def __init__(self):
         """Initialize section content."""
-        self.tables = []
-        self.text = []
-        self.code_lines = []
-        self.html_lines = []
-        self.blockquotes = []
         self.raw_text = ''
         self.subnodes_keys = []
-        self.governed_document = []
 
-    def union(self, node: MarkdownNode) -> None:
+    def union(self, node: BaseMarkdownNode) -> None:
         """Unites contents together."""
         self.subnodes_keys.append(node.key)
         self.subnodes_keys.extend(node.content.subnodes_keys)
-        self.code_lines.extend(node.content.code_lines)
-        self.html_lines.extend(node.content.html_lines)
-        self.tables.extend(node.content.tables)
-        self.blockquotes.extend(node.content.blockquotes)
 
 
-class MarkdownNode:
+class BaseMarkdownNode:
     """Markdown will be read to the tree."""
 
-    def __init__(self, key: str, content: SectionContent, starting_line: int):
+    def __init__(self, key: str, content: BaseSectionContent, starting_line: int):
         """Initialize markdown node."""
-        self.subnodes: List[MarkdownNode] = []
+        self.subnodes: List[BaseMarkdownNode] = []
         self.key = key
         self.content = content
         self.starting_line = starting_line
@@ -76,17 +66,17 @@ class MarkdownNode:
             filter(lambda header: self._get_header_level_if_valid(header) == level, self.content.subnodes_keys)
         ).__iter__()
 
-    def get_node_for_key(self, key: str, strict_matching: bool = True) -> Optional[MarkdownNode]:
-        """Return a first node for the given key, substring matching is supported."""
+    def get_node_for_key(self, key: str, strict_matching: bool = True) -> Optional[BaseMarkdownNode]:
+        """Return a first node for the given key, substring matching is supported. The method is case insensitive."""
         if not strict_matching:
-            if not any([key in el for el in self.content.subnodes_keys]):
+            if not any([key.lower() in el.lower() for el in self.content.subnodes_keys]):
                 return None
-            elif len(as_filtered_list(self.content.subnodes_keys, lambda el: key in el)) > 1:
+            elif len(as_filtered_list(self.content.subnodes_keys, lambda el: key.lower() in el.lower())) > 1:
                 logger.warning(f'Multiple nodes for {key} were found, only the first one will be returned.')
         else:
-            if key not in self.content.subnodes_keys:
+            if key.lower() not in [el.lower() for el in self.content.subnodes_keys]:
                 return None
-            elif len(as_filtered_list(self.content.subnodes_keys, lambda el: el == key)) > 1:
+            elif len(as_filtered_list(self.content.subnodes_keys, lambda el: el.lower() == key.lower())) > 1:
                 logger.warning(f'Multiple nodes for {key} were found, only the first one will be returned.')
 
         return self._rec_traverse(self, key, strict_matching)
@@ -96,7 +86,7 @@ class MarkdownNode:
         keys: List[str],
         strict_matching: bool = True,
         stop_recurse_on_first_match: bool = False
-    ) -> List[MarkdownNode]:
+    ) -> List[BaseMarkdownNode]:
         """
         Return all nodes for the given keys, substring matching is supported.
 
@@ -173,7 +163,7 @@ class MarkdownNode:
         starting_line: int,
         level: int,
         governed_header: Optional[str] = None
-    ) -> Tuple[MarkdownNode, int]:
+    ) -> Tuple[BaseMarkdownNode, int]:
         """
         Build a tree from the markdown recursively.
 
@@ -187,7 +177,7 @@ class MarkdownNode:
           3. Inside the html comment
           4. Inside any table, code block or blockquotes
         """
-        content = SectionContent()
+        content = BaseSectionContent()
         node_children = []
         i = starting_line
 
@@ -205,35 +195,10 @@ class MarkdownNode:
                     content.union(subtree)
                 else:
                     break  # level of the header is above or equal to the current level, subtree is over
-            elif self._does_start_with(line, md_const.CODEBLOCK_DEF):
-                code_lines, i = self._read_code_lines(lines, line, i + 1)
-                content.code_lines.extend(code_lines)
-            elif self._does_start_with(line, md_const.HTML_COMMENT_START):
-                html_lines, i = self._read_html_block(lines, line, i + 1, md_const.HTML_COMMENT_END_REGEX)
-                content.html_lines.extend(html_lines)
-            elif self._does_contain(line, md_const.HTML_TAG_REGEX_START):
-                html_lines, i = self._read_html_block(lines, line, i + 1, md_const.HTML_TAG_REGEX_END)
-                content.html_lines.extend(html_lines)
-            elif self._does_start_with(line, md_const.TABLE_SYMBOL):
-                table_block, i = self._read_table_block(lines, line, i + 1)
-                content.tables.extend(table_block)
-            elif self._does_start_with(line, md_const.BLOCKQUOTE_CHAR):
-                content.blockquotes.append(line)
-                i += 1
-            elif governed_header is not None and self._does_contain(
-                    root_key, fr'^[#]+ {governed_header}$') and self._does_contain(line, md_const.GOVERNED_DOC_REGEX):
-                regexp = re.compile(md_const.GOVERNED_DOC_REGEX)
-                match = regexp.search(line)
-                header = match.group(0).strip('*').strip(':')
-                content.governed_document.append(header)
-                i += 1
-            else:
-                content.text.append(line)
-                i += 1
 
         first_line_to_grab = starting_line - 1 if starting_line else 0
         content.raw_text = '\n'.join(lines[first_line_to_grab:i])
-        md_node = MarkdownNode(key=root_key, content=content, starting_line=first_line_to_grab)
+        md_node = BaseMarkdownNode(key=root_key, content=content, starting_line=first_line_to_grab)
         md_node.subnodes = node_children
         return (md_node, i)
 
@@ -283,7 +248,7 @@ class MarkdownNode:
         regexp = re.compile(reg)
         return regexp.search(line) is not None
 
-    def _read_code_lines(self, lines: List[str], line: str, i: int) -> Tuple[str, int]:
+    def _read_code_lines(self, lines: List[str], line: str, i: int) -> tuple[list[str], int]:
         """Read code block."""
         code_lines = [line]
         while True:
@@ -297,7 +262,7 @@ class MarkdownNode:
                 break
         return code_lines, i
 
-    def _read_html_block(self, lines: List[str], line: str, i: int, ending_regex: str) -> Tuple[str, int]:
+    def _read_html_block(self, lines: List[str], line: str, i: int, ending_regex: str) -> tuple[list[str], int]:
         """Read html block."""
         html_block = [line]
         if self._does_contain(line, r'<br[ /]*>'):
@@ -315,7 +280,7 @@ class MarkdownNode:
                 break
         return html_block, i
 
-    def _read_table_block(self, lines: List[str], line: str, i: int) -> Tuple[str, int]:
+    def _read_table_block(self, lines: List[str], line: str, i: int) -> tuple[list[str], int]:
         """Read table."""
         table_block = [line]
         while True:
@@ -330,16 +295,18 @@ class MarkdownNode:
             i += 1
         return table_block, i
 
-    def _rec_traverse(self, node: MarkdownNode, key: str, strict_matching: bool) -> Optional[MarkdownNode]:
+    def _rec_traverse(self, node: BaseMarkdownNode, key: str, strict_matching: bool) -> Optional[BaseMarkdownNode]:
         """
         Recursevely traverses the tree and searches for the given key.
 
         If strict matching is turned off, node will be matched if key is a substring of the node's header.
         """
-        if key == node.key or (not strict_matching and key in node.key):
+        if key.lower() == node.key.lower() or (not strict_matching and key.lower() in node.key.lower()):
             return node
-        if (not strict_matching and any([key in el
-                                         for el in node.content.subnodes_keys])) or (key in node.content.subnodes_keys):
+        if (not strict_matching and any([key.lower() in el.lower()
+                                         for el in node.content.subnodes_keys])) or (key.lower() in [
+                                             el.lower() for el in node.content.subnodes_keys
+                                         ]):
             for subnode in node.subnodes:
                 matched_node = self._rec_traverse(subnode, key, strict_matching)
                 if matched_node is not None:
@@ -348,15 +315,15 @@ class MarkdownNode:
         return None
 
     def _rec_traverse_all(
-        self, node: MarkdownNode, keys: List[str], strict_matching: bool, stop_recurse_on_first_match: bool
-    ) -> List[MarkdownNode]:
+        self, node: BaseMarkdownNode, keys: List[str], strict_matching: bool, stop_recurse_on_first_match: bool
+    ) -> List[BaseMarkdownNode]:
         """
         Recursevely traverse the tree and find all nodes matching the keys.
 
         If strict matching is turned off, nodes will be matched if key is a substring of the node's header.
         stop_recurse_on_first_match will return only the highest level key match and not any subnodes
         """
-        found_nodes: List[MarkdownNode] = []
+        found_nodes: List[BaseMarkdownNode] = []
         for key in keys:
             if key == node.key or (not strict_matching and key in node.key):
                 found_nodes.append(node)
@@ -367,7 +334,7 @@ class MarkdownNode:
             found_nodes.extend(matched_nodes)
         return found_nodes
 
-    def _rec_traverse_header_update(self, node: MarkdownNode, header_map: Dict[str, str]) -> None:
+    def _rec_traverse_header_update(self, node: BaseMarkdownNode, header_map: Dict[str, str]) -> None:
         """Recursively traverse tree and update the contents."""
         if node:
             if node.key != 'root':

--- a/trestle/core/markdown/control_markdown_node.py
+++ b/trestle/core/markdown/control_markdown_node.py
@@ -1,0 +1,464 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2023 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A control markdown node."""
+from __future__ import annotations
+
+import logging
+import string
+from typing import List, Optional, Tuple
+
+from trestle.common import const
+from trestle.common.err import TrestleError
+from trestle.common.list_utils import none_if_empty
+from trestle.core.control_interface import ControlInterface
+from trestle.core.markdown.base_markdown_node import BaseMarkdownNode, BaseSectionContent
+from trestle.oscal import common
+
+logger = logging.getLogger(__name__)
+
+
+class TreeContext:
+    """A shared singleton tree context."""
+
+    def __init__(self):
+        """Initialize tree context."""
+        self.control_id = ''
+        self.control_group = ''
+        self.control_title = ''
+
+    def reset(self):
+        """Reset global control tree context."""
+        self.control_id = ''
+        self.control_group = ''
+        self.control_title = ''
+
+
+tree_context = TreeContext()
+
+
+class ControlSectionContent(BaseSectionContent):
+    """A content of the node."""
+
+    def __init__(self):
+        """Initialize section content."""
+        super(ControlSectionContent, self).__init__()
+        self.statement_part = None
+        self.objective_part = None
+        self.guidance_part = None
+        self.other_parts = []
+
+    def union(self, node: ControlMarkdownNode) -> None:
+        """Unites contents together."""
+        super().union(node)
+        pass
+
+
+class ControlMarkdownNode(BaseMarkdownNode):
+    """Markdown will be read to the tree."""
+
+    def __init__(self, key: str, content: ControlSectionContent, starting_line: int):
+        """Initialize markdown node."""
+        super(ControlMarkdownNode, self).__init__(key, content, starting_line)
+        self.content: ControlSectionContent = content
+
+    def _build_tree(
+        self,
+        lines: List[str],
+        root_key: str,
+        starting_line: int,
+        level: int,
+        governed_header: Optional[str] = None
+    ) -> Tuple[ControlMarkdownNode, int]:
+        """
+        Build a tree from the markdown recursively.
+
+        The tree is contructed with valid headers as node's keys
+        and node's content contains everything that is under that header.
+        The subsections are placed into node's children with the same structure.
+
+        A header is valid iff the line starts with # and it is not:
+          1. Inside of the html blocks
+          2. Inside single lined in the <> tags
+          3. Inside the html comment
+          4. Inside any table, code block or blockquotes
+
+        Specific Control Rules:
+          1. If we are in control statement or objective, no subsections are allowed.
+        """
+        content = ControlSectionContent()
+        node_children = []
+        i = starting_line
+
+        is_control_statement = root_key.lower() == '## control statement'
+        is_control_objective = root_key.lower() == '## control objective'
+        is_control_guidance = root_key.lower() == '## control guidance'
+        _ = f'# {const.EDITABLE_CONTENT}'.lower() in root_key.lower()  # TODO, currently handled by control_reader
+        is_generic_control_part = '## control' in root_key.lower(
+        ) and not (is_control_guidance or is_control_objective or is_control_statement)
+
+        if is_control_guidance or is_generic_control_part:
+            prefix = const.CONTROL_HEADER + ' '
+            control_md_heading_label = root_key[len(prefix):].strip()
+            control_md_heading_label_ncname = ControlInterface.strip_to_make_ncname(control_md_heading_label)
+
+        current_key_lvl = self._get_header_level_if_valid(root_key)
+        if current_key_lvl and current_key_lvl == 1:
+            # Parse control title
+            if tree_context.control_id:
+                logger.debug(
+                    f'Duplicate control_id is found for the markdown {root_key}, '
+                    f'make sure you have reset tree context before reading another markdown.'
+                    f'Use markdown processor to avoid this error.'
+                )
+                raise TrestleError(
+                    f'Multiple top-level headers are found but only one header is allowed. See line {root_key} '
+                    f'for control {tree_context.control_id}.'
+                )
+            tree_context.control_id, tree_context.control_group, tree_context.control_title = ControlMarkdownNode._parse_control_title_line(root_key)  # noqa: E501
+            content.control_id = tree_context.control_id
+            content.control_group = tree_context.control_group
+            content.control_title = tree_context.control_title
+
+        while True:
+            if i >= len(lines):
+                break
+            line = lines[i].strip(' ')
+            header_lvl = self._get_header_level_if_valid(line)
+
+            if header_lvl is not None:
+                if header_lvl >= level + 1:
+                    if is_control_statement or is_control_objective:
+                        raise TrestleError(
+                            f'Control Statement or Objective sections cannot contain subsections but found: {line}.'
+                            f'Please delete this subsection and refer to docs on the required format.'
+                        )
+                    # build subtree
+                    subtree, i = self._build_tree(lines, line, i + 1, level + 1, governed_header)
+                    node_children.append(subtree)
+                    content.union(subtree)
+                    # Control parts can have general markdown in the prose, if we are in the control part
+                    # add its contents under the prose of a parent
+                    if is_control_statement:
+                        content.statement_part.prose += subtree.content.raw_text
+                    if is_control_objective:
+                        content.objective_part.prose += subtree.content.raw_text
+                    if is_control_guidance:
+                        content.guidance_part.prose += subtree.content.raw_text
+                    if is_generic_control_part:
+                        content.other_parts[-1].prose += subtree.content.raw_text
+                    continue
+                else:
+                    i -= 1  # need to revert back one line to properly handle next heading
+                    break  # level of the header is above or equal to the current level, subtree is over
+            if is_control_statement:
+                # Read control statement to a part object
+                if not content.statement_part:
+                    if not tree_context.control_id:
+                        raise TrestleError(
+                            'Unexpected error, control id, group and title should be before ## Control statement.'
+                            'However, none was found.'
+                        )
+                    statement_id = ControlInterface.create_statement_id(tree_context.control_id)
+                    content.statement_part = common.Part(name=const.STATEMENT, id=statement_id, prose='')
+
+                i = self._process_part_line(i, line, lines, content.statement_part)
+
+            elif is_control_objective:
+                # Read control objective to a part object
+                if not content.objective_part:
+                    if not tree_context.control_id:
+                        raise TrestleError(
+                            'Unexpected error, control id, group and title should be before ## Control objective.'
+                            'However, none was found.'
+                        )
+                    content.objective_part = common.Part(
+                        name='objective', id=f'{tree_context.control_id}_obj', prose=''
+                    )
+
+                i = self._process_part_line(i, line, lines, content.objective_part)
+
+            elif is_control_guidance:
+                # Read control guidance to a part object
+                if not content.guidance_part:
+                    if not tree_context.control_id:
+                        raise TrestleError(
+                            'Unexpected error, control id, group and title should be before ## Control guidance.'
+                            'However, none was found.'
+                        )
+
+                    guidance_id = ControlInterface.strip_to_make_ncname(tree_context.control_id + '_gdn')
+                    content.guidance_part = common.Part(id=guidance_id, name=control_md_heading_label_ncname, prose='')
+
+                i = self._process_part_line(i, line, lines, content.guidance_part, read_parts=False)
+
+            elif is_generic_control_part:
+                # Read other control parts to a part objects
+                if not content.other_parts:
+                    if not tree_context.control_id:
+                        raise TrestleError(
+                            'Unexpected error, control id, group and title should be before ## Control parts.'
+                            'However, none was found.'
+                        )
+
+                    part_id = ControlInterface.strip_to_make_ncname(
+                        tree_context.control_id + '_' + control_md_heading_label
+                    )
+                    a_part = common.Part(id=part_id, name=control_md_heading_label_ncname, prose='')
+                    content.other_parts.append(a_part)
+
+                i = self._process_part_line(i, line, lines, content.other_parts[-1], read_parts=False)
+            else:
+                i += 1
+
+        first_line_to_grab = starting_line - 1 if starting_line else 0
+        content.raw_text = '\n'.join(lines[first_line_to_grab:i])
+
+        def _strip_prose_or_none(part: Optional[common.Part]):
+            if part and part.prose:
+                part.prose = part.prose.strip() if part.prose.strip() else None
+
+        _strip_prose_or_none(content.statement_part)
+        _strip_prose_or_none(content.objective_part)
+        _strip_prose_or_none(content.guidance_part)
+        for some_part in content.other_parts:
+            _strip_prose_or_none(some_part)
+
+        md_node = ControlMarkdownNode(key=root_key, content=content, starting_line=first_line_to_grab)
+        md_node.subnodes = node_children
+        return md_node, i
+
+    def get_control_statement(self) -> Optional[ControlMarkdownNode]:
+        """Get control statement node."""
+        return self.get_node_for_key('## Control Statement')
+
+    def get_control_objective(self) -> Optional[ControlMarkdownNode]:
+        """Get control objective node."""
+        return self.get_node_for_key(const.CONTROL_OBJECTIVE_HEADER)
+
+    def get_control_guidance(self) -> Optional[ControlMarkdownNode]:
+        """Get control guidance node."""
+        return self.get_node_for_key('## Control Guidance')
+
+    def get_other_control_parts(self) -> List[Optional[ControlMarkdownNode]]:
+        """Get all other control parts that are not statement, guidance or objective."""
+        all_other_nodes = []
+        all_control_sections = self.get_all_headers_for_key(const.CONTROL_HEADER, False)
+        control_statement = self.get_control_statement()
+        control_objective = self.get_control_objective()
+        control_guidance = self.get_control_guidance()
+        control_statement_heading = control_statement.key if control_statement else ''
+        control_objective_heading = control_objective.key if control_objective else ''
+        control_guidance_heading = control_guidance.key if control_guidance else ''
+        for heading_key in all_control_sections:
+            if heading_key not in {control_statement_heading, control_objective_heading, control_guidance_heading}:
+                section_node = self.get_node_for_key(heading_key)
+                all_other_nodes.append(section_node)
+
+        return all_other_nodes
+
+    def _process_part_line(
+        self, line_idx: int, line: str, lines: List[str], part: common.Part, read_parts: bool = True
+    ) -> int:
+        """Process line for the part."""
+        if not line:
+            # Empty line
+            part.prose += '\n'
+            line_idx += 1
+            return line_idx
+
+        if line.lstrip()[0] != '-':
+            # Line of text in prose
+            part.prose += line + '\n'
+            line_idx += 1
+        else:
+            # A part of inside of statement part
+            if read_parts:
+                end_idx, parts = self._read_parts(0, line_idx, lines, part.id, [])
+                part.parts = none_if_empty(parts)
+                line_idx = end_idx
+            else:
+                logger.warning(
+                    f'{part.name} does not support subparts, ignoring {line} in control {tree_context.control_id}.'
+                )
+                line_idx += 1
+
+        return line_idx
+
+    def _read_parts(self, indent: int, ii: int, lines: List[str], parent_id: str,
+                    parts: List[common.Part]) -> Tuple[int, List[common.Part]]:
+        """If indentation level goes up or down, create new list or close current one."""
+        while True:
+            ii, new_indent, line = ControlMarkdownNode._get_next_indent(ii, lines)
+            if new_indent < 0:
+                # we are done reading control statement
+                return ii, parts
+            if new_indent == indent:
+                # create new item part and add to current list of parts
+                id_text, prose = ControlMarkdownNode._read_part_id_prose(line)
+                # id_text is the part id and needs to be as a label property value
+                # if none is there then create one from previous part, or use default
+                if not id_text:
+                    prev_label = ControlInterface.get_label(parts[-1]) if parts else ''
+                    id_text = ControlMarkdownNode._create_next_label(prev_label, indent)
+                id_ = ControlInterface.strip_to_make_ncname(parent_id.rstrip('.') + '.' + id_text.strip('.'))
+                name = 'objective' if id_.find('_obj') > 0 else 'item'
+                prop = common.Property(name='label', value=id_text)
+                part = common.Part(name=name, id=id_, prose=prose, props=[prop])
+                parts.append(part)
+                ii += 1
+            elif new_indent > indent:
+                # add new list of parts to last part and continue
+                if len(parts) == 0:
+                    raise TrestleError(f'Improper indentation structure: {line}')
+                ii, new_parts = self._read_parts(new_indent, ii, lines, parts[-1].id, [])
+                if new_parts:
+                    parts[-1].parts = new_parts
+            else:
+                # return list of sub-parts
+                return ii, parts
+
+    @staticmethod
+    def _indent(line: str) -> int:
+        """Measure indent of non-empty line."""
+        if not line:
+            raise TrestleError('Empty line queried for indent.')
+        if line[0] not in [' ', '-']:
+            return -1
+        for ii in range(len(line)):
+            if line[ii] == '-':
+                return ii
+            # if line is indented it must start with -
+            if line[ii] != ' ':
+                break
+        raise TrestleError(f'List elements must start with -: {line}')
+
+    @staticmethod
+    def _parse_control_title_line(line: str) -> Tuple[str, str, str]:
+        """Process the title line and extract the control id, group title (in brackets) and control title."""
+        if line.count('-') == 0:
+            raise TrestleError(f'Markdown control title format error, missing - after control id: {line}')
+        split_line = line.split()
+        if len(split_line) < 3 or split_line[2] != '-':
+            raise TrestleError(f'Cannot parse control markdown title for control_id group and title: {line}')
+        # first token after the #
+        control_id = split_line[1]
+        group_title_start = line.find('\[')
+        group_title_end = line.find('\]')
+        if group_title_start < 0 or group_title_end < 0 or group_title_start > group_title_end:
+            raise TrestleError(f'unable to read group title for control {control_id}')
+        group_title = line[group_title_start + 2:group_title_end].strip()
+        control_title = line[group_title_end + 2:].strip()
+        return control_id, group_title, control_title
+
+    @staticmethod
+    def _read_part_id_prose(line: str) -> Tuple[str, str]:
+        """Extract the part id letter or number and prose from line."""
+        start = line.find('\\[')
+        end = line.find('\\]')
+        prose = line.strip() if start < 0 else line[end + 2:].strip()
+        id_ = '' if start < 0 or end < 0 else line[start + 2:end]
+        return id_, prose
+
+    @staticmethod
+    def _create_next_label(prev_label: str, indent: int) -> str:
+        """
+        Create new label at indent level based on previous label if available.
+
+        If previous label is available, make this the next one in the sequence.
+        Otherwise start with a or 1 on alternate levels of indentation.
+        If alphabetic label reaches z, next one is aa.
+        Numeric ranges from 1 to 9, then 10 etc.
+        """
+        if not prev_label:
+            # assume indent goes in steps of 2
+            return ['a', '1'][(indent // 2) % 2]
+        label_prefix = ''
+        label_suffix = prev_label
+        is_char = prev_label[-1] in string.ascii_letters
+        # if it isn't ending in letter or digit just append 'a' to end
+        if not is_char and prev_label[-1] not in string.digits:
+            return prev_label + 'a'
+        # break in middle of string if mixed types
+        if len(prev_label) > 1:
+            ii = len(prev_label) - 1
+            while ii >= 0:
+                if prev_label[ii] not in string.ascii_letters + string.digits:
+                    break
+                if (prev_label[ii] in string.ascii_letters) != is_char:
+                    break
+                ii -= 1
+            if ii >= 0:
+                label_prefix = prev_label[:(ii + 1)]
+                label_suffix = prev_label[(ii + 1):]
+
+        return label_prefix + ControlMarkdownNode._bump_label(label_suffix)
+
+    @staticmethod
+    def _bump_label(label: str) -> str:
+        """
+        Find next label given a string of 1 or more pure letters or digits.
+
+        The input must be either a string of digits or a string of ascii letters - or empty string.
+        """
+        if not label:
+            return 'a'
+        if label[0] in string.digits:
+            return str(int(label) + 1)
+        if len(label) == 1 and label[0].lower() < 'z':
+            return chr(ord(label[0]) + 1)
+        # if this happens to be a string of letters, force it lowercase and bump
+        label = label.lower()
+        factor = 1
+        value = 0
+        # delta is needed because a counts as 0 when first value on right, but 1 for all others
+        delta = 0
+        for letter in label[::-1]:
+            value += (ord(letter) - ord('a') + delta) * factor
+            factor *= 26
+            delta = 1
+
+        value += 1
+
+        new_label = ''
+        delta = 0
+        while value > 0:
+            new_label += chr(ord('a') + value % 26 - delta)
+            value = value // 26
+            delta = 1
+        return new_label[::-1]
+
+    @staticmethod
+    def _get_next_indent(ii: int, lines: List[str], skip_empty_lines: bool = True) -> Tuple[int, int, str]:
+        """Seek to next content line.  ii remains at line read."""
+        while 0 <= ii < len(lines):
+            line = lines[ii]
+            if line and not line.isspace():
+                if line[0] == '#':
+                    return ii, -1, line
+                indent = ControlMarkdownNode._indent(line)
+                if indent >= 0:
+                    # extract text after -
+                    start = indent + 1
+                    while start < len(line) and line[start] == ' ':
+                        start += 1
+                    if start >= len(line):
+                        raise TrestleError(f'Invalid line {line}')
+                    return ii, indent, line[start:]
+                return ii, indent, line
+            elif not skip_empty_lines:
+                return ii, -1, line
+            ii += 1
+        return ii, -1, ''

--- a/trestle/core/markdown/docs_markdown_node.py
+++ b/trestle/core/markdown/docs_markdown_node.py
@@ -1,0 +1,128 @@
+# -*- mode:python; coding:utf-8 -*-
+
+# Copyright (c) 2023 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A docs markdown node."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Optional, Tuple
+
+import trestle.core.markdown.markdown_const as md_const
+from trestle.core.markdown.base_markdown_node import BaseMarkdownNode, BaseSectionContent
+
+logger = logging.getLogger(__name__)
+
+
+class DocsSectionContent(BaseSectionContent):
+    """A content of the node."""
+
+    def __init__(self):
+        """Initialize section content."""
+        super(DocsSectionContent, self).__init__()
+        self.tables = []
+        self.text = []
+        self.code_lines = []
+        self.html_lines = []
+        self.blockquotes = []
+        self.governed_document = []
+
+    def union(self, node: DocsMarkdownNode) -> None:
+        """Unites contents together."""
+        super().union(node)
+        self.code_lines.extend(node.content.code_lines)
+        self.html_lines.extend(node.content.html_lines)
+        self.tables.extend(node.content.tables)
+        self.blockquotes.extend(node.content.blockquotes)
+
+
+class DocsMarkdownNode(BaseMarkdownNode):
+    """Markdown will be read to the tree."""
+
+    def __init__(self, key: str, content: DocsSectionContent, starting_line: int):
+        """Initialize markdown node."""
+        super(DocsMarkdownNode, self).__init__(key, content, starting_line)
+        self.content: DocsSectionContent = content
+
+    def _build_tree(
+        self,
+        lines: List[str],
+        root_key: str,
+        starting_line: int,
+        level: int,
+        governed_header: Optional[str] = None
+    ) -> Tuple[DocsMarkdownNode, int]:
+        """
+        Build a tree from the markdown recursively.
+
+        The tree is contructed with valid headers as node's keys
+        and node's content contains everything that is under that header.
+        The subsections are placed into node's children with the same structure.
+
+        A header is valid iff the line starts with # and it is not:
+          1. Inside of the html blocks
+          2. Inside single lined in the <> tags
+          3. Inside the html comment
+          4. Inside any table, code block or blockquotes
+        """
+        content = DocsSectionContent()
+        node_children = []
+        i = starting_line
+
+        while True:
+            if i >= len(lines):
+                break
+            line = lines[i].strip(' ')
+            header_lvl = self._get_header_level_if_valid(line)
+
+            if header_lvl is not None:
+                if header_lvl >= level + 1:
+                    # build subtree
+                    subtree, i = self._build_tree(lines, line, i + 1, level + 1, governed_header)
+                    node_children.append(subtree)
+                    content.union(subtree)
+                else:
+                    break  # level of the header is above or equal to the current level, subtree is over
+            elif self._does_start_with(line, md_const.CODEBLOCK_DEF):
+                code_lines, i = self._read_code_lines(lines, line, i + 1)
+                content.code_lines.extend(code_lines)
+            elif self._does_start_with(line, md_const.HTML_COMMENT_START):
+                html_lines, i = self._read_html_block(lines, line, i + 1, md_const.HTML_COMMENT_END_REGEX)
+                content.html_lines.extend(html_lines)
+            elif self._does_contain(line, md_const.HTML_TAG_REGEX_START):
+                html_lines, i = self._read_html_block(lines, line, i + 1, md_const.HTML_TAG_REGEX_END)
+                content.html_lines.extend(html_lines)
+            elif self._does_start_with(line, md_const.TABLE_SYMBOL):
+                table_block, i = self._read_table_block(lines, line, i + 1)
+                content.tables.extend(table_block)
+            elif self._does_start_with(line, md_const.BLOCKQUOTE_CHAR):
+                content.blockquotes.append(line)
+                i += 1
+            elif governed_header is not None and self._does_contain(
+                    root_key, fr'^[#]+ {governed_header}$') and self._does_contain(line, md_const.GOVERNED_DOC_REGEX):
+                regexp = re.compile(md_const.GOVERNED_DOC_REGEX)
+                match = regexp.search(line)
+                header = match.group(0).strip('*').strip(':')
+                content.governed_document.append(header)
+                i += 1
+            else:
+                content.text.append(line)
+                i += 1
+
+        first_line_to_grab = starting_line - 1 if starting_line else 0
+        content.raw_text = '\n'.join(lines[first_line_to_grab:i])
+        md_node = DocsMarkdownNode(key=root_key, content=content, starting_line=first_line_to_grab)
+        md_node.subnodes = node_children
+        return md_node, i

--- a/trestle/core/markdown/markdown_validator.py
+++ b/trestle/core/markdown/markdown_validator.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 import trestle.core.markdown.markdown_const as md_const
 from trestle.common.err import TrestleError
 from trestle.core.commands.author.consts import START_TEMPLATE_VERSION, TEMPLATE_VERSION_HEADER
-from trestle.core.markdown.markdown_node import MarkdownNode
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class MarkdownValidator:
         self,
         tmp_path: pathlib.Path,
         template_header: Dict,
-        template_tree: MarkdownNode,
+        template_tree: DocsMarkdownNode,
         validate_yaml_header: bool,
         validate_md_body: bool,
         governed_section: Optional[str] = None
@@ -64,7 +64,7 @@ class MarkdownValidator:
                         self._ignore_headers.append(key2.lower())
 
     def is_valid_against_template(
-        self, instance: pathlib.Path, instance_header: Dict, instance_tree: MarkdownNode
+        self, instance: pathlib.Path, instance_header: Dict, instance_tree: DocsMarkdownNode
     ) -> bool:
         """
         Validate instance markdown against template.

--- a/trestle/core/remote/cache.py
+++ b/trestle/core/remote/cache.py
@@ -282,7 +282,7 @@ class HTTPSFetcher(FetcherBase):
             auth = HTTPBasicAuth(self._username, self._password)
 
         try:
-            response = requests.get(self._url, auth=auth, verify=verify)
+            response = requests.get(self._url, auth=auth, verify=verify, timeout=10)
         except Exception as e:
             raise TrestleError(f'Cache update failure to connect via HTTPS: {self._url} ({e})')
 

--- a/trestle/core/ssp_io.py
+++ b/trestle/core/ssp_io.py
@@ -22,7 +22,7 @@ from trestle.common.list_utils import as_list
 from trestle.core.catalog import catalog_interface
 from trestle.core.catalog.catalog_interface import CatalogInterface
 from trestle.core.docs_control_writer import DocsControlWriter
-from trestle.core.markdown.markdown_node import MarkdownNode
+from trestle.core.markdown.docs_markdown_node import DocsMarkdownNode
 from trestle.core.markdown.md_writer import MDWriter
 from trestle.oscal import ssp
 from trestle.oscal.catalog import Catalog
@@ -165,7 +165,7 @@ class SSPMarkdownWriter():
         for line in params_lines:
             clean_lines.append(line.replace('{{', '[[').replace('}}', ']]'))
 
-        tree = MarkdownNode.build_tree_from_markdown(clean_lines)
+        tree = DocsMarkdownNode.build_tree_from_markdown(clean_lines)
         tree.change_header_level_by(level)
         return tree.content.raw_text
 
@@ -265,7 +265,7 @@ class SSPMarkdownWriter():
 
         lines = md_writer.get_lines()
 
-        tree = MarkdownNode.build_tree_from_markdown(lines)
+        tree = DocsMarkdownNode.build_tree_from_markdown(lines)
         tree.change_header_level_by(level)
 
         return tree.content.raw_text
@@ -342,7 +342,7 @@ class SSPMarkdownWriter():
         return ''
 
     def _build_tree_and_adjust(self, lines: List[str], level: int) -> str:
-        tree = MarkdownNode.build_tree_from_markdown(lines)
+        tree = DocsMarkdownNode.build_tree_from_markdown(lines)
         tree.change_header_level_by(level)
 
         return tree.content.raw_text


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
A first part of refactoring control_reader.py. 
Currently this change **only affects catalog** functionality.


Features:
1. Added a new type of markdown node: `ControlMarkdownNode` to separate the functionality needed for governed documents and Trestle core.
2. Rewrote the reading of control parts: statement, guidance, objective and extra.
3. Added an interface to fetch control parts from the tree (see changes to `control_reader.read_control` for example)
4. Deleted no longer needed code from control_reader, and moved the legacy code to `ControlMarkdownNode`

Things left to do for part 2
1. Reading of Editable content is still read by control_reader
2. Legacy code for reading subparts of a part needs further refactoring 
3. Further control_reader refactoring to put all code into `ControlMarkdownNode`

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
