### PR TITLE
fix(tests): pins oscal-content references in tests the latest 1.0 commit

### DIFF
--- a/tests/data/json/full_profile_rev5.json
+++ b/tests/data/json/full_profile_rev5.json
@@ -5823,7 +5823,7 @@
           ],
           "rlinks": [
             {
-              "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
+              "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/690f517daaf3a6cbb4056d3cde6eae2756765620/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json",
               "media-type": "application/json"
             }
           ]

--- a/tests/trestle/core/commands/import__test.py
+++ b/tests/trestle/core/commands/import__test.py
@@ -328,7 +328,7 @@ def test_import_from_url(tmp_trestle_dir: pathlib.Path) -> None:
 
 def test_import_from_nist(tmp_trestle_dir: pathlib.Path) -> None:
     """Test import via url from nist."""
-    uri = 'https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_HIGH-baseline_profile-min.json'  # noqa: E501
+    uri = 'https://raw.githubusercontent.com/usnistgov/oscal-content/690f517daaf3a6cbb4056d3cde6eae2756765620/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_HIGH-baseline_profile-min.json'  # noqa: E501
     args = argparse.Namespace(trestle_root=tmp_trestle_dir, file=uri, output='my_catalog', verbose=1, regenerate=False)
     i = importcmd.ImportCmd()
     assert i._run(args) == 0

--- a/tests/trestle/core/profile_resolver_test.py
+++ b/tests/trestle/core/profile_resolver_test.py
@@ -441,6 +441,6 @@ def test_profile_resolver_no_params(tmp_trestle_dir: pathlib.Path) -> None:
 
 def test_remote_profile_relative_cat(tmp_trestle_dir: pathlib.Path) -> None:
     """Test profile resolver with remote profile and import of relative catalog path."""
-    profile_path = 'https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json'  # noqa E501
+    profile_path = 'https://raw.githubusercontent.com/usnistgov/oscal-content/690f517daaf3a6cbb4056d3cde6eae2756765620/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_LOW-baseline_profile.json'  # noqa E501
     resolved_cat = ProfileResolver.get_resolved_profile_catalog(tmp_trestle_dir, profile_path)
     assert len(resolved_cat.groups) > 10


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [X] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [X] My PR meets testing requirements.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Updates the remote references to NIST `oscal-content` repository in tests to a commit.

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
