### PR TITLE
fix: prevent duplicates in set-parameters

### DIFF
--- a/trestle/tasks/csv_to_oscal_cd.py
+++ b/trestle/tasks/csv_to_oscal_cd.py
@@ -331,7 +331,7 @@ class CsvToOscalComponentDefinition(TaskBase):
                 logger.debug(f'params mod: {key}')
             else:
                 add_set_params.append(key)
-                logger.debug(f'prams add: {key}')
+                logger.debug(f'params add: {key}')
         return (del_set_params, add_set_params, mod_set_params)
 
     def _calculate_control_mappings(self, mod_rules: List) -> tuple:
@@ -824,7 +824,17 @@ class _OscalHelper():
     @staticmethod
     def add_set_parameter(set_parameter_list: List[SetParameter], set_parameter: SetParameter) -> None:
         """Add set parameter."""
-        set_parameter_list.append(set_parameter)
+        add = True
+        # don't add duplicate
+        for sp in set_parameter_list:
+            if sp.param_id == set_parameter.param_id:
+                add = False
+                if sp.values != set_parameter.values:
+                    text = f'set-parameter id={sp.param_id} conflicting values'
+                    raise RuntimeError(text)
+                break
+        if add:
+            set_parameter_list.append(set_parameter)
 
     @staticmethod
     def remove_rule_statement(statements: List[Statement], rule_id: str, smt_id: str) -> List[Statement]:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [x] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [x] My PR meets testing requirements.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Summary

1. do not add duplicate set-parameter name when value is same as existing one
2. error if adding set-parameter with same name but different value

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
