### PR TITLE
fix: duplicate param_id should be invalid only in profile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,14 @@ def sample_profile():
 
 
 @pytest.fixture(scope='function')
+def sample_trestle_profile():
+    """Return a hand curated profile for testing."""
+    file_path = pathlib.Path(test_utils.JSON_TEST_DATA_PATH) / 'simple_test_profile.json'
+    profile_obj = Profile.oscal_read(file_path)
+    return profile_obj
+
+
+@pytest.fixture(scope='function')
 def simplified_nist_catalog():
     """Return a simplified nist catalog."""
     file_path = pathlib.Path(test_utils.JSON_TEST_DATA_PATH) / test_utils.SIMPLIFIED_NIST_CATALOG_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,8 +194,8 @@ def sample_catalog_subgroups():
 def sample_component_definition():
     """Return a valid ComponentDefinition object with some contents."""
     # one component has no properties - the other has two
-    def_comp1: DefinedComponent = gens.generate_sample_model(DefinedComponent)
-    def_comp2: DefinedComponent = gens.generate_sample_model(DefinedComponent)
+    def_comp1: DefinedComponent = gens.generate_sample_model(DefinedComponent, True, 3)
+    def_comp2: DefinedComponent = gens.generate_sample_model(DefinedComponent, True, 3)
     prop_1 = common.Property(name='prop_1', value='prop_1_value')
     prop_2 = common.Property(name='prop_2', value='prop_2_value')
     def_comp2.props = [prop_1, prop_2]

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -230,7 +230,11 @@ def test_validate_dup_uuids(
     args = argparse.Namespace(mode=const.VAL_MODE_ALL, quiet=True)
     validator = validator_factory.get(args)
 
-    # confirm the comp_def is valid
+    # confirm the comp_def has duplicate param_ids (REPLACE_ME)
+    ci = sample_component_definition.components[0].control_implementations[0]
+    assert ci.set_parameters[0].param_id == ci.implemented_requirements[0].set_parameters[0].param_id
+
+    # confirm the comp_def is valid despite duplicate param_ids (this is allowed for compdef and ssp)
     assert validator.model_is_valid(sample_component_definition, False)
 
     # force two components to have same uuid and confirm invalid

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -28,6 +28,7 @@ from tests import test_utils
 
 import trestle.common.const as const
 import trestle.oscal.assessment_plan as ap
+import trestle.oscal.profile as prof
 from trestle import cli
 from trestle.cli import Trestle
 from trestle.core.commands.common.return_codes import CmdReturnCodes
@@ -222,7 +223,9 @@ def test_validate_direct(sample_catalog_minimal: Catalog) -> None:
     assert validator.model_is_valid(sample_catalog_minimal, True)
 
 
-def test_validate_dup_uuids(sample_component_definition: ComponentDefinition) -> None:
+def test_validate_dup_uuids(
+    sample_component_definition: ComponentDefinition, sample_trestle_profile: prof.Profile
+) -> None:
     """Test validation of comp def with duplicate uuids."""
     args = argparse.Namespace(mode=const.VAL_MODE_ALL, quiet=True)
     validator = validator_factory.get(args)
@@ -247,6 +250,14 @@ def test_validate_dup_uuids(sample_component_definition: ComponentDefinition) ->
     sample_component_definition.components[1].control_implementations[0].uuid = sample_component_definition.components[
         0].uuid
     assert not validator.model_is_valid(sample_component_definition, True)
+
+    assert validator.model_is_valid(sample_trestle_profile, True)
+
+    # add extra set_param with duplicate param_id and confirm it is not valid
+    set_param = sample_trestle_profile.modify.set_parameters[0].copy()
+    set_param.values = ['foo']
+    sample_trestle_profile.modify.set_parameters.append(set_param)
+    assert not validator.model_is_valid(sample_trestle_profile, True)
 
 
 def test_validate_distributed(

--- a/tests/trestle/core/commands/validate_test.py
+++ b/tests/trestle/core/commands/validate_test.py
@@ -254,6 +254,7 @@ def test_validate_dup_uuids(
     assert validator.model_is_valid(sample_trestle_profile, True)
 
     # add extra set_param with duplicate param_id and confirm it is not valid
+    # only profile has this additional test
     set_param = sample_trestle_profile.modify.set_parameters[0].copy()
     set_param.values = ['foo']
     sample_trestle_profile.modify.set_parameters.append(set_param)

--- a/trestle/core/duplicates_validator.py
+++ b/trestle/core/duplicates_validator.py
@@ -18,6 +18,7 @@
 from trestle.common.model_utils import ModelUtils
 from trestle.core.base_model import OscalBaseModel
 from trestle.core.validator import Validator
+from trestle.oscal.profile import Profile
 
 
 class DuplicatesValidator(Validator):
@@ -36,4 +37,8 @@ class DuplicatesValidator(Validator):
         """
         if not ModelUtils.has_no_duplicate_values_by_name(model, 'uuid'):
             return False
-        return ModelUtils.has_no_duplicate_values_by_name(model, 'param_id')
+        # only profile, comp-def and ssp have set-params and only set-params have param_id
+        # param_id is required to be unique in profiles but not in other models
+        if isinstance(model, Profile):
+            return ModelUtils.has_no_duplicate_values_by_name(model, 'param_id')
+        return True


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
duplicate validator was failing for ssp and compdef if duplicate param_ids were found.  

closes #1339 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
