### PR TITLE
docs: fix refs to version numbers and warn if no comp defs during ssp assemble

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ Trestle runs on most all python platforms (e.g. Linux, Mac, Windows) and is avai
 
 ## Development status
 
-Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.2, with active development continuing.
+Compliance trestle is currently stable and is based on NIST OSCAL version 1.0.4, with active development continuing.
 
 ## Contributing to Trestle
 

--- a/docs/python_trestle_setup.md
+++ b/docs/python_trestle_setup.md
@@ -50,7 +50,7 @@ Details can be found at [Installation - pip documentation](https://pip.pypa.io/e
 - Install [compliance-trestle](https://ibm.github.io/compliance-trestle/).
 
 ```bash
-(venv.trestle)$ pip install compliance-trestle
+(venv.trestle)$ python -m pip install compliance-trestle
 Looking in indexes: https://pypi.org/simple,...
 
 ```

--- a/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
+++ b/docs/tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
@@ -1,4 +1,4 @@
-# Tutorial: Catalog, Component, Profile and SSP Authoring
+# Tutorial: Catalog, Profile, ComponentDefinition, and SSP Authoring
 
 ## Introduction and background
 
@@ -524,7 +524,7 @@ Similar options apply to the `jinja` authoring commands.
 
 <details markdown>
 
-<summary>trestle author component-generate</summary>
+<summary>trestle author component-generate and component-assemble</summary>
 
 The `trestle author component-generate` command takes a JSON ComponentDefinition file and creates markdown for its controls in separate directories for each of the DefinedComponents in the file.  This allows specifying the implementation response and status for each component separately in separate markdown files for a control.  In addition, the markdown captures Rules in the control that specify descriptions and parameter values that apply to the expected responses.
 

--- a/docs/tutorials/trestle_sample_workflow.md
+++ b/docs/tutorials/trestle_sample_workflow.md
@@ -65,7 +65,7 @@ As a reminder, you could also have imported the file from a local directory on y
 
 The `import` command will also check the
 validity of the file including the presence of any duplicate uuid's.  If the file is manually created
-please be sure it conforms with the current OSCAL schema (OSCAL version 1.0.2) and has no defined uuid's that are duplicates.
+please be sure it conforms with the current OSCAL schema (OSCAL version 1.0.4) and has no defined uuid's that are duplicates.
 If there are any errors the Import will fail and the file must be corrected.
 
 <br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
   - Compliance posture: tutorials/continuous-compliance/continuous-compliance.md
   - Trestle Authoring:
     - Governance of Authored Documents: trestle_author.md
-    - SSP, Catalog, and Profile Authoring: tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
+    - Catalog, Profile, ComponentDefinition, and SSP Authoring: tutorials/ssp_profile_catalog_authoring/ssp_profile_catalog_authoring.md
   - Trestle Transformers and Tasks:
     - Transformer construction: tutorials/task.transformer-construction/transformer-construction.md
     - Task - task.csv-to-oscal-cd: tutorials/task.csv-to-oscal-cd/transformation.md

--- a/tests/trestle/core/generator_test.py
+++ b/tests/trestle/core/generator_test.py
@@ -20,7 +20,7 @@ import pkgutil
 import sys
 import uuid
 from datetime import date, datetime
-from typing import Any, Dict, List
+from typing import Any, List
 
 import pydantic.networks
 from pydantic import ConstrainedStr
@@ -52,9 +52,9 @@ def test_get_sample_value_by_type() -> None:
     assert type(gens.generate_sample_value_by_type(datetime, '')) == datetime
     assert gens.generate_sample_value_by_type(bool, '') is False
     assert gens.generate_sample_value_by_type(int, '') == 0
-    assert gens.generate_sample_value_by_type(str, '') == 'REPLACE_ME'
+    assert gens.generate_sample_value_by_type(str, '') == const.REPLACE_ME
     assert gens.generate_sample_value_by_type(float, '') == 0.0
-    assert gens.generate_sample_value_by_type(ConstrainedStr, '') == 'REPLACE_ME'
+    assert gens.generate_sample_value_by_type(ConstrainedStr, '') == const.REPLACE_ME
     assert gens.generate_sample_value_by_type(ConstrainedStr, 'oarty-uuid') == const.SAMPLE_UUID_STR
     uuid_ = gens.generate_sample_value_by_type(ConstrainedStr, 'uuid')
     assert is_valid_uuid(uuid_) and str(uuid_) != const.SAMPLE_UUID_STR
@@ -84,9 +84,9 @@ def test_generate_sample_model() -> None:
     expected_ctlg_dict = {
         'uuid': 'ea784488-49a1-4ee5-9830-38058c7c10a4',
         'metadata': {
-            'title': 'REPLACE_ME',
+            'title': const.REPLACE_ME,
             'last-modified': '2020-10-21T06:52:10.387+00:00',
-            'version': 'REPLACE_ME',
+            'version': const.REPLACE_ME,
             'oscal-version': oscal.OSCAL_VERSION
         }
     }
@@ -105,21 +105,11 @@ def test_generate_sample_model() -> None:
     assert expected_ctlg == actual_ctlg
 
     # Test list type models
-    expected_role = common.Role(**{'id': 'REPLACE_ME', 'title': 'REPLACE_ME'})
+    expected_role = common.Role(**{'id': const.REPLACE_ME, 'title': const.REPLACE_ME})
     list_role = gens.generate_sample_model(List[common.Role])
     assert type(list_role) is list
     actual_role = list_role[0]
     assert expected_role == actual_role
-
-    # Test dict type models
-    if False:
-        party_uuid = common.PartyUuid(__root__=const.SAMPLE_UUID_STR)
-        expected_rp = {'role_id': 'REPLACE_ME', 'party-uuids': [party_uuid]}
-        expected_rp = common.ResponsibleParty(**expected_rp)
-        expected_rp_dict = {'REPLACE_ME': expected_rp}
-        actual_rp_dict = gens.generate_sample_model(Dict[str, common.ResponsibleParty])
-        assert type(actual_rp_dict) is dict
-        assert expected_rp_dict == actual_rp_dict
 
 
 def test_get_all_sample_models() -> None:

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -498,6 +498,12 @@ class SSPAssemble(AuthorCommonCommand):
 
                 new_file_content_type = FileContentType.path_to_content_type(orig_ssp_path)
             else:
+                if not args.compdefs:
+                    logger.warning(
+                        'No comp_defs have been specified and a destination SSP does not exist.  If you want the full '
+                        'set of components in the SSP you should specify the needed comp_def names.  The SSP '
+                        'will now attempt to be assembled without them but may fail.'
+                    )
                 # create a sample ssp to hold all the parts
                 ssp = gens.generate_sample_model(ossp.SystemSecurityPlan)
                 ssp.control_implementation.implemented_requirements = []

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -513,7 +513,7 @@ class SSPAssemble(AuthorCommonCommand):
                 CatalogReader.read_ssp_md_content(md_path, ssp, comp_dict, part_id_map_by_label, context)
 
                 import_profile: ossp.ImportProfile = gens.generate_sample_model(ossp.ImportProfile)
-                import_profile.href = 'REPLACE_ME'
+                import_profile.href = const.REPLACE_ME
                 ssp.import_profile = import_profile
 
             # now that we know the complete list of needed components, add them to the sys_imp

--- a/trestle/core/generators.py
+++ b/trestle/core/generators.py
@@ -77,7 +77,7 @@ def generate_sample_value_by_type(
         # Only case where are UUID is required but not in name.
         if field_name.rstrip('s') == 'member_of_organization':
             return const.SAMPLE_UUID_STR
-        return 'REPLACE_ME'
+        return const.REPLACE_ME
     if hasattr(type_, '__name__') and 'ConstrainedIntValue' in type_.__name__:
         # create an int value as close to the floor as possible does not test upper bound
         multiple = type_.multiple_of if type_.multiple_of else 1  # default to every integer
@@ -93,7 +93,7 @@ def generate_sample_value_by_type(
     if type_ is str:
         if field_name == 'oscal_version':
             return OSCAL_VERSION
-        return 'REPLACE_ME'
+        return const.REPLACE_ME
     if type_ is pydantic.networks.EmailStr:
         return pydantic.networks.EmailStr('dummy@sample.com')
     if type_ is pydantic.networks.AnyUrl:
@@ -174,10 +174,10 @@ def generate_sample_model(
         if model_type is list:
             return [generate_sample_value_by_type(model, '')]
         if model_type is dict:
-            return {'REPLACE_ME': generate_sample_value_by_type(model, '')}
+            return {const.REPLACE_ME: generate_sample_value_by_type(model, '')}
         raise err.TrestleError('Unhandled collection type.')
     if model_type is list:
         return [model(**model_dict)]
     if model_type is dict:
-        return {'REPLACE_ME': model(**model_dict)}
+        return {const.REPLACE_ME: model(**model_dict)}
     return model(**model_dict)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Cleaned up docs in support of OSCAL 1.0.4
Add warning when ssp assemble with no compdefs and no existing ssp

closes #1320 
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
