### PR TITLE
feat: allow use of OpenSCAP result files in task xccdf_result_to_oscal_ar

### DIFF
--- a/tests/data/tasks/xccdf/input-oscap-arf-results/results_arf.xml
+++ b/tests/data/tasks/xccdf/input-oscap-arf-results/results_arf.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arf:asset-report-collection xmlns:arf="http://scap.nist.gov/schema/asset-reporting-format/1.1"
+  xmlns:core="http://scap.nist.gov/schema/reporting-core/1.1"
+  xmlns:ai="http://scap.nist.gov/schema/asset-identification/1.1">
+  <arf:reports>
+    <arf:report id="xccdf1">
+      <arf:content>
+        <TestResult xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_cis" start-time="2021-06-08T02:35:55+00:00" end-time="2021-06-08T02:54:51+00:00" version="0.1.57" test-system="cpe:/a:redhat:openscap:1.3.3">
+          <benchmark href="/content/ssg-rhel7-ds.xml" id="xccdf_org.ssgproject.content_benchmark_RHEL-7"/>
+          <title>OSCAP Scan Result</title>
+          <profile idref="xccdf_org.ssgproject.content_profile_cis"/>
+          <target>kube-c18ler8d06m877hrn7jg-roks8-default-00000319.iks.mycorp</target>
+          <target-facts>
+            <fact name="urn:xccdf:fact:identifier" type="string">chroot:///host</fact>
+            <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+            <fact name="urn:xccdf:fact:scanner:version" type="string">1.3.3</fact>
+          </target-facts>
+          <target-id-ref system="http://scap.nist.gov/schema/asset-identification/1.1" name="asset0" href=""/>
+          <platform idref="cpe:/a:pam"/>
+          <platform idref="cpe:/o:redhat:enterprise_linux:7::workstation"/>
+          <platform idref="cpe:/o:redhat:enterprise_linux:7::client"/>
+          <platform idref="cpe:/o:redhat:enterprise_linux:7::server"/>
+          <platform idref="cpe:/a:grub2"/>
+          <platform idref="cpe:/o:redhat:enterprise_linux:7::computenode"/>
+          <platform idref="cpe:/o:redhat:enterprise_linux:7"/>
+          <platform idref="cpe:/a:login_defs"/>
+          <platform idref="cpe:/a:non-uefi"/>
+          <platform idref="cpe:/a:machine"/>
+          <platform idref="cpe:/a:yum"/>
+
+          <rule-result idref="xccdf_org.ssgproject.content_rule_prefer_64bit_os" role="full" time="2021-06-08T02:35:55+00:00" severity="medium" weight="1.000000">
+            <result>notselected</result>
+            <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-83691-6</ident>
+          </rule-result>
+          <rule-result idref="xccdf_org.ssgproject.content_rule_disable_prelink" role="full" time="2021-06-08T02:35:55+00:00" severity="medium" weight="1.000000">
+            <result>pass</result>
+            <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-27078-5</ident>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+              <check-content-ref name="oval:ssg-disable_prelink:def:1" href="#oval0"/>
+            </check>
+          </rule-result>
+
+          <score system="urn:xccdf:scoring:default" maximum="100.000000">74.713684</score>
+        </TestResult>
+
+      </arf:content>
+    </arf:report>
+  </arf:reports>
+</arf:asset-report-collection>

--- a/tests/data/tasks/xccdf/input-oscap-results/results.xml
+++ b/tests/data/tasks/xccdf/input-oscap-results/results.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="xccdf_org.ssgproject.content_benchmark_FEDORA" resolved="1" xml:lang="en-US" style="SCAP_1.2">
+  <TestResult xmlns="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_cis" start-time="2021-06-08T02:35:55+00:00" end-time="2021-06-08T02:54:51+00:00" version="0.1.57" test-system="cpe:/a:redhat:openscap:1.3.3">
+    <benchmark href="/content/ssg-rhel7-ds.xml" id="xccdf_org.ssgproject.content_benchmark_RHEL-7"/>
+    <title>OSCAP Scan Result</title>
+    <profile idref="xccdf_org.ssgproject.content_profile_cis"/>
+    <target>kube-c18ler8d06m877hrn7jg-roks8-default-00000319.iks.mycorp</target>
+    <target-facts>
+      <fact name="urn:xccdf:fact:identifier" type="string">chroot:///host</fact>
+      <fact name="urn:xccdf:fact:scanner:name" type="string">OpenSCAP</fact>
+      <fact name="urn:xccdf:fact:scanner:version" type="string">1.3.3</fact>
+    </target-facts>
+    <target-id-ref system="http://scap.nist.gov/schema/asset-identification/1.1" name="asset0" href=""/>
+    <platform idref="cpe:/a:pam"/>
+    <platform idref="cpe:/o:redhat:enterprise_linux:7::workstation"/>
+    <platform idref="cpe:/o:redhat:enterprise_linux:7::client"/>
+    <platform idref="cpe:/o:redhat:enterprise_linux:7::server"/>
+    <platform idref="cpe:/a:grub2"/>
+    <platform idref="cpe:/o:redhat:enterprise_linux:7::computenode"/>
+    <platform idref="cpe:/o:redhat:enterprise_linux:7"/>
+    <platform idref="cpe:/a:login_defs"/>
+    <platform idref="cpe:/a:non-uefi"/>
+    <platform idref="cpe:/a:machine"/>
+    <platform idref="cpe:/a:yum"/>
+
+    <rule-result idref="xccdf_org.ssgproject.content_rule_prefer_64bit_os" role="full" time="2021-06-08T02:35:55+00:00" severity="medium" weight="1.000000">
+      <result>notselected</result>
+      <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-83691-6</ident>
+    </rule-result>
+    <rule-result idref="xccdf_org.ssgproject.content_rule_disable_prelink" role="full" time="2021-06-08T02:35:55+00:00" severity="medium" weight="1.000000">
+      <result>pass</result>
+      <ident system="https://nvd.nist.gov/cce/index.cfm">CCE-27078-5</ident>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:ssg-disable_prelink:def:1" href="#oval0"/>
+      </check>
+    </rule-result>
+    <score system="urn:xccdf:scoring:default" maximum="100.000000">74.713684</score>
+  </TestResult>
+</Benchmark>

--- a/tests/data/tasks/xccdf/output-oscap-arf-results/results_arf.oscal.json
+++ b/tests/data/tasks/xccdf/output-oscap-arf-results/results_arf.oscal.json
@@ -1,0 +1,165 @@
+{
+  "results": [
+    {
+      "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+      "title": "XCCDF",
+      "description": "XCCDF Scan Results",
+      "start": "2021-06-08T02:35:55+00:00",
+      "end": "2021-06-08T02:35:55+00:00",
+      "local-definitions": {
+        "components": [
+          {
+            "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "Service",
+            "title": "rhel7",
+            "description": "rhel7",
+            "status": {
+              "state": "operational"
+            }
+          }
+        ],
+        "inventory-items": [
+          {
+            "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "description": "inventory",
+            "props": [
+              {
+                "name": "target",
+                "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                "value": "kube-c18ler8d06m877hrn7jg-roks8-default-00000319.iks.mycorp"
+              },
+              {
+                "name": "target_type",
+                "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                "value": "rhel7"
+              }
+            ],
+            "implemented-components": [
+              {
+                "component-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821"
+              }
+            ]
+          }
+        ],
+        "assessment-assets": {
+          "components": [
+            {
+              "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "Validator",
+              "title": "OpenSCAP",
+              "description": "OpenSCAP",
+              "props": [
+                {
+                  "name": "scanner_name",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "OpenSCAP"
+                },
+                {
+                  "name": "scanner_version",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "1.3.3"
+                },
+                {
+                  "name": "version",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP"
+                },
+                {
+                  "name": "severity",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "medium"
+                },
+                {
+                  "name": "weight",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "1.000000"
+                },
+                {
+                  "name": "benchmark_id",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "xccdf_org.ssgproject.content_benchmark_RHEL-7"
+                },
+                {
+                  "name": "benchmark_href",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "/content/ssg-rhel7-ds.xml"
+                },
+                {
+                  "name": "id",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_cis"
+                }
+              ],
+              "status": {
+                "state": "operational"
+              }
+            }
+          ],
+          "assessment-platforms": [
+            {
+              "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821"
+            }
+          ]
+        }
+      },
+      "reviewed-controls": {
+        "control-selections": [
+          {}
+        ]
+      },
+      "observations": [
+        {
+          "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "description": "xccdf_org.ssgproject.content_rule_prefer_64bit_os",
+          "props": [
+            {
+              "name": "idref",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "xccdf_org.ssgproject.content_rule_prefer_64bit_os"
+            },
+            {
+              "name": "result",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "notselected"
+            }
+          ],
+          "methods": [
+            "TEST-AUTOMATED"
+          ],
+          "subjects": [
+            {
+              "subject-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "inventory-item"
+            }
+          ],
+          "collected": "2023-11-30T23:00:03+00:00"
+        },
+        {
+          "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "description": "xccdf_org.ssgproject.content_rule_disable_prelink",
+          "props": [
+            {
+              "name": "idref",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "xccdf_org.ssgproject.content_rule_disable_prelink"
+            },
+            {
+              "name": "result",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "pass"
+            }
+          ],
+          "methods": [
+            "TEST-AUTOMATED"
+          ],
+          "subjects": [
+            {
+              "subject-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "inventory-item"
+            }
+          ],
+          "collected": "2023-11-30T23:00:03+00:00"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/tasks/xccdf/output-oscap-results/results.oscal.json
+++ b/tests/data/tasks/xccdf/output-oscap-results/results.oscal.json
@@ -1,0 +1,165 @@
+{
+  "results": [
+    {
+      "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+      "title": "XCCDF",
+      "description": "XCCDF Scan Results",
+      "start": "2021-06-08T02:35:55+00:00",
+      "end": "2021-06-08T02:35:55+00:00",
+      "local-definitions": {
+        "components": [
+          {
+            "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "type": "Service",
+            "title": "rhel7",
+            "description": "rhel7",
+            "status": {
+              "state": "operational"
+            }
+          }
+        ],
+        "inventory-items": [
+          {
+            "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+            "description": "inventory",
+            "props": [
+              {
+                "name": "target",
+                "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                "value": "kube-c18ler8d06m877hrn7jg-roks8-default-00000319.iks.mycorp"
+              },
+              {
+                "name": "target_type",
+                "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                "value": "rhel7"
+              }
+            ],
+            "implemented-components": [
+              {
+                "component-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821"
+              }
+            ]
+          }
+        ],
+        "assessment-assets": {
+          "components": [
+            {
+              "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "Validator",
+              "title": "OpenSCAP",
+              "description": "OpenSCAP",
+              "props": [
+                {
+                  "name": "scanner_name",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "OpenSCAP"
+                },
+                {
+                  "name": "scanner_version",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "1.3.3"
+                },
+                {
+                  "name": "version",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP"
+                },
+                {
+                  "name": "severity",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "medium"
+                },
+                {
+                  "name": "weight",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "1.000000"
+                },
+                {
+                  "name": "benchmark_id",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "xccdf_org.ssgproject.content_benchmark_RHEL-7"
+                },
+                {
+                  "name": "benchmark_href",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "/content/ssg-rhel7-ds.xml"
+                },
+                {
+                  "name": "id",
+                  "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+                  "value": "xccdf_org.open-scap_testresult_xccdf_org.ssgproject.content_profile_cis"
+                }
+              ],
+              "status": {
+                "state": "operational"
+              }
+            }
+          ],
+          "assessment-platforms": [
+            {
+              "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821"
+            }
+          ]
+        }
+      },
+      "reviewed-controls": {
+        "control-selections": [
+          {}
+        ]
+      },
+      "observations": [
+        {
+          "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "description": "xccdf_org.ssgproject.content_rule_prefer_64bit_os",
+          "props": [
+            {
+              "name": "idref",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "xccdf_org.ssgproject.content_rule_prefer_64bit_os"
+            },
+            {
+              "name": "result",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "notselected"
+            }
+          ],
+          "methods": [
+            "TEST-AUTOMATED"
+          ],
+          "subjects": [
+            {
+              "subject-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "inventory-item"
+            }
+          ],
+          "collected": "2023-11-30T23:00:03+00:00"
+        },
+        {
+          "uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+          "description": "xccdf_org.ssgproject.content_rule_disable_prelink",
+          "props": [
+            {
+              "name": "idref",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "xccdf_org.ssgproject.content_rule_disable_prelink"
+            },
+            {
+              "name": "result",
+              "ns": "https://ibm.github.io/compliance-trestle/schemas/oscal/ar/OpenSCAP",
+              "value": "pass"
+            }
+          ],
+          "methods": [
+            "TEST-AUTOMATED"
+          ],
+          "subjects": [
+            {
+              "subject-uuid": "56666738-0f9a-4e38-9aac-c0fad00a5821",
+              "type": "inventory-item"
+            }
+          ],
+          "collected": "2023-11-30T23:00:03+00:00"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-arf-results.config
+++ b/tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-arf-results.config
@@ -1,0 +1,4 @@
+[task.xccdf-result-to-oscal-ar]
+input-dir =  tests/data/tasks/xccdf/input-oscap-arf-results
+output-dir = tests/data/tasks/xccdf/output-oscap-arf-results
+output-overwrite = true

--- a/tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-results.config
+++ b/tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-results.config
@@ -1,0 +1,4 @@
+[task.xccdf-result-to-oscal-ar]
+input-dir =  tests/data/tasks/xccdf/input-oscap-results
+output-dir = tests/data/tasks/xccdf/output-oscap-results
+output-overwrite = true

--- a/tests/trestle/tasks/xccdf_result_to_oscal_ar_test.py
+++ b/tests/trestle/tasks/xccdf_result_to_oscal_ar_test.py
@@ -48,6 +48,8 @@ cf05 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-1.3.5.config'
 cf06 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-rhel7.config'
 cf07 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-xml-ocp4.config'
 cf08 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-configmaps.config'
+cf09 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-results.config'
+cf10 = 'tests/data/tasks/xccdf/test-xccdf-result-to-oscal-ar-input-oscap-arf-results.config'
 
 
 def setup_config(path: str):
@@ -428,6 +430,50 @@ def test_xccdf_execute_input_configmaps(tmp_path, monkeypatch: MonkeyPatch):
     monkeypatch.setattr(uuid, 'uuid4', monkeybusiness.uuid_mock1)
     xccdf.XccdfTransformer.set_timestamp('2021-02-24T19:31:13+00:00')
     config = setup_config(cf08)
+    section = config['task.xccdf-result-to-oscal-ar']
+    d_expected = pathlib.Path(section['output-dir'])
+    d_produced = tmp_path
+    section['output-dir'] = str(d_produced)
+    tgt = xccdf_result_to_oscal_ar.XccdfResultToOscalAR(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
+    list_dir = os.listdir(d_produced)
+    assert len(list_dir) == 1
+    for fn in list_dir:
+        f_expected = d_expected / fn
+        f_produced = d_produced / fn
+        result = text_files_equal(f_expected, f_produced)
+        assert result
+
+
+def test_xccdf_execute_input_oscap_result(tmp_path, monkeypatch: MonkeyPatch):
+    """Test OpenSCAP XCCDF to OSCAL AR."""
+    monkeybusiness = MonkeyBusiness()
+    monkeypatch.setattr(uuid, 'uuid4', monkeybusiness.uuid_mock1)
+    xccdf.XccdfTransformer.set_timestamp('2023-11-30T23:00:03+00:00')
+    config = setup_config(cf09)
+    section = config['task.xccdf-result-to-oscal-ar']
+    d_expected = pathlib.Path(section['output-dir'])
+    d_produced = tmp_path
+    section['output-dir'] = str(d_produced)
+    tgt = xccdf_result_to_oscal_ar.XccdfResultToOscalAR(section)
+    retval = tgt.execute()
+    assert retval == TaskOutcome.SUCCESS
+    list_dir = os.listdir(d_produced)
+    assert len(list_dir) == 1
+    for fn in list_dir:
+        f_expected = d_expected / fn
+        f_produced = d_produced / fn
+        result = text_files_equal(f_expected, f_produced)
+        assert result
+
+
+def test_xccdf_execute_input_oscap_arf_result(tmp_path, monkeypatch: MonkeyPatch):
+    """Test OpenSCAP ARF to OSCAL AR."""
+    monkeybusiness = MonkeyBusiness()
+    monkeypatch.setattr(uuid, 'uuid4', monkeybusiness.uuid_mock1)
+    xccdf.XccdfTransformer.set_timestamp('2023-11-30T23:00:03+00:00')
+    config = setup_config(cf10)
     section = config['task.xccdf-result-to-oscal-ar']
     d_expected = pathlib.Path(section['output-dir'])
     d_produced = tmp_path

--- a/trestle/transforms/implementations/xccdf.py
+++ b/trestle/transforms/implementations/xccdf.py
@@ -199,7 +199,7 @@ class RuleUse():
     @property
     def ns(self):
         """Derive namespace."""
-        return f'https://ibm.github.io/compliance-trestle/schemas/oscal/ar/{self.scanner_name}'
+        return f'https://ibm.github.io/compliance-trestle/schemas/oscal/ar/{self.scanner_name}'  # noqa: E231
 
 
 class _XccdfResult():
@@ -317,9 +317,14 @@ class _XccdfResult():
 
     def _parse_xml(self) -> Iterator[RuleUse]:
         """Parse the stringified XML."""
+        ns = {
+            'checklist12': 'http://checklists.nist.gov/xccdf/1.2',
+        }
         results = self.xccdf_xml
         root = ElementTree.fromstring(results, forbid_dtd=True)
         version = self._get_version(root)
+        if _remove_namespace(root.tag) != 'TestResult':
+            root = root.find('.//checklist12:TestResult', ns)
         id_ = self._get_id(root)
         target = self._get_target(root)
         target_type = self._get_target_type(root)


### PR DESCRIPTION

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary


Before this commit if you wanted to use result files from OpenSCAP in the task xccdf_result_to_oscal_ar you had to extract the `TestResult` element and place it as the root of the XML document, otherwise the resulting OSCAL document would be blank. Thus making it impossible to directly use output from OpenSCAP with the task.

With this commit the task will detect that the root element is not `TestResult` and then it will find the `TestResult` element in the XML document. This allows the use of files created by OpenSCAP using the `--results` and `--results-arf` switches.

Fixes #1410

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
