### PR TITLE
fix: docs for task xlsx-result-to-oscal-ar replacing "osco"

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -561,15 +561,15 @@ references to links, and corresponding links in the backmatter.
 
 Open Shift Compliance Operator and Tanium are supported as 3rd party tools.
 
-## `trestle task osco-result-to-oscal-ar`
+## `trestle task xccdf-result-to-oscal-ar`
 
-The *trestle task osco-result-to-oscal-ar* command facilitates transformation of OpenShift Compliance Operator (OSCO) scan results *.yaml* files into OSCAL partial results *.json* files. Specify required config parameters to indicate the location of the input and the output. Specify optional config parameters to indicate the name of the oscal-metadata.yaml file, if any, and whether overwriting of existing output is permitted.
+The *trestle task xccdf-result-to-oscal-ar* command facilitates transformation of XCCDF results, e.g. OpenShift Compliance Operator (OSCO) scan results, *.yaml* files into OSCAL partial results *.json* files. Specify required config parameters to indicate the location of the input and the output. Specify optional config parameters to indicate the name of the oscal-metadata.yaml file, if any, and whether overwriting of existing output is permitted.
 
 <span style="color:green">
 Example command invocation:
 </span>
 
-`$TRESTLE_BASEDIR$ trestle task osco-result-to-oscal-ar -c /home/user/task.config`
+`$TRESTLE_BASEDIR$ trestle task xccdf-result-to-oscal-ar -c /home/user/task.config`
 
 <span style="color:green">
 Example config:
@@ -578,9 +578,9 @@ Example config:
 */home/user/task.config*
 
 ```conf
-[task.osco-result-to-oscal-ar]
+[task.xccdf-result-to-oscal-ar]
 
-input-dir =  /home/user/git/evidence/osco/input
+input-dir =  /home/user/git/evidence/xccdf/input
 output-dir = /home/user/git/evidence/oscal/output
 oscal-metadata = oscal-metadata.yaml
 output-overwrite = true
@@ -592,7 +592,7 @@ output-overwrite = true
 Example input directory contents listing:
 </span>
 
-*/home/user/git/evidence/osco/input*
+*/home/user/git/evidence/xccdf/input*
 
 ```bash
 -rw-rw-r--. 1 user user  3832 Feb  2 09:36 oscal-metadata.yaml
@@ -666,7 +666,8 @@ metadata:
   name: ssg-ocp4-ds-cis-111.222.333.444-pod
   namespace: openshift-compliance
   resourceVersion: '22693328'
-  selfLink: /api/v1/namespaces/openshift-compliance/configmaps/ssg-ocp4-ds-cis-111.222.333.444-pod
+  selfLink: 
+    /api/v1/namespaces/openshift-compliance/configmaps/ssg-ocp4-ds-cis-111.222.333.444-pod
   uid: 1da3ea81-0a25-4512-ad86-7ac360246b5d
 
 ```

--- a/docs/tutorials/continuous-compliance/continuous-compliance.md
+++ b/docs/tutorials/continuous-compliance/continuous-compliance.md
@@ -33,7 +33,7 @@ The bad news is that a transformer to [OSCAL](https://pages.nist.gov/OSCAL) is n
 
 However, there is plenty of good news:
 
-- a transformer for your Cloud Service type may already exist, such as: [Tanium to OSCAL](https://github.com/IBM/compliance-trestle/blob/main/trestle/tasks/tanium-result-to-oscal-ar.py), [OpenShift Compliance Operator to OSCAL](https://github.com/IBM/compliance-trestle/blob/main/trestle/tasks/osco_result_to_oscal_ar.py)
+- a transformer for your Cloud Service type may already exist, such as: [Tanium to OSCAL](https://github.com/IBM/compliance-trestle/blob/main/trestle/tasks/tanium-result-to-oscal-ar.py), [OpenShift Compliance Operator to OSCAL](https://github.com/IBM/compliance-trestle/blob/main/trestle/tasks/xccdf_result_to_oscal_ar.py)
 - once a transformer for a Cloud Service type has been written, it can be open-sourced/re-used
 - writing a transformer is fairly easy: just a few lines of Python code using [trestle](https://ibm.github.io/compliance-trestle/) as a foundation
 

--- a/docs/tutorials/task.transformer-construction/transformer-construction.md
+++ b/docs/tutorials/task.transformer-construction/transformer-construction.md
@@ -17,7 +17,7 @@ The objective here is to transform your compliance data into valid OSCAL, in par
 [SAR](https://pages.nist.gov/OSCAL/documentation/schema/assessment-results-layer/).
 
 Examples of existing transformers  included with trestle are for the
-OpenShift Compliance Operator [OSCO](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/osco_result_to_oscal_ar.py) and
+OpenShift Compliance Operator [OSCO](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/xccdf_result_to_oscal_ar.py) and
 [Tanium](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/tanium-result-to-oscal-ar.py).
 
 ## *Overview*
@@ -41,7 +41,7 @@ Other possible code stack configurations (not shown):
 For example, one could create an
 auditree-arboretum [harvest](https://github.com/ComplianceAsCode/auditree-harvest#report-development)
 report (file interface) that employs the trestle
-osco-result-to-oscal-ar transformation (data processing) module.
+xccdf-result-to-oscal-ar transformation (data processing) module.
 
 ## *Choose Mapping Strategy*
 
@@ -404,7 +404,7 @@ where 14 have result=PASS and 1 has result=FAIL, then the overall status for the
 ## *Examples*
 
 There are 2 transformers in trestle.
-The [osco-result-to-oscal-ar](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/osco_result_to_oscal_ar.py)
+The [xccdf-result-to-oscal-ar](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/xccdf_result_to_oscal_ar.py)
 transformer emits OSCAL Observations, the simplest partial result.
 
 The [tanium-result-to-oscal-ar](https://github.com/IBM/compliance-trestle/blob/develop/trestle/tasks/tanium-result-to-oscal-ar.py)
@@ -421,7 +421,7 @@ Table of approximate lines of code.
  <th style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;background-color: #f1f1c1;">test cases
 
 <tr>
- <td style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;">osco-result-to-oscal-ar
+ <td style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;">xccdf-result-to-oscal-ar
  <td style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;">Observations only
  <td style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;">275
  <td style="text-align:right;border: 1px solid black;border-collapse: collapse;padding: 15px;">350


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [x] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Commensurate with #1329 update docs to specify renamed task xccdf-result-to-oscal-ar.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
