### PR TITLE
fix: quiet warning about system component status as operational

### DIFF
--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -205,7 +205,8 @@ class SSPAssemble(AuthorCommonCommand):
         for component in as_list(ssp.system_implementation.components):
             if component.title == gen_comp.title:
                 return component
-        # if this is a new system component assign its status as operational because markdown doesnt have its status
+        # if this is a new system component assign its status as operational by default
+        # the status of the system components are not stored in the markdown
         gen_comp.status.state = const.STATUS_OPERATIONAL
         new_component = gen_comp.as_system_component()
         return new_component

--- a/trestle/core/commands/author/ssp.py
+++ b/trestle/core/commands/author/ssp.py
@@ -205,6 +205,8 @@ class SSPAssemble(AuthorCommonCommand):
         for component in as_list(ssp.system_implementation.components):
             if component.title == gen_comp.title:
                 return component
+        # if this is a new system component assign its status as operational because markdown doesnt have its status
+        gen_comp.status.state = const.STATUS_OPERATIONAL
         new_component = gen_comp.as_system_component()
         return new_component
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary
Quieted confusing message about system component statuses set to operational during ssp assemble.  They are now quietly set to operational as default.  The markdown captures status of implementations but not the status of the components themselves.
## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
